### PR TITLE
fix: prevent long container names from overflowing card

### DIFF
--- a/src/ui/desktop/apps/features/docker/components/ContainerCard.tsx
+++ b/src/ui/desktop/apps/features/docker/components/ContainerCard.tsx
@@ -255,7 +255,7 @@ export function ContainerCard({
       >
         <CardHeader className="pb-2 px-4">
           <div className="flex items-start justify-between gap-2">
-            <CardTitle className="text-base font-semibold truncate flex-1">
+            <CardTitle className="text-base font-semibold truncate flex-1 min-w-0">
               {container.name.startsWith("/")
                 ? container.name.slice(1)
                 : container.name}


### PR DESCRIPTION
## Summary
- Adds `min-w-0` to container name CardTitle to enable proper text truncation

## Root Cause
In flexbox, child elements have `min-width: auto` by default, which prevents them from shrinking below their content width. The existing `truncate` class was ineffective because the element couldn't shrink.

## Changes
```diff
- <CardTitle className="text-base font-semibold truncate flex-1">
+ <CardTitle className="text-base font-semibold truncate flex-1 min-w-0">
```

## Test plan
- [ ] Create a Docker container with a long name (>36 chars)
- [ ] Verify the name is truncated with ellipsis instead of overflowing

Fixes Termix-SSH/Support#411