### PR TITLE
fix: add min-w-0 to grid children for container name truncation

### DIFF
--- a/src/ui/desktop/apps/features/docker/components/ContainerCard.tsx
+++ b/src/ui/desktop/apps/features/docker/components/ContainerCard.tsx
@@ -254,7 +254,7 @@ export function ContainerCard({
         onClick={onSelect}
       >
         <CardHeader className="pb-2 px-4">
-          <div className="flex items-start justify-between gap-2">
+          <div className="flex items-start justify-between gap-2 min-w-0">
             <CardTitle className="text-base font-semibold truncate flex-1 min-w-0">
               {container.name.startsWith("/")
                 ? container.name.slice(1)

--- a/src/ui/desktop/apps/features/docker/components/ContainerStats.tsx
+++ b/src/ui/desktop/apps/features/docker/components/ContainerStats.tsx
@@ -232,9 +232,9 @@ export function ContainerStats({
         </CardHeader>
         <CardContent className="px-4 pb-3">
           <div className="grid grid-cols-1 sm:grid-cols-3 gap-3 text-sm">
-            <div className="flex justify-between items-center">
-              <span className="text-muted-foreground">{t("docker.name")}</span>
-              <span className="font-mono text-foreground">{containerName}</span>
+            <div className="flex justify-between items-center gap-2 min-w-0">
+              <span className="text-muted-foreground shrink-0">{t("docker.name")}</span>
+              <span className="font-mono text-foreground truncate">{containerName}</span>
             </div>
             <div className="flex justify-between items-center">
               <span className="text-muted-foreground">{t("docker.id")}</span>


### PR DESCRIPTION
## Summary
Fix long Docker container names still overflowing after the v1.11.0 fix attempt.

Fixes Termix-SSH/Support#411

## Problem
Users reported that long container names (e.g., ShinyProxy-generated names with 36+ characters) still overflow the card boundaries in v1.11.0, despite the previous fix in commit 7ecfb4d.

## Root Cause
The previous fix added `min-w-0` to `CardTitle`, but missed the parent flex container. The layout structure is:

```
CardHeader (grid layout)
  └── div.flex (grid child, default min-width: auto) ← MISSING min-w-0
        └── CardTitle (truncate min-w-0) ← previous fix here
```

Grid/Flex children have `min-width: auto` by default, which prevents `truncate` from working. Even though `CardTitle` has `min-w-0`, its parent flex container (a grid child) doesn't, so the container expands beyond its bounds.

## Fix
Add `min-w-0` to the parent flex div that is a direct child of the grid container.

**ContainerCard.tsx:**
```diff
- <div className="flex items-start justify-between gap-2">
+ <div className="flex items-start justify-between gap-2 min-w-0">
```

**ContainerStats.tsx:**
```diff
- <div className="flex justify-between items-center">
-   <span className="text-muted-foreground">{t("docker.name")}</span>
-   <span className="font-mono text-foreground">{containerName}</span>
+ <div className="flex justify-between items-center gap-2 min-w-0">
+   <span className="text-muted-foreground shrink-0">{t("docker.name")}</span>
+   <span className="font-mono text-foreground truncate">{containerName}</span>
```

## Files Changed
- `src/ui/desktop/apps/features/docker/components/ContainerCard.tsx`
- `src/ui/desktop/apps/features/docker/components/ContainerStats.tsx`

## Test Plan
- [ ] Create a Docker container with a long name (36+ characters)
- [ ] Verify container name is truncated with ellipsis in ContainerCard
- [ ] Verify container name is truncated in ContainerStats view
- [ ] Hover over truncated name to see full name in tooltip (if applicable)