### PR TITLE
feat: add Docker container healthcheck

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -74,6 +74,9 @@ VOLUME ["/app/data"]
 
 EXPOSE ${PORT} 30001 30002 30003 30004 30005 30006
 
+HEALTHCHECK --interval=30s --timeout=10s --start-period=30s --retries=3 \
+    CMD node -e "require('http').get('http://localhost:30001/health', (r) => process.exit(r.statusCode === 200 ? 0 : 1)).on('error', () => process.exit(1))"
+
 COPY docker/entrypoint.sh /entrypoint.sh
 RUN chmod +x /entrypoint.sh
 


### PR DESCRIPTION
## Summary

- Add HEALTHCHECK instruction to Dockerfile
- Uses existing `/health` endpoint on port 30001
- Enables container orchestration tools (Docker Compose, Kubernetes, etc.) to monitor container health

**Configuration**:
- Interval: 30s
- Timeout: 10s
- Start period: 30s (allows app to start up)
- Retries: 3

**Usage**:
```bash
# Check container health status
docker inspect --format='{{.State.Health.Status}}' termix

# View health check logs
docker inspect --format='{{json .State.Health}}' termix | jq
```

Related to #400