### PR TITLE
feat: switch to adjacent tab when closing current tab

### DIFF
--- a/Casks/termix.rb
+++ b/Casks/termix.rb
@@ -1,6 +1,6 @@
 cask "termix" do
   version "2.0.0"
-  sha256 "a752ad4f05b4991b8a2ef986da80a86b79a70c93fe1045c4399fcf348a28c1d0"
+  sha256 "2e381ac504093bfa72d16ee20043640724394729b2ca0e6b26c9eac19aeb6d08"
 
   url "https://github.com/Termix-SSH/Termix/releases/download/release-#{version}-tag/termix_macos_universal_dmg.dmg"
   name "Termix"

--- a/src/ui/desktop/navigation/tabs/TabContext.tsx
+++ b/src/ui/desktop/navigation/tabs/TabContext.tsx
@@ -293,7 +293,13 @@ export function TabProvider({ children }: TabProviderProps) {
         if (remainingSplitTabs.length > 0) {
           setCurrentTab(remainingSplitTabs[0]);
         } else {
-          setCurrentTab(remainingTabs[0].id);
+          // Switch to the adjacent tab (prefer the one after, then before)
+          const closedIndex = tabs.findIndex((t) => t.id === tabId);
+          const nextTab =
+            closedIndex < remainingTabs.length
+              ? remainingTabs[closedIndex]
+              : remainingTabs[remainingTabs.length - 1];
+          setCurrentTab(nextTab.id);
         }
       } else {
         setCurrentTab(1);


### PR DESCRIPTION
## Summary
- Closing the current tab always switched to the first remaining tab (often the Dashboard), regardless of which tabs were open
- Now switches to the **adjacent tab** — the next tab in order, or the previous one if the closed tab was the last
- This matches the behavior of browsers and IDEs

## Related Issue
Closes Termix-SSH/Support#606

## Test plan
- [ ] Open tabs: Dashboard, Terminal A, Terminal B, Terminal C
- [ ] Close Terminal B → should switch to Terminal C (next)
- [ ] Close Terminal C → should switch to Terminal A (previous, since C was last)
- [ ] Close the only remaining tab → should switch to Dashboard