### PR TITLE
fix: revoke all sessions when password is changed or reset

### DIFF
--- a/Casks/termix.rb
+++ b/Casks/termix.rb
@@ -1,6 +1,6 @@
 cask "termix" do
   version "2.0.0"
-  sha256 "a752ad4f05b4991b8a2ef986da80a86b79a70c93fe1045c4399fcf348a28c1d0"
+  sha256 "2e381ac504093bfa72d16ee20043640724394729b2ca0e6b26c9eac19aeb6d08"
 
   url "https://github.com/Termix-SSH/Termix/releases/download/release-#{version}-tag/termix_macos_universal_dmg.dmg"
   name "Termix"

--- a/src/backend/utils/auth-manager.ts
+++ b/src/backend/utils/auth-manager.ts
@@ -785,6 +785,26 @@ class AuthManager {
         });
       }
     } else {
+      try {
+        await db.delete(sessions).where(eq(sessions.userId, userId));
+
+        try {
+          const { saveMemoryDatabaseToFile } =
+            await import("../database/db/index.js");
+          await saveMemoryDatabaseToFile();
+        } catch {
+          // best effort
+        }
+      } catch (error) {
+        databaseLogger.error(
+          "Failed to revoke all sessions on logout",
+          error,
+          {
+            operation: "session_revoke_all_failed",
+            userId,
+          },
+        );
+      }
       this.userCrypto.logoutUser(userId);
     }
   }


### PR DESCRIPTION
## Summary
- `logoutUser(userId)` without sessionId only cleared in-memory crypto state but did not delete session records from the database
- Old JWT tokens remained valid after password change/reset, allowing an attacker with a stolen token to maintain access
- Now deletes all session records for the user when no specific sessionId is provided
- Affects three code paths: password reset (data preserved), password reset (full), and password change

## Test plan
- [ ] Log in from two different browsers
- [ ] Change password from one browser
- [ ] Verify the other browser's session is immediately invalidated
- [ ] Reset password via admin — verify all sessions are revoked