### PR TITLE
fix: set default lineHeight to 1.0 for TUI apps compatibility

### DIFF
--- a/src/constants/terminal-themes.ts
+++ b/src/constants/terminal-themes.ts
@@ -745,7 +745,7 @@ export const DEFAULT_TERMINAL_CONFIG = {
   fontSize: 14,
   fontFamily: "Caskaydia Cove Nerd Font Mono",
   letterSpacing: 0,
-  lineHeight: 1.2,
+  lineHeight: 1.0,
   theme: "termix",
 
   scrollback: 10000,


### PR DESCRIPTION
## Summary

- Change default terminal lineHeight from 1.2 to 1.0
- TUI apps (htop, lazydocker, gitui, ctop) rely on exact character cell layout
- lineHeight 1.2 breaks vertical alignment causing layout issues

**Note**: This may slightly reduce line spacing for regular terminal use. Users who prefer more spacing can adjust in terminal settings.

Related to #392