### PR TITLE
fix: add missing mimeTypes definition for image preview

### DIFF
--- a/src/ui/desktop/apps/features/file-manager/components/FileViewer.tsx
+++ b/src/ui/desktop/apps/features/file-manager/components/FileViewer.tsx
@@ -332,9 +332,18 @@ export function FileViewer({
   const getImageDataUrl = (content: string, fileName: string): string => {
     const ext = fileName.split(".").pop()?.toLowerCase() || "";
 
-    if (ext === "svg") {
-      return `data:image/svg+xml;base64,${content}`;
-    }
+    const mimeTypes: Record<string, string> = {
+      svg: "image/svg+xml",
+      png: "image/png",
+      jpg: "image/jpeg",
+      jpeg: "image/jpeg",
+      gif: "image/gif",
+      webp: "image/webp",
+      bmp: "image/bmp",
+      ico: "image/x-icon",
+      tiff: "image/tiff",
+      tif: "image/tiff",
+    };
 
     const mimeType = mimeTypes[ext] || "image/png";
     return `data:${mimeType};base64,${content}`;


### PR DESCRIPTION
## Summary
- Fix image preview not working due to undefined `mimeTypes` variable
- Add complete MIME type mapping for common image formats

## Problem
The `getImageDataUrl` function references `mimeTypes[ext]` but the `mimeTypes` object was never defined, causing image preview to fail with a runtime error.

## Changes
- Add `mimeTypes` Record definition inside `getImageDataUrl` function in `FileViewer.tsx`
- Supports: svg, png, jpg, jpeg, gif, webp, bmp, ico, tiff, tif

## Test Plan
- [ ] Open an image file (png, jpg, gif, etc.) in the file manager
- [ ] Verify the image preview displays correctly
- [ ] Test with SVG files to ensure they still work

Fixes Termix-SSH/Support#408