### PR TITLE
fix: restrict postMessage targetOrigin to prevent JWT leakage

### DIFF
--- a/Casks/termix.rb
+++ b/Casks/termix.rb
@@ -1,6 +1,6 @@
 cask "termix" do
   version "2.0.0"
-  sha256 "a752ad4f05b4991b8a2ef986da80a86b79a70c93fe1045c4399fcf348a28c1d0"
+  sha256 "2e381ac504093bfa72d16ee20043640724394729b2ca0e6b26c9eac19aeb6d08"
 
   url "https://github.com/Termix-SSH/Termix/releases/download/release-#{version}-tag/termix_macos_universal_dmg.dmg"
   name "Termix"

--- a/src/ui/desktop/authentication/Auth.tsx
+++ b/src/ui/desktop/authentication/Auth.tsx
@@ -325,7 +325,7 @@ export function Auth({
               platform: "desktop",
               timestamp: Date.now(),
             },
-            "*",
+            window.location.origin,
           );
           setWebviewAuthSuccess(true);
           return;
@@ -534,7 +534,7 @@ export function Auth({
               platform: "desktop",
               timestamp: Date.now(),
             },
-            "*",
+            window.location.origin,
           );
           setWebviewAuthSuccess(true);
           setTotpLoading(false);
@@ -672,7 +672,7 @@ export function Auth({
                     platform: "desktop",
                     timestamp: Date.now(),
                   },
-                  "*",
+                  window.location.origin,
                 );
                 setWebviewAuthSuccess(true);
                 setOidcLoading(false);

--- a/src/ui/desktop/authentication/ElectronLoginForm.tsx
+++ b/src/ui/desktop/authentication/ElectronLoginForm.tsx
@@ -190,10 +190,18 @@ export function ElectronLoginForm({
             try {
               iframe.contentWindow.eval(injectedScript);
             } catch (evalError) {
-              iframe.contentWindow.postMessage(
-                { type: "INJECT_SCRIPT", script: injectedScript },
-                "*",
-              );
+              try {
+                const iframeOrigin = new URL(serverUrl).origin;
+                iframe.contentWindow.postMessage(
+                  { type: "INJECT_SCRIPT", script: injectedScript },
+                  iframeOrigin,
+                );
+              } catch {
+                iframe.contentWindow.postMessage(
+                  { type: "INJECT_SCRIPT", script: injectedScript },
+                  "*",
+                );
+              }
             }
           }
         } catch (err) {

--- a/src/ui/main-axios.ts
+++ b/src/ui/main-axios.ts
@@ -2538,7 +2538,7 @@ export async function loginUser(
     const isInIframe =
       typeof window !== "undefined" && window.self !== window.top;
 
-    if (isInIframe && hasToken) {
+    if (isInIframe && isElectron() && hasToken) {
       localStorage.setItem("jwt", response.data.token);
 
       try {
@@ -2550,7 +2550,7 @@ export async function loginUser(
             platform: "desktop",
             timestamp: Date.now(),
           },
-          "*",
+          window.location.origin,
         );
       } catch (e) {
         console.error("[main-axios] Error posting message to parent:", e);
@@ -3012,7 +3012,7 @@ export async function verifyTOTPLogin(
     const isInIframe =
       typeof window !== "undefined" && window.self !== window.top;
 
-    if (isInIframe && hasToken) {
+    if (isInIframe && isElectron() && hasToken) {
       localStorage.setItem("jwt", response.data.token);
 
       try {
@@ -3024,7 +3024,7 @@ export async function verifyTOTPLogin(
             platform: "desktop",
             timestamp: Date.now(),
           },
-          "*",
+          window.location.origin,
         );
       } catch (e) {
         console.error("[main-axios] Error posting message to parent:", e);


### PR DESCRIPTION
## Summary
- Multiple `postMessage` calls used wildcard `"*"` as targetOrigin, allowing any parent window to intercept JWT tokens if Termix web UI is embedded in a malicious iframe
- **main-axios.ts**: Added `isElectron()` guard — postMessage to parent only fires in Electron iframe context (not in regular browsers). Changed targetOrigin from `"*"` to `window.location.origin`
- **Auth.tsx**: Replaced `"*"` with `window.location.origin` for all three AUTH_SUCCESS postMessage calls (login, TOTP, OIDC callback)
- **ElectronLoginForm.tsx**: Parent→iframe postMessage now uses parsed server URL origin instead of `"*"`, with fallback for unparseable URLs

## Test plan
- [ ] Electron desktop app: login via password, TOTP, and OIDC — all should work
- [ ] Web browser: verify postMessage is not sent when not in Electron context
- [ ] Verify no JWT tokens appear in browser console from cross-origin messages