### PR TITLE
fix: nginx permission denied on restricted kernels

### DIFF
--- a/docker/nginx-https.conf
+++ b/docker/nginx-https.conf
@@ -1,3 +1,5 @@
+worker_processes 1;
+master_process off;
 pid /app/nginx/nginx.pid;
 error_log /app/nginx/logs/error.log warn;
 

--- a/docker/nginx.conf
+++ b/docker/nginx.conf
@@ -1,3 +1,5 @@
+worker_processes 1;
+master_process off;
 pid /app/nginx/nginx.pid;
 error_log /app/nginx/logs/error.log warn;
 


### PR DESCRIPTION
## Summary

- Add `worker_processes 1` and `master_process off` to nginx configs
- Fixes `socketpair() failed while spawning worker process (Permission denied)` on restricted kernels like Proxmox

Fixes #396