### PR TITLE
fix: stats monitoring resolves SSH key from credential privateKey field

### DIFF
--- a/Casks/termix.rb
+++ b/Casks/termix.rb
@@ -1,6 +1,6 @@
 cask "termix" do
   version "2.0.0"
-  sha256 "a752ad4f05b4991b8a2ef986da80a86b79a70c93fe1045c4399fcf348a28c1d0"
+  sha256 "2e381ac504093bfa72d16ee20043640724394729b2ca0e6b26c9eac19aeb6d08"
 
   url "https://github.com/Termix-SSH/Termix/releases/download/release-#{version}-tag/termix_macos_universal_dmg.dmg"
   name "Termix"

--- a/src/backend/ssh/server-stats.ts
+++ b/src/backend/ssh/server-stats.ts
@@ -1373,8 +1373,8 @@ async function resolveHostCredentials(
             if (credential.password) {
               baseHost.password = credential.password;
             }
-            if (credential.key) {
-              baseHost.key = credential.key;
+            if (credential.key || (credential as Record<string, unknown>).privateKey) {
+              baseHost.key = credential.key || (credential as Record<string, unknown>).privateKey as string;
             }
             if (credential.keyPassword) {
               baseHost.keyPassword = credential.keyPassword;


### PR DESCRIPTION
## Summary
- `resolveHostCredentials()` in server-stats.ts only checked `credential.key` when loading SSH keys from credential records
- The `ssh_credentials` table has both `key` and `privateKey` fields — some credentials store the key in `privateKey`
- This caused status monitoring to attempt connection without the SSH key, resulting in "Connection closed by authenticating user" errors every 30 seconds
- Now checks both `credential.key` and `credential.privateKey`

## Related Issue
Closes Termix-SSH/Support#429

## Test plan
- [ ] Create a credential with SSH key authentication
- [ ] Assign it to a host
- [ ] Enable status monitoring for that host
- [ ] Verify metrics are collected without auth errors in logs