### PR TITLE
Added ability to close non-primary tabs involved in a split view

### DIFF
--- a/src/ui/desktop/navigation/TopNavbar.tsx
+++ b/src/ui/desktop/navigation/TopNavbar.tsx
@@ -340,7 +340,7 @@ export function TopNavbar({
                 isSplitScreenActive);
             const isHome = tab.type === "home";
             const disableClose =
-              (isSplitScreenActive && isActive) || isSplit || isHome;
+              (isSplitScreenActive && isActive) || isHome;
 
             const isDraggingThisTab = dragState.draggedIndex === index;
             const isTheDraggedTab = tab.id === dragState.draggedId;


### PR DESCRIPTION
# Overview

When managing multiple tabs involved in a split view, I found myself wanting to fully close specific tabs rather than just un-splitting them. I therefore enabled the ability to close tabs involved in the split view but still prevent the primary tab from being closed. 

# Changes Made

The code already had the capability to remove a session from split view when being closed so all I had to do was remove `isSplit` from the following line in `TopNavbar.tsx`
```
              (isSplitScreenActive && isActive) || isSplit || isHome;
```

# Related Issues

https://github.com/Termix-SSH/Support/issues/258

# Checklist

- [x] Code follows project style guidelines
- [ ] Supports mobile and desktop UI/app (N/A)
- [x] I have read [Contributing.md](https://github.com/Termix-SSH/Termix/blob/main/CONTRIBUTING.md)
