### PR TITLE
Fix: Change minmax lower bound to 540px from 600px for gridTemplateColumns

### DIFF
--- a/src/ui/desktop/apps/dashboard/Dashboard.tsx
+++ b/src/ui/desktop/apps/dashboard/Dashboard.tsx
@@ -558,7 +558,7 @@ export function Dashboard({
                 <div
                   className="grid gap-4"
                   style={{
-                    gridTemplateColumns: "repeat(auto-fit, minmax(600px, 1fr))",
+                    gridTemplateColumns: "repeat(auto-fit, minmax(540px, 1fr))",
                     gridAutoRows: "minmax(300px, 1fr)",
                     minHeight: "100%",
                   }}


### PR DESCRIPTION
# Overview

_Short summary of what this PR does_

- [ ] Added: ...
- [ ] Updated: ...
- [ ] Removed: ...
- [x] Fixed: Cards taking 100% width on smaller displays in the dashboard

# Changes Made

- Change minmax lower bound for the dashboard grid to `540px` from `600px`

_Detailed explanation of changes (if needed)_

- N/A

# Related Issues

_Link any issues this PR addresses_

- Closes [#440 from Issues](https://github.com/Termix-SSH/Support/issues/440)

# Screenshots / Demos

_(Optional: add before/after screenshots, GIFs, or console output)_

# Checklist

- [x] Code follows project style guidelines
- [x] Supports mobile and desktop UI/app (if applicable)
- [x] I have read [Contributing.md](https://github.com/Termix-SSH/Termix/blob/main/CONTRIBUTING.md)
- [x] This is not a translation request. See [docs](https://docs.termix.site/translations)
