### PR TITLE
feat: add collapse/expand all button for host manager folders

### DIFF
--- a/Casks/termix.rb
+++ b/Casks/termix.rb
@@ -1,6 +1,6 @@
 cask "termix" do
   version "2.0.0"
-  sha256 "a752ad4f05b4991b8a2ef986da80a86b79a70c93fe1045c4399fcf348a28c1d0"
+  sha256 "2e381ac504093bfa72d16ee20043640724394729b2ca0e6b26c9eac19aeb6d08"
 
   url "https://github.com/Termix-SSH/Termix/releases/download/release-#{version}-tag/termix_macos_universal_dmg.dmg"
   name "Termix"

--- a/src/ui/desktop/apps/host-manager/hosts/HostManagerViewer.tsx
+++ b/src/ui/desktop/apps/host-manager/hosts/HostManagerViewer.tsx
@@ -89,6 +89,8 @@ import {
   Monitor,
   MessagesSquare,
   Eye,
+  ChevronsDownUp,
+  ChevronsUpDown,
 } from "lucide-react";
 import type {
   SSHHost,
@@ -1214,6 +1216,24 @@ export function HostManagerViewer({
           >
             <ListChecks className="h-4 w-4 mr-2" />
             {selectionMode ? t("hosts.exitSelectMode") : t("hosts.selectMode")}
+          </Button>
+          <Button
+            variant="outline"
+            className="h-9"
+            onClick={() => {
+              if (openAccordions.length > 0) {
+                setOpenAccordions([]);
+              } else {
+                setOpenAccordions(folderKeys);
+              }
+            }}
+            title={openAccordions.length > 0 ? t("hosts.collapseAll", "Collapse All") : t("hosts.expandAll", "Expand All")}
+          >
+            {openAccordions.length > 0 ? (
+              <ChevronsDownUp className="h-4 w-4" />
+            ) : (
+              <ChevronsUpDown className="h-4 w-4" />
+            )}
           </Button>
         </div>
 


### PR DESCRIPTION
## Summary
- All host manager folders were auto-expanded on load with no way to collapse them all at once
- Added a collapse/expand toggle button in the toolbar next to "Select Mode"
- Click to collapse all folders, click again to expand all
- Icon indicates current action: ↕ to expand, ↑↓ to collapse

## Related Issue
Closes Termix-SSH/Support#488

## Test plan
- [ ] Open Host Manager with multiple folders
- [ ] Click the collapse button — all folders should collapse
- [ ] Click again — all folders should expand
- [ ] Verify individual folder accordion still works independently