### PR TITLE
fix: check connection state before fallback exec in file manager

### DIFF
--- a/Casks/termix.rb
+++ b/Casks/termix.rb
@@ -1,6 +1,6 @@
 cask "termix" do
   version "2.0.0"
-  sha256 "a752ad4f05b4991b8a2ef986da80a86b79a70c93fe1045c4399fcf348a28c1d0"
+  sha256 "2e381ac504093bfa72d16ee20043640724394729b2ca0e6b26c9eac19aeb6d08"
 
   url "https://github.com/Termix-SSH/Termix/releases/download/release-#{version}-tag/termix_macos_universal_dmg.dmg"
   name "Termix"

--- a/src/backend/ssh/file-manager.ts
+++ b/src/backend/ssh/file-manager.ts
@@ -2472,6 +2472,10 @@ app.get("/ssh/file_manager/ssh/listFiles", (req, res) => {
   };
 
   const tryFallbackMethod = () => {
+    if (!sshConn?.isConnected) {
+      sshConn.activeOperations--;
+      return res.status(500).json({ error: "SSH session disconnected" });
+    }
     try {
       const escapedPath = sshPath.replace(/'/g, "'\"'\"'");
       sshConn.client.exec(
@@ -3278,6 +3282,10 @@ app.post("/ssh/file_manager/ssh/writeFile", async (req, res) => {
   };
 
   const tryFallbackMethod = () => {
+    if (!sshConn?.isConnected) {
+      sshConn.activeOperations--;
+      return res.status(500).json({ error: "SSH session disconnected" });
+    }
     try {
       let contentBuffer: Buffer;
       if (typeof content === "string") {
@@ -3564,6 +3572,10 @@ app.post("/ssh/file_manager/ssh/uploadFile", async (req, res) => {
   };
 
   const tryFallbackMethod = () => {
+    if (!sshConn?.isConnected) {
+      sshConn.activeOperations--;
+      return res.status(500).json({ error: "SSH session disconnected" });
+    }
     try {
       let contentBuffer: Buffer;
       if (typeof content === "string") {


### PR DESCRIPTION
## Summary
- When SFTP operations fail (timeout, disconnect), the file manager calls `tryFallbackMethod()` which executes `client.exec()` as an alternative
- If the SSH client is already disconnected at that point, `client.exec()` throws an unhandled `Error: Not connected` exception that crashes the entire backend process
- Added `sshConn.isConnected` check at the start of all three `tryFallbackMethod` closures (listFiles, writeFile, uploadFile) to return a proper error response instead of crashing

## Related Issue
Closes Termix-SSH/Support#451

## Test plan
- [ ] Open file manager with an SSH connection
- [ ] Cause the connection to drop (e.g. network interruption)
- [ ] Click refresh in the file manager
- [ ] Verify an error message is shown instead of backend crash
- [ ] Verify other sessions continue to work normally