### PR TITLE
fix: skip metrics collection for hosts with authType none or opkssh

### DIFF
--- a/Casks/termix.rb
+++ b/Casks/termix.rb
@@ -1,6 +1,6 @@
 cask "termix" do
   version "2.0.0"
-  sha256 "a752ad4f05b4991b8a2ef986da80a86b79a70c93fe1045c4399fcf348a28c1d0"
+  sha256 "2e381ac504093bfa72d16ee20043640724394729b2ca0e6b26c9eac19aeb6d08"
 
   url "https://github.com/Termix-SSH/Termix/releases/download/release-#{version}-tag/termix_macos_universal_dmg.dmg"
   name "Termix"

--- a/src/backend/ssh/server-stats.ts
+++ b/src/backend/ssh/server-stats.ts
@@ -31,7 +31,9 @@ import { connectionPool, withConnection } from "./ssh-connection-pool.js";
 
 function supportsMetrics(host: SSHHostWithCredentials): boolean {
   const connectionType = host.connectionType || "ssh";
-  return connectionType === "ssh";
+  if (connectionType !== "ssh") return false;
+  if (host.authType === "none" || host.authType === "opkssh") return false;
+  return true;
 }
 
 function isTcpPingEnabled(statsConfig: StatsConfig): boolean {


### PR DESCRIPTION
## Summary
- `supportsMetrics()` only checked `connectionType` but ignored `authType`
- Hosts with `authType: "none"` (e.g. Tailscale SSH) or `"opkssh"` triggered SSH metrics polling, causing repeated "Too many authentication failures" errors since no credentials are available
- Added `authType` check to `supportsMetrics()` — these hosts are now correctly skipped for metrics collection (status-only checks via TCP ping still work)

## Related Issue
Closes Termix-SSH/Support#515

## Test plan
- [ ] Add a host with Authentication: None
- [ ] Enable metrics in host stats config
- [ ] Verify no SSH auth errors in logs for that host
- [ ] Verify TCP ping status check still works if enabled