### PR TITLE
fix: use correct MIME types for image preview

### DIFF
--- a/src/ui/desktop/apps/features/file-manager/components/FileViewer.tsx
+++ b/src/ui/desktop/apps/features/file-manager/components/FileViewer.tsx
@@ -332,11 +332,21 @@ export function FileViewer({
   const getImageDataUrl = (content: string, fileName: string): string => {
     const ext = fileName.split(".").pop()?.toLowerCase() || "";
 
-    if (ext === "svg") {
-      return `data:image/svg+xml;base64,${content}`;
-    }
+    const mimeTypes: Record<string, string> = {
+      svg: "image/svg+xml",
+      png: "image/png",
+      jpg: "image/jpeg",
+      jpeg: "image/jpeg",
+      gif: "image/gif",
+      webp: "image/webp",
+      bmp: "image/bmp",
+      ico: "image/x-icon",
+      tiff: "image/tiff",
+      tif: "image/tiff",
+    };
 
-    return `data:image/*;base64,${content}`;
+    const mimeType = mimeTypes[ext] || "image/png";
+    return `data:${mimeType};base64,${content}`;
   };
 
   const WARNING_SIZE = 50 * 1024 * 1024;


### PR DESCRIPTION
## Summary

- Replace `image/*` wildcard with specific MIME types in data URLs
- Add MIME type mapping for common image formats (png, jpg, gif, webp, bmp, ico, tiff)

**Root cause**: `data:image/*;base64,...` uses a wildcard MIME type which is not valid in data URLs. Browsers require specific MIME types like `image/png` or `image/jpeg`.

**Before**: `data:image/*;base64,{content}` → browser fails to parse
**After**: `data:image/png;base64,{content}` → browser renders correctly

Related to #408