### PR TITLE
fix: downgrade credential migration errors to warnings

### DIFF
--- a/Casks/termix.rb
+++ b/Casks/termix.rb
@@ -1,6 +1,6 @@
 cask "termix" do
   version "2.0.0"
-  sha256 "a752ad4f05b4991b8a2ef986da80a86b79a70c93fe1045c4399fcf348a28c1d0"
+  sha256 "2e381ac504093bfa72d16ee20043640724394729b2ca0e6b26c9eac19aeb6d08"
 
   url "https://github.com/Termix-SSH/Termix/releases/download/release-#{version}-tag/termix_macos_universal_dmg.dmg"
   name "Termix"

--- a/src/backend/utils/credential-system-encryption-migration.ts
+++ b/src/backend/utils/credential-system-encryption-migration.ts
@@ -107,20 +107,23 @@ export class CredentialSystemEncryptionMigration {
 
           migrated++;
         } catch (error) {
-          databaseLogger.error("Failed to migrate credential", error, {
-            credentialId: cred.id,
-            userId,
-          });
+          databaseLogger.warn(
+            `Skipping credential migration for credential ${cred.id}: ${error instanceof Error ? error.message : "Unknown error"}`,
+            {
+              operation: "credential_migration_skip",
+              credentialId: cred.id,
+              userId,
+            },
+          );
           failed++;
         }
       }
       return { migrated, failed, skipped };
     } catch (error) {
-      databaseLogger.error(
-        "Credential system encryption migration failed",
-        error,
+      databaseLogger.warn(
+        "Credential system encryption migration incomplete",
         {
-          operation: "credential_migration_failed",
+          operation: "credential_migration_incomplete",
           userId,
           error: error instanceof Error ? error.message : "Unknown error",
         },


### PR DESCRIPTION
## Summary
- Credential migration failures during login were logged at ERROR level, causing alarm in Docker logs even though login succeeds normally
- The migration is non-blocking (best-effort) — it tries to re-encrypt credentials from user-level to system-level encryption, but failure doesn't affect authentication
- Changed log level from `error` to `warn` for both individual credential failures and overall migration failures
- Improved log messages to be more descriptive ("Skipping credential migration" instead of "Failed to migrate credential")

## Related Issue
Closes Termix-SSH/Support#541

## Test plan
- [ ] Login with 2FA enabled — should succeed without ERROR in logs
- [ ] If credentials fail to migrate, should show WARN instead of ERROR
- [ ] Login flow should not be interrupted by migration failures