### PR TITLE
feat: add Select All / Deselect All buttons for snippet terminal selection

### DIFF
--- a/Casks/termix.rb
+++ b/Casks/termix.rb
@@ -1,6 +1,6 @@
 cask "termix" do
   version "2.0.0"
-  sha256 "a752ad4f05b4991b8a2ef986da80a86b79a70c93fe1045c4399fcf348a28c1d0"
+  sha256 "2e381ac504093bfa72d16ee20043640724394729b2ca0e6b26c9eac19aeb6d08"
 
   url "https://github.com/Termix-SSH/Termix/releases/download/release-#{version}-tag/termix_macos_universal_dmg.dmg"
   name "Termix"

--- a/src/ui/desktop/apps/tools/SSHToolsSidebar.tsx
+++ b/src/ui/desktop/apps/tools/SSHToolsSidebar.tsx
@@ -1296,6 +1296,30 @@ export function SSHToolsSidebar({
                                   })
                                 : t("snippets.executeOnCurrent")}
                             </p>
+                            <div className="flex gap-2 mb-1">
+                              <Button
+                                type="button"
+                                variant="ghost"
+                                size="sm"
+                                className="text-xs h-6 px-2"
+                                onClick={() =>
+                                  setSelectedSnippetTabIds(
+                                    terminalTabs.map((t) => t.id),
+                                  )
+                                }
+                              >
+                                {t("snippets.selectAll", "Select All")}
+                              </Button>
+                              <Button
+                                type="button"
+                                variant="ghost"
+                                size="sm"
+                                className="text-xs h-6 px-2"
+                                onClick={() => setSelectedSnippetTabIds([])}
+                              >
+                                {t("snippets.deselectAll", "Deselect All")}
+                              </Button>
+                            </div>
                             <div className="flex flex-wrap gap-2 max-h-32 overflow-y-auto thin-scrollbar">
                               {terminalTabs.map((tab) => (
                                 <Button


### PR DESCRIPTION
## Summary
- When running snippets on many open terminals (e.g. 24 servers), users had to click each terminal button individually
- Added "Select All" and "Deselect All" buttons above the terminal list in the snippet execution panel
- Uses compact ghost button style to avoid cluttering the UI

## Related Issue
Closes Termix-SSH/Support#535

## Test plan
- [ ] Open multiple terminal sessions
- [ ] Open snippet panel → click "Select All" → all terminals highlighted
- [ ] Click "Deselect All" → all terminals deselected
- [ ] Run a snippet with all selected → executes on all terminals