### PR TITLE
feat: add toggle for password reset feature

### DIFF
--- a/src/locales/en.json
+++ b/src/locales/en.json
@@ -539,6 +539,7 @@
     "userRegistration": "User Registration",
     "allowNewAccountRegistration": "Allow new account registration",
     "allowPasswordLogin": "Allow username/password login",
+    "allowPasswordReset": "Allow password reset via reset code",
     "missingRequiredFields": "Missing required fields: {{fields}}",
     "oidcConfigurationUpdated": "OIDC configuration updated successfully!",
     "failedToFetchOidcConfig": "Failed to fetch OIDC configuration",

--- a/src/ui/desktop/apps/admin/AdminSettings.tsx
+++ b/src/ui/desktop/apps/admin/AdminSettings.tsx
@@ -15,6 +15,7 @@ import {
   getAdminOIDCConfig,
   getRegistrationAllowed,
   getPasswordLoginAllowed,
+  getPasswordResetAllowed,
   getUserList,
   getUserInfo,
   isElectron,
@@ -48,6 +49,7 @@ export function AdminSettings({
 
   const [allowRegistration, setAllowRegistration] = React.useState(true);
   const [allowPasswordLogin, setAllowPasswordLogin] = React.useState(true);
+  const [allowPasswordReset, setAllowPasswordReset] = React.useState(true);
 
   const [oidcConfig, setOidcConfig] = React.useState({
     client_id: "",
@@ -189,6 +191,28 @@ export function AdminSettings({
       .catch((err) => {
         if (err.code !== "NO_SERVER_CONFIGURED") {
           toast.error(t("admin.failedToFetchPasswordLoginStatus"));
+        }
+      });
+  }, []);
+
+  React.useEffect(() => {
+    if (isElectron()) {
+      const serverUrl = (window as { configuredServerUrl?: string })
+        .configuredServerUrl;
+      if (!serverUrl) {
+        return;
+      }
+    }
+
+    getPasswordResetAllowed()
+      .then((res) => {
+        if (typeof res === "boolean") {
+          setAllowPasswordReset(res);
+        }
+      })
+      .catch((err) => {
+        if (err.code !== "NO_SERVER_CONFIGURED") {
+          console.warn("Failed to fetch password reset status", err);
         }
       });
   }, []);
@@ -367,6 +391,8 @@ export function AdminSettings({
                 setAllowRegistration={setAllowRegistration}
                 allowPasswordLogin={allowPasswordLogin}
                 setAllowPasswordLogin={setAllowPasswordLogin}
+                allowPasswordReset={allowPasswordReset}
+                setAllowPasswordReset={setAllowPasswordReset}
                 oidcConfig={oidcConfig}
               />
             </TabsContent>

--- a/src/ui/desktop/apps/admin/tabs/GeneralSettingsTab.tsx
+++ b/src/ui/desktop/apps/admin/tabs/GeneralSettingsTab.tsx
@@ -6,6 +6,7 @@ import { useConfirmation } from "@/hooks/use-confirmation.ts";
 import {
   updateRegistrationAllowed,
   updatePasswordLoginAllowed,
+  updatePasswordResetAllowed,
 } from "@/ui/main-axios.ts";
 
 interface GeneralSettingsTabProps {
@@ -13,6 +14,8 @@ interface GeneralSettingsTabProps {
   setAllowRegistration: (value: boolean) => void;
   allowPasswordLogin: boolean;
   setAllowPasswordLogin: (value: boolean) => void;
+  allowPasswordReset: boolean;
+  setAllowPasswordReset: (value: boolean) => void;
   oidcConfig: {
     client_id: string;
     client_secret: string;
@@ -27,6 +30,8 @@ export function GeneralSettingsTab({
   setAllowRegistration,
   allowPasswordLogin,
   setAllowPasswordLogin,
+  allowPasswordReset,
+  setAllowPasswordReset,
   oidcConfig,
 }: GeneralSettingsTabProps): React.ReactElement {
   const { t } = useTranslation();
@@ -34,6 +39,7 @@ export function GeneralSettingsTab({
 
   const [regLoading, setRegLoading] = React.useState(false);
   const [passwordLoginLoading, setPasswordLoginLoading] = React.useState(false);
+  const [passwordResetLoading, setPasswordResetLoading] = React.useState(false);
 
   const handleToggleRegistration = async (checked: boolean) => {
     setRegLoading(true);
@@ -96,6 +102,16 @@ export function GeneralSettingsTab({
     }
   };
 
+  const handleTogglePasswordReset = async (checked: boolean) => {
+    setPasswordResetLoading(true);
+    try {
+      await updatePasswordResetAllowed(checked);
+      setAllowPasswordReset(checked);
+    } finally {
+      setPasswordResetLoading(false);
+    }
+  };
+
   return (
     <div className="rounded-lg border-2 border-border bg-card p-4 space-y-4">
       <h3 className="text-lg font-semibold">{t("admin.userRegistration")}</h3>
@@ -119,6 +135,19 @@ export function GeneralSettingsTab({
           disabled={passwordLoginLoading}
         />
         {t("admin.allowPasswordLogin")}
+      </label>
+      <label className="flex items-center gap-2">
+        <Checkbox
+          checked={allowPasswordReset}
+          onCheckedChange={handleTogglePasswordReset}
+          disabled={passwordResetLoading || !allowPasswordLogin}
+        />
+        {t("admin.allowPasswordReset")}
+        {!allowPasswordLogin && (
+          <span className="text-xs text-muted-foreground">
+            ({t("admin.requiresPasswordLogin")})
+          </span>
+        )}
       </label>
     </div>
   );

--- a/src/ui/main-axios.ts
+++ b/src/ui/main-axios.ts
@@ -2501,6 +2501,28 @@ export async function updatePasswordLoginAllowed(
   }
 }
 
+export async function getPasswordResetAllowed(): Promise<boolean> {
+  try {
+    const response = await authApi.get("/users/password-reset-allowed");
+    return response.data.allowed;
+  } catch (error) {
+    handleApiError(error, "get password reset allowed");
+  }
+}
+
+export async function updatePasswordResetAllowed(
+  allowed: boolean,
+): Promise<{ allowed: boolean }> {
+  try {
+    const response = await authApi.patch("/users/password-reset-allowed", {
+      allowed,
+    });
+    return response.data;
+  } catch (error) {
+    handleApiError(error, "update password reset allowed");
+  }
+}
+
 export async function updateOIDCConfig(
   config: Record<string, unknown>,
 ): Promise<Record<string, unknown>> {


### PR DESCRIPTION
## Summary
- Add admin setting toggle to enable/disable password reset functionality
- When disabled, the `/users/initiate-reset` API returns 403
- Toggle is automatically disabled when password login is disabled

## Changes
- **Backend**: Add `GET/PATCH /users/password-reset-allowed` endpoints
- **Backend**: Add setting check in `initiate-reset` endpoint
- **Frontend**: Add checkbox in General Settings tab
- **i18n**: Add translation key

## Test Plan
- [ ] Toggle appears in Admin Settings > General tab
- [ ] Toggle state persists after page reload
- [ ] When disabled, password reset API returns 403 error
- [ ] Toggle is disabled when "Allow password login" is off