### PR TITLE
fix: preserve original timestamps in SSH login statistics

### DIFF
--- a/Casks/termix.rb
+++ b/Casks/termix.rb
@@ -1,6 +1,6 @@
 cask "termix" do
   version "2.0.0"
-  sha256 "a752ad4f05b4991b8a2ef986da80a86b79a70c93fe1045c4399fcf348a28c1d0"
+  sha256 "2e381ac504093bfa72d16ee20043640724394729b2ca0e6b26c9eac19aeb6d08"
 
   url "https://github.com/Termix-SSH/Termix/releases/download/release-#{version}-tag/termix_macos_universal_dmg.dmg"
   name "Termix"

--- a/src/backend/ssh/widgets/login-stats-collector.ts
+++ b/src/backend/ssh/widgets/login-stats-collector.ts
@@ -49,11 +49,12 @@ export async function collectLoginStats(client: Client): Promise<LoginStats> {
             let parsedTime: string;
             try {
               const date = new Date(timeStr);
-              parsedTime = isNaN(date.getTime())
-                ? new Date().toISOString()
-                : date.toISOString();
+              parsedTime =
+                isNaN(date.getTime())
+                  ? timeStr || "unknown"
+                  : date.toISOString();
             } catch {
-              parsedTime = new Date().toISOString();
+              parsedTime = timeStr || "unknown";
             }
 
             recentLogins.push({
@@ -99,21 +100,30 @@ export async function collectLoginStats(client: Client): Promise<LoginStats> {
         ip = ipMatch[1];
       }
 
-      const dateMatch = line.match(/^(\w+\s+\d+\s+\d+:\d+:\d+)/);
+      const dateMatch = line.match(/^(\w+)\s+(\d+)\s+(\d+:\d+:\d+)/);
       if (dateMatch) {
-        const currentYear = new Date().getFullYear();
-        timeStr = `${currentYear} ${dateMatch[1]}`;
+        const [, month, day, time] = dateMatch;
+        const now = new Date();
+        const currentYear = now.getFullYear();
+        const candidate = new Date(`${month} ${day}, ${currentYear} ${time}`);
+        if (!isNaN(candidate.getTime()) && candidate > now) {
+          // If parsed date is in the future, it's from last year
+          timeStr = `${month} ${day}, ${currentYear - 1} ${time}`;
+        } else {
+          timeStr = `${month} ${day}, ${currentYear} ${time}`;
+        }
       }
 
       if (user && ip) {
         let parsedTime: string;
         try {
-          const date = timeStr ? new Date(timeStr) : new Date();
-          parsedTime = isNaN(date.getTime())
-            ? new Date().toISOString()
-            : date.toISOString();
+          const date = timeStr ? new Date(timeStr) : null;
+          parsedTime =
+            date && !isNaN(date.getTime())
+              ? date.toISOString()
+              : timeStr || "unknown";
         } catch {
-          parsedTime = new Date().toISOString();
+          parsedTime = timeStr || "unknown";
         }
 
         failedLogins.push({


### PR DESCRIPTION
## Summary
Failed login attempts in the SSH statistics widget showed the current time instead of the actual attempt time, updating on every refresh cycle.

Root cause: `auth.log` dates like `Mar 15 10:23:45` (no year) were parsed using `new Date("2026 Mar 15 10:23:45")` which fails on some JS runtimes. The fallback was `new Date()` — the current time.

Fixes:
1. Changed date format to `"Mar 15, 2026 10:23:45"` for more reliable parsing
2. When parsing fails, fall back to the raw time string instead of current time
3. Detect cross-year entries (e.g. December logs in January) by checking for future dates and subtracting a year
4. Applied same fix to successful login timestamps

## Related Issue
Closes Termix-SSH/Support#570

## Test plan
- [ ] View SSH stats for a host with failed login attempts
- [ ] Timestamps should show the original attempt time, not current time
- [ ] Refresh the page — timestamps should remain stable
- [ ] Test with logs from the previous year