### PR TITLE
fix: validate containerId and timestamp params to prevent command injection

### DIFF
--- a/Casks/termix.rb
+++ b/Casks/termix.rb
@@ -1,6 +1,6 @@
 cask "termix" do
   version "2.0.0"
-  sha256 "a752ad4f05b4991b8a2ef986da80a86b79a70c93fe1045c4399fcf348a28c1d0"
+  sha256 "2e381ac504093bfa72d16ee20043640724394729b2ca0e6b26c9eac19aeb6d08"
 
   url "https://github.com/Termix-SSH/Termix/releases/download/release-#{version}-tag/termix_macos_universal_dmg.dmg"
   name "Termix"

--- a/src/backend/ssh/docker.ts
+++ b/src/backend/ssh/docker.ts
@@ -469,6 +469,16 @@ app.use((_req, res, next) => {
 const authManager = AuthManager.getInstance();
 app.use(authManager.createAuthMiddleware());
 
+const CONTAINER_ID_RE = /^[a-zA-Z0-9][a-zA-Z0-9_.-]*$/;
+const DOCKER_TIMESTAMP_RE = /^[0-9T:.Z+-]+$/;
+
+app.param("containerId", (req, res, next, value) => {
+  if (!CONTAINER_ID_RE.test(value)) {
+    return res.status(400).json({ error: "Invalid container ID" });
+  }
+  next();
+});
+
 /**
  * @openapi
  * /docker/ssh/connect:
@@ -3016,18 +3026,18 @@ app.get("/docker/containers/:sessionId/:containerId/logs", async (req, res) => {
     let command = `docker logs ${containerId}`;
 
     if (tail && tail > 0) {
-      command += ` --tail ${tail}`;
+      command += ` --tail ${Math.floor(tail)}`;
     }
 
     if (timestamps) {
       command += " --timestamps";
     }
 
-    if (since) {
+    if (since && DOCKER_TIMESTAMP_RE.test(since)) {
       command += ` --since ${since}`;
     }
 
-    if (until) {
+    if (until && DOCKER_TIMESTAMP_RE.test(until)) {
       command += ` --until ${until}`;
     }
 


### PR DESCRIPTION
## Summary
- Docker API endpoints passed `containerId`, `since`, and `until` parameters directly into shell commands without validation
- An authenticated user with Docker feature access could inject arbitrary commands on the remote SSH host
- Added `app.param("containerId")` middleware validating against `^[a-zA-Z0-9][a-zA-Z0-9_.-]*$` — covers all 9 Docker endpoints at once
- Validated `since`/`until` timestamps in the logs endpoint against `^[0-9T:.Z+-]+$`
- `tail` parameter forced through `Math.floor()` to ensure integer

## Test plan
- [ ] List, inspect, start, stop, restart, pause, unpause, remove containers — should work normally
- [ ] View container logs with timestamps/since/until — should work
- [ ] Try containerId with special chars (`;`, `$()`, backticks) — should return 400