### PR TITLE
fix: use cookie-based auth for WebSocket instead of URL token

### DIFF
--- a/Casks/termix.rb
+++ b/Casks/termix.rb
@@ -1,6 +1,6 @@
 cask "termix" do
   version "2.0.0"
-  sha256 "a752ad4f05b4991b8a2ef986da80a86b79a70c93fe1045c4399fcf348a28c1d0"
+  sha256 "2e381ac504093bfa72d16ee20043640724394729b2ca0e6b26c9eac19aeb6d08"
 
   url "https://github.com/Termix-SSH/Termix/releases/download/release-#{version}-tag/termix_macos_universal_dmg.dmg"
   name "Termix"

--- a/src/backend/ssh/docker-console.ts
+++ b/src/backend/ssh/docker-console.ts
@@ -28,7 +28,15 @@ const wss = new WebSocketServer({
   verifyClient: async (info) => {
     try {
       const url = parseUrl(info.req.url || "", true);
-      const token = url.query.token as string;
+      let token = url.query.token as string;
+
+      if (!token) {
+        const cookieHeader = info.req.headers.cookie;
+        if (cookieHeader) {
+          const match = cookieHeader.match(/(?:^|;\s*)jwt=([^;]+)/);
+          if (match) token = decodeURIComponent(match[1]);
+        }
+      }
 
       if (!token) {
         return false;

--- a/src/backend/ssh/terminal.ts
+++ b/src/backend/ssh/terminal.ts
@@ -320,7 +320,15 @@ const wss = new WebSocketServer({
   verifyClient: async (info) => {
     try {
       const url = parseUrl(info.req.url!, true);
-      const token = url.query.token as string;
+      let token = url.query.token as string;
+
+      if (!token) {
+        const cookieHeader = info.req.headers.cookie;
+        if (cookieHeader) {
+          const match = cookieHeader.match(/(?:^|;\s*)jwt=([^;]+)/);
+          if (match) token = decodeURIComponent(match[1]);
+        }
+      }
 
       if (!token) {
         return false;

--- a/src/ui/desktop/apps/features/docker/components/ConsoleTerminal.tsx
+++ b/src/ui/desktop/apps/features/docker/components/ConsoleTerminal.tsx
@@ -263,8 +263,7 @@ export function ConsoleTerminal({
             })()
           : `${window.location.protocol === "https:" ? "wss" : "ws"}://${window.location.host}${getBasePath()}/docker/console/`;
 
-      const wsUrl = `${baseWsUrl}?token=${encodeURIComponent(token)}`;
-      const ws = new WebSocket(wsUrl);
+      const ws = new WebSocket(baseWsUrl);
 
       ws.onopen = () => {
         const cols = terminal.cols || 80;

--- a/src/ui/desktop/apps/features/terminal/Terminal.tsx
+++ b/src/ui/desktop/apps/features/terminal/Terminal.tsx
@@ -769,9 +769,7 @@ const TerminalInner = forwardRef<TerminalHandle, SSHTerminalProps>(
         connectionTimeoutRef.current = null;
       }
 
-      const wsUrl = `${baseWsUrl}?token=${encodeURIComponent(jwtToken)}`;
-
-      const ws = new WebSocket(wsUrl);
+      const ws = new WebSocket(baseWsUrl);
       webSocketRef.current = ws;
       wasDisconnectedBySSH.current = false;
       updateConnectionError(null);


### PR DESCRIPTION
## Summary
- JWT tokens were passed in WebSocket URL query strings (`?token=JWT`), exposing them in nginx access logs, browser history, and proxy logs
- **Backend**: Terminal (port 30002) and Docker console (port 30009) WebSocket servers now read JWT from the `Cookie` header as fallback when no URL token is provided. URL token still works for backward compatibility (mobile clients)
- **Frontend**: Desktop terminal and docker console no longer append token to WebSocket URL — the browser automatically sends cookies with the WebSocket handshake
- Mobile terminal and Guacamole connections are unchanged as they may rely on URL token

## Test plan
- [ ] Open terminal via web browser — should connect without token in URL
- [ ] Open docker console via web browser — should connect without token in URL
- [ ] Check nginx access logs — no JWT tokens should appear in WebSocket URLs
- [ ] Mobile app terminal — should still work (uses URL token fallback)
- [ ] Electron desktop app — should work via cookie