### PR TITLE
feat: add Ctrl+Alt key remapping for browser-blocked shortcuts

### DIFF
--- a/src/ui/desktop/apps/features/terminal/Terminal.tsx
+++ b/src/ui/desktop/apps/features/terminal/Terminal.tsx
@@ -1349,6 +1349,24 @@ export const Terminal = forwardRef<TerminalHandle, SSHTerminalProps>(
           return true;
         }
 
+        // Ctrl+Alt+<key> → Ctrl+<key> remapping for browser-blocked shortcuts
+        // Browsers intercept Ctrl+W/T/N/Q, so we use Ctrl+Alt as an alternative
+        if (e.ctrlKey && e.altKey && !e.metaKey && !e.shiftKey) {
+          const key = e.key.toLowerCase();
+          const blockedKeys = ["w", "t", "n", "q"];
+          if (blockedKeys.includes(key)) {
+            e.preventDefault();
+            e.stopPropagation();
+            const ctrlCode = key.charCodeAt(0) - 96;
+            if (webSocketRef.current?.readyState === 1) {
+              webSocketRef.current.send(
+                JSON.stringify({ type: "input", data: String.fromCharCode(ctrlCode) }),
+              );
+            }
+            return false;
+          }
+        }
+
         if (showAutocompleteRef.current) {
           if (e.key === "Escape") {
             e.preventDefault();


### PR DESCRIPTION
## Summary
- Add keyboard remapping to bypass browser-intercepted shortcuts
- Users can now use `Ctrl+Alt+<key>` to send `Ctrl+<key>` to the terminal

## Problem
Browsers intercept certain Ctrl shortcuts (Ctrl+W closes tab, Ctrl+T opens new tab, etc.), making them unusable in the terminal. For example, pressing Ctrl+W in nano to search will close the browser tab instead.

## Solution
Remap `Ctrl+Alt+<key>` combinations to send the corresponding `Ctrl+<key>` to the terminal:
- `Ctrl+Alt+W` → `Ctrl+W` (nano search, delete word)
- `Ctrl+Alt+T` → `Ctrl+T` (transpose chars)
- `Ctrl+Alt+N` → `Ctrl+N` (next line)
- `Ctrl+Alt+Q` → `Ctrl+Q` (XON flow control)

## Test plan
- [ ] Open terminal, run `nano`
- [ ] Press `Ctrl+Alt+W` to trigger search (instead of closing tab)
- [ ] Verify the search prompt appears

Fixes Termix-SSH/Support#407