### PR TITLE
fix: align cookie maxAge with JWT expiration to prevent early logout

### DIFF
--- a/Casks/termix.rb
+++ b/Casks/termix.rb
@@ -1,6 +1,6 @@
 cask "termix" do
   version "2.0.0"
-  sha256 "a752ad4f05b4991b8a2ef986da80a86b79a70c93fe1045c4399fcf348a28c1d0"
+  sha256 "2e381ac504093bfa72d16ee20043640724394729b2ca0e6b26c9eac19aeb6d08"
 
   url "https://github.com/Termix-SSH/Termix/releases/download/release-#{version}-tag/termix_macos_universal_dmg.dmg"
   name "Termix"

--- a/src/backend/database/routes/users.ts
+++ b/src/backend/database/routes/users.ts
@@ -1577,7 +1577,7 @@ router.post("/login", async (req, res) => {
       response.token = token;
     }
 
-    const maxAge = rememberMe ? 30 * 24 * 60 * 60 * 1000 : 2 * 60 * 60 * 1000;
+    const maxAge = rememberMe ? 30 * 24 * 60 * 60 * 1000 : 24 * 60 * 60 * 1000;
 
     return res
       .cookie("jwt", token, authManager.getSecureCookieOptions(req, maxAge))
@@ -3359,7 +3359,7 @@ router.post("/totp/verify-login", async (req, res) => {
       response.token = token;
     }
 
-    const maxAge = rememberMe ? 30 * 24 * 60 * 60 * 1000 : 2 * 60 * 60 * 1000;
+    const maxAge = rememberMe ? 30 * 24 * 60 * 60 * 1000 : 24 * 60 * 60 * 1000;
 
     return res
       .cookie("jwt", token, authManager.getSecureCookieOptions(req, maxAge))


### PR DESCRIPTION
## Summary
**Note: Superseded by #662 which includes this fix plus configurable session timeout.**

- The JWT cookie maxAge for regular logins was set to 2 hours, while the JWT token was valid for 24 hours
- Changed cookie maxAge from 2h to 24h to match JWT expiration

## Related Issues
Closes Termix-SSH/Support#595
Closes Termix-SSH/Support#583