### PR TITLE
Fix Docker routing for SSH host and folder endpoints

### DIFF
--- a/docker/nginx-https.conf
+++ b/docker/nginx-https.conf
@@ -294,6 +294,34 @@ http {
             proxy_next_upstream error timeout invalid_header http_500 http_502 http_503;
         }
 
+        location ~ ^/ssh/db(/.*)?$ {
+            client_max_body_size 5G;
+            client_body_timeout 300s;
+
+            proxy_pass http://127.0.0.1:30001/host/db$1$is_args$args;
+            proxy_http_version 1.1;
+            proxy_set_header Host $http_host;
+            proxy_set_header X-Real-IP $remote_addr;
+            proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+            proxy_set_header X-Forwarded-Proto $scheme;
+
+            proxy_connect_timeout 60s;
+            proxy_send_timeout 300s;
+            proxy_read_timeout 300s;
+
+            proxy_request_buffering off;
+            proxy_buffering off;
+        }
+
+        location ~ ^/ssh/folders(/.*)?$ {
+            proxy_pass http://127.0.0.1:30001/host/folders$1$is_args$args;
+            proxy_http_version 1.1;
+            proxy_set_header Host $http_host;
+            proxy_set_header X-Real-IP $remote_addr;
+            proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+            proxy_set_header X-Forwarded-Proto $scheme;
+        }
+
         location ^~ /guacamole/websocket/ {
             proxy_pass http://127.0.0.1:30008/;
             proxy_http_version 1.1;

--- a/docker/nginx.conf
+++ b/docker/nginx.conf
@@ -283,6 +283,34 @@ http {
             proxy_next_upstream error timeout invalid_header http_500 http_502 http_503;
         }
 
+        location ~ ^/ssh/db(/.*)?$ {
+            client_max_body_size 5G;
+            client_body_timeout 300s;
+
+            proxy_pass http://127.0.0.1:30001/host/db$1$is_args$args;
+            proxy_http_version 1.1;
+            proxy_set_header Host $http_host;
+            proxy_set_header X-Real-IP $remote_addr;
+            proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+            proxy_set_header X-Forwarded-Proto $scheme;
+
+            proxy_connect_timeout 60s;
+            proxy_send_timeout 300s;
+            proxy_read_timeout 300s;
+
+            proxy_request_buffering off;
+            proxy_buffering off;
+        }
+
+        location ~ ^/ssh/folders(/.*)?$ {
+            proxy_pass http://127.0.0.1:30001/host/folders$1$is_args$args;
+            proxy_http_version 1.1;
+            proxy_set_header Host $http_host;
+            proxy_set_header X-Real-IP $remote_addr;
+            proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+            proxy_set_header X-Forwarded-Proto $scheme;
+        }
+
         location ^~ /guacamole/websocket/ {
             proxy_pass http://127.0.0.1:30008/;
             proxy_http_version 1.1;


### PR DESCRIPTION
## Summary
Add the missing Docker nginx routes for `/ssh/db/*` and `/ssh/folders*` so the web UI reaches the backend host and folder endpoints correctly.

## Problem
In `release-2.0.0`, the Docker deployment proxies `/db/*` and `/host/*`, but the UI calls:
- `/ssh/db/host`
- `/ssh/folders`

Without explicit nginx routing for those paths, add-host and file-browser requests fail in Docker deployments.

## Repro
1. Deploy Termix `release-2.0.0` with the documented Docker setup.
2. Log in and try to add an SSH host.
3. Observe the host save failure.
4. Open the file browser.
5. Observe folder/file-manager requests failing or misbehaving.

On my local Docker deployment this showed up as broken `POST /ssh/db/host` and `GET /ssh/folders` behavior until these routes were added.

## Fix
- route `/ssh/db/*` to `http://127.0.0.1:30001/host/db/*`
- route `/ssh/folders*` to `http://127.0.0.1:30001/host/folders*`

Applied in both:
- `docker/nginx.conf`
- `docker/nginx-https.conf`

## Verification
Verified on a localhost-only Docker deployment on macOS:
- host creation works again through `/ssh/db/host`
- `/ssh/folders` returns authenticated data instead of 404/405
- SSH file-manager connect/list/upload/download work again through the fixed deployment
