### PR TITLE
fix: owner should not be marked as shared when host is shared to their role

### DIFF
--- a/src/backend/database/routes/ssh.ts
+++ b/src/backend/database/routes/ssh.ts
@@ -852,7 +852,7 @@ router.get(
           socks5ProxyChain: sshData.socks5ProxyChain,
 
           ownerId: sshData.userId,
-          isShared: sql<boolean>`${hostAccess.id} IS NOT NULL`,
+          isShared: sql<boolean>`${hostAccess.id} IS NOT NULL AND ${sshData.userId} != ${userId}`,
           permissionLevel: hostAccess.permissionLevel,
           expiresAt: hostAccess.expiresAt,
         })
@@ -1700,8 +1700,9 @@ async function resolveHostCredentials(
 
       if (requestingUserId && requestingUserId !== ownerId) {
         try {
-          const { SharedCredentialManager } =
-            await import("../../utils/shared-credential-manager.js");
+          const { SharedCredentialManager } = await import(
+            "../../utils/shared-credential-manager.js"
+          );
           const sharedCredManager = SharedCredentialManager.getInstance();
           const sharedCred = await sharedCredManager.getSharedCredentialForUser(
             host.id as number,


### PR DESCRIPTION
## Summary

- Fix `isShared` flag logic to exclude host owners
- Owner retains full edit/delete permissions even when host is shared to their role

**Root cause**: The SQL query `hostAccess.id IS NOT NULL` marked hosts as "shared" whenever a hostAccess record existed, without checking if the current user is the owner.

**Scenario**:
1. Admin creates a host (owner)
2. Admin shares host to "Administrator" role
3. Admin is in "Administrator" role
4. `hostAccess` record exists → `isShared = true`
5. Frontend hides edit/delete buttons for shared hosts
6. Admin loses ability to modify their own host

**Fix**: Add owner check to SQL: `hostAccess.id IS NOT NULL AND sshData.userId != userId`

Related to #391