### PR TITLE
feat: add SBOM generation for supply chain transparency

### DIFF
--- a/.github/workflows/sbom.yml
+++ b/.github/workflows/sbom.yml
@@ -1,0 +1,59 @@
+name: Generate SBOM
+
+on:
+  release:
+    types: [published]
+  workflow_dispatch:
+
+jobs:
+  generate-sbom:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v5
+        with:
+          fetch-depth: 1
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: "20"
+          cache: "npm"
+
+      - name: Install dependencies
+        run: npm ci
+
+      - name: Get version
+        id: package-version
+        run: |
+          VERSION=$(node -p "require('./package.json').version")
+          echo "version=$VERSION" >> $GITHUB_OUTPUT
+
+      - name: Generate SBOM (CycloneDX)
+        run: |
+          npx @cyclonedx/cyclonedx-npm --output-file termix_sbom.json --output-format JSON
+          npx @cyclonedx/cyclonedx-npm --output-file termix_sbom.xml --output-format XML
+
+      - name: Upload SBOM JSON as artifact
+        uses: actions/upload-artifact@v4
+        with:
+          name: termix_sbom_json
+          path: termix_sbom.json
+          retention-days: 90
+
+      - name: Upload SBOM XML as artifact
+        uses: actions/upload-artifact@v4
+        with:
+          name: termix_sbom_xml
+          path: termix_sbom.xml
+          retention-days: 90
+
+      - name: Upload SBOM to release
+        if: github.event_name == 'release'
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          gh release upload "${{ github.event.release.tag_name }}" termix_sbom.json termix_sbom.xml --clobber

--- a/package.json
+++ b/package.json
@@ -25,7 +25,8 @@
     "build:linux-portable": "npm run build && electron-builder --linux --dir",
     "build:linux-appimage": "npm run build && electron-builder --linux AppImage",
     "build:linux-targz": "npm run build && electron-builder --linux tar.gz",
-    "build:mac": "npm run build && electron-builder --mac --universal"
+    "build:mac": "npm run build && electron-builder --mac --universal",
+    "sbom:generate": "npx @cyclonedx/cyclonedx-npm --output-file sbom.json --output-format JSON && npx @cyclonedx/cyclonedx-npm --output-file sbom.xml --output-format XML"
   },
   "dependencies": {
     "@codemirror/autocomplete": "^6.18.7",


### PR DESCRIPTION
## Summary
- Add `sbom:generate` npm script using CycloneDX format
- Add GitHub Actions workflow (`.github/workflows/sbom.yml`) to auto-generate SBOM
- SBOM files (JSON + XML) are uploaded to releases automatically

## Why SBOM?
Software Bill of Materials (SBOM) provides:
- Supply chain transparency for security audits
- Dependency tracking for vulnerability management
- Compliance with industry standards (NIST, EO 14028)

## Test plan
- [ ] Run `npm run sbom:generate` locally to verify output
- [ ] Trigger workflow manually via `workflow_dispatch`
- [ ] Verify SBOM files are uploaded on next release