### PR TITLE
fix select edit host but not update view

### DIFF
--- a/src/ui/desktop/apps/host-manager/HostManager.tsx
+++ b/src/ui/desktop/apps/host-manager/HostManager.tsx
@@ -42,6 +42,15 @@ export function HostManager({
     }
   }, [initialTab]);
 
+  // Update editingHost when hostConfig changes
+  useEffect(() => {
+    if (hostConfig) {
+      setEditingHost(hostConfig);
+      setActiveTab("add_host");
+      lastProcessedHostIdRef.current = hostConfig.id;
+    }
+  }, [hostConfig?.id]);
+
   const handleEditHost = (host: SSHHost) => {
     setEditingHost(host);
     setActiveTab("add_host");


### PR DESCRIPTION
# Overview

Bug: When the Host Manager tab is active, if select Edit another host from Side bar, view is not update

# Changes Made

updates the editingHost state and switches to the "add_host" tab whenever hostConfig id changes, ensuring the edit form reflects the newly selected host.

# Checklist

- [x] Code follows project style guidelines
- [x] Supports mobile and desktop UI/app (if applicable)
- [x] I have read [Contributing.md](https://github.com/Termix-SSH/Termix/blob/main/CONTRIBUTING.md)
