### PR TITLE
fix: remove sensitive data from log output and prevent user enumeration

### DIFF
--- a/src/backend/database/routes/host.ts
+++ b/src/backend/database/routes/host.ts
@@ -4315,15 +4315,7 @@ router.get("/opkssh-callback", async (req: Request, res: Response) => {
   try {
     sshLogger.info("OAuth callback received", {
       operation: "opkssh_static_callback_received",
-      url: req.url,
-      originalUrl: req.originalUrl,
-      query: req.query,
-      headers: {
-        host: req.headers.host,
-        "x-forwarded-proto": req.headers["x-forwarded-proto"],
-        "x-forwarded-host": req.headers["x-forwarded-host"],
-        "x-forwarded-port": req.headers["x-forwarded-port"],
-      },
+      host: req.headers.host,
     });
 
     const { getUserIdFromRequest, getActiveSessionsForUser } =

--- a/src/backend/database/routes/users.ts
+++ b/src/backend/database/routes/users.ts
@@ -2155,12 +2155,16 @@ router.post("/initiate-reset", async (req, res) => {
       authLogger.warn(
         `Password reset attempted for non-existent user: ${username}`,
       );
-      return res.status(404).json({ error: "User not found" });
+      return res.json({
+        message:
+          "If the user exists, a password reset code has been generated. Check docker logs for the code.",
+      });
     }
 
     if (user[0].isOidc) {
-      return res.status(403).json({
-        error: "Password reset not available for external authentication users",
+      return res.json({
+        message:
+          "If the user exists, a password reset code has been generated. Check docker logs for the code.",
       });
     }
 
@@ -2175,7 +2179,7 @@ router.post("/initiate-reset", async (req, res) => {
       );
 
     authLogger.info(
-      `Password reset code for user ${username}: ${resetCode} (expires at ${expiresAt.toLocaleString()})`,
+      `Password reset code generated for user ${username} (expires at ${expiresAt.toLocaleString()}). Check admin panel or database settings table for code.`,
     );
 
     res.json({


### PR DESCRIPTION
## Summary
- **Password reset code in logs**: The 6-digit reset code was logged in plaintext. Removed the code from log output — it remains in the settings DB table for admin retrieval
- **User enumeration**: Password reset endpoint returned different HTTP status codes for non-existent users (404) vs OIDC users (403) vs success (200). Now returns identical success response for all cases
- **OPKSSH callback logs**: Full URL, query params, and forwarded headers were logged, potentially exposing OAuth tokens/codes. Reduced to only log the host header

## Test plan
- [ ] Initiate password reset — verify code is NOT in docker logs
- [ ] Verify reset code still works (stored in settings table)
- [ ] Try reset for non-existent user — should get same response as valid user
- [ ] OPKSSH callback — verify logs don't contain URL params