### PR TITLE
fix: prevent session reset when updating host properties

### DIFF
--- a/src/ui/desktop/apps/features/terminal/Terminal.tsx
+++ b/src/ui/desktop/apps/features/terminal/Terminal.tsx
@@ -618,15 +618,15 @@ export const Terminal = forwardRef<TerminalHandle, SSHTerminalProps>(
         ? `${window.location.protocol === "https:" ? "wss" : "ws"}://localhost:30002`
         : isElectron()
           ? (() => {
-            const baseUrl =
-              (window as { configuredServerUrl?: string })
-                .configuredServerUrl || "http://127.0.0.1:30001";
-            const wsProtocol = baseUrl.startsWith("https://")
-              ? "wss://"
-              : "ws://";
-            const wsHost = baseUrl.replace(/^https?:\/\//, "");
-            return `${wsProtocol}${wsHost}/ssh/websocket/`;
-          })()
+              const baseUrl =
+                (window as { configuredServerUrl?: string })
+                  .configuredServerUrl || "http://127.0.0.1:30001";
+              const wsProtocol = baseUrl.startsWith("https://")
+                ? "wss://"
+                : "ws://";
+              const wsHost = baseUrl.replace(/^https?:\/\//, "");
+              return `${wsProtocol}${wsHost}/ssh/websocket/`;
+            })()
           : `${window.location.protocol === "https:" ? "wss" : "ws"}://${window.location.host}/ssh/websocket/`;
 
       if (
@@ -1387,7 +1387,7 @@ export const Terminal = forwardRef<TerminalHandle, SSHTerminalProps>(
 
             const selectedCommand =
               autocompleteSuggestionsRef.current[
-              autocompleteSelectedIndexRef.current
+                autocompleteSelectedIndexRef.current
               ];
             const currentCmd = currentAutocompleteCommand.current;
             const completion = selectedCommand.substring(currentCmd.length);
@@ -1548,7 +1548,11 @@ export const Terminal = forwardRef<TerminalHandle, SSHTerminalProps>(
         scheduleNotify(terminal.cols, terminal.rows);
         connectToHost(terminal.cols, terminal.rows);
       }
-    }, [terminal, hostConfig, isVisible, isConnected, isConnecting]);
+      // Note: Using hostConfig.id instead of hostConfig object to prevent
+      // unnecessary reconnections when host properties are updated.
+      // Only reconnect when switching to a different host.
+      // eslint-disable-next-line react-hooks/exhaustive-deps
+    }, [terminal, hostConfig.id, isVisible, isConnected, isConnecting]);
 
     useEffect(() => {
       if (!terminal || !fitAddonRef.current || !isVisible) return;


### PR DESCRIPTION
## Summary

- Use `hostConfig.id` instead of entire `hostConfig` object in useEffect dependency array
- Prevents unnecessary terminal reconnections when host properties are updated

**Root cause**: When any host property is updated, `updateHostConfig()` creates a new object reference. The Terminal component's useEffect depended on the entire `hostConfig` object, so any reference change triggered reconnection logic.

**Fix**: Only depend on `hostConfig.id` since we only need to reconnect when switching to a different host, not when properties of the same host change.

**Before**: Edit any host → all open terminals disconnect and reconnect
**After**: Edit any host → terminals stay connected

Related to #401