### PR TITLE
fix: restore SSH connection timeout to 120s for 2FA authentication

### DIFF
--- a/src/backend/ssh/terminal.ts
+++ b/src/backend/ssh/terminal.ts
@@ -648,7 +648,7 @@ wss.on("connection", async (ws: WebSocket, req) => {
         );
         cleanupSSH(connectionTimeout);
       }
-    }, 30000);
+    }, 120000);
 
     let resolvedCredentials = { password, key, keyPassword, keyType, authType };
     let authMethodNotAvailable = false;
@@ -1115,10 +1115,10 @@ wss.on("connection", async (ws: WebSocket, req) => {
       tryKeyboard: true,
       keepaliveInterval: 30000,
       keepaliveCountMax: 3,
-      readyTimeout: 30000,
+      readyTimeout: 120000,
       tcpKeepAlive: true,
       tcpKeepAliveInitialDelay: 30000,
-      timeout: 30000,
+      timeout: 120000,
       env: {
         TERM: "xterm-256color",
         LANG: "en_US.UTF-8",


### PR DESCRIPTION
## Summary
- Restores SSH connection timeout from 30s back to 120s (as in v1.9.0)
- Fixes 2FA/TOTP login failures introduced in v1.10

## Root Cause
The timeout reduction in v1.10 caused `ECONNRESET` errors during keyboard-interactive authentication. Users with 2FA enabled didn't have enough time to enter their TOTP codes before the connection timed out.

## Changes
- `readyTimeout`: 30000 → 120000
- `timeout`: 30000 → 120000
- `connectionTimeout`: 30000 → 120000

## Test plan
- [ ] Configure SSH server with 2FA/TOTP requirement
- [ ] Verify login works with sufficient time to enter TOTP code
- [ ] Verify normal password authentication still works

Fixes Termix-SSH/Support#404