### PR TITLE
fix: prevent session reset when updating host properties

### DIFF
--- a/src/ui/desktop/apps/features/terminal/Terminal.tsx
+++ b/src/ui/desktop/apps/features/terminal/Terminal.tsx
@@ -1384,16 +1384,26 @@ export const Terminal = forwardRef<TerminalHandle, SSHTerminalProps>(
       resizeObserver.observe(xtermRef.current);
 
       return () => {
-        isUnmountingRef.current = true;
-        shouldNotReconnectRef.current = true;
-        isReconnectingRef.current = false;
-        setIsConnecting(false);
+        // Only clean up UI-related resources here.
+        // WebSocket cleanup is handled in a separate unmount-only effect
+        // to prevent session loss when hostConfig object reference changes.
         isFittingRef.current = false;
         resizeObserver.disconnect();
         element?.removeEventListener("contextmenu", handleContextMenu);
         element?.removeEventListener("keydown", handleMacKeyboard, true);
         if (notifyTimerRef.current) clearTimeout(notifyTimerRef.current);
         if (resizeTimeout.current) clearTimeout(resizeTimeout.current);
+      };
+    }, [xtermRef, terminal, hostConfig, isDarkMode]);
+
+    // Separate effect for WebSocket cleanup on true component unmount only.
+    // This prevents session loss when hostConfig properties are updated.
+    useEffect(() => {
+      return () => {
+        isUnmountingRef.current = true;
+        shouldNotReconnectRef.current = true;
+        isReconnectingRef.current = false;
+        setIsConnecting(false);
         if (reconnectTimeoutRef.current)
           clearTimeout(reconnectTimeoutRef.current);
         if (connectionTimeoutRef.current)
@@ -1405,7 +1415,7 @@ export const Terminal = forwardRef<TerminalHandle, SSHTerminalProps>(
         }
         webSocketRef.current?.close();
       };
-    }, [xtermRef, terminal, hostConfig, isDarkMode]);
+    }, []);
 
     useEffect(() => {
       if (!terminal) return;


### PR DESCRIPTION
## Summary
- Move WebSocket cleanup logic from the main terminal setup effect to a separate unmount-only effect
- Prevents SSH sessions from disconnecting when host properties (like folder path) are updated
- Fixes the issue where updating any host's settings would cause all running sessions to reset

## Root Cause
The main terminal useEffect had `hostConfig` (full object) as a dependency. When host properties were updated via `updateHostConfig`, it created a new object reference which triggered the effect's cleanup function. The cleanup closed the WebSocket and set flags (`isUnmountingRef`, `shouldNotReconnectRef`) that prevented reconnection.

## Solution
Split the cleanup logic:
1. **UI-related cleanup** (resize observer, event listeners, timeouts) - runs on every effect re-run
2. **WebSocket cleanup** - only runs when the component truly unmounts (empty dependency array `[]`)

This ensures that updating host properties only triggers UI reconfiguration, not session termination.

## Test plan
- [ ] Open an SSH terminal to a host
- [ ] Run a long-running command (e.g., `top`, `htop`, or `watch date`)
- [ ] In another tab, edit the host's folder property and save
- [ ] Verify the terminal session is NOT interrupted

Closes Termix-SSH/Support#401