### PR TITLE
fix: isolate RDP keyboard input to active tab

### DIFF
--- a/Casks/termix.rb
+++ b/Casks/termix.rb
@@ -1,6 +1,6 @@
 cask "termix" do
   version "2.0.0"
-  sha256 "a752ad4f05b4991b8a2ef986da80a86b79a70c93fe1045c4399fcf348a28c1d0"
+  sha256 "2e381ac504093bfa72d16ee20043640724394729b2ca0e6b26c9eac19aeb6d08"
 
   url "https://github.com/Termix-SSH/Termix/releases/download/release-#{version}-tag/termix_macos_universal_dmg.dmg"
   name "Termix"

--- a/src/ui/desktop/apps/features/guacamole/GuacamoleDisplay.tsx
+++ b/src/ui/desktop/apps/features/guacamole/GuacamoleDisplay.tsx
@@ -56,6 +56,7 @@ export const GuacamoleDisplay = forwardRef<
   const containerRef = useRef<HTMLDivElement>(null);
   const displayRef = useRef<HTMLDivElement>(null);
   const clientRef = useRef<Guacamole.Client | null>(null);
+  const keyboardRef = useRef<Guacamole.Keyboard | null>(null);
   const scaleRef = useRef<number>(1);
   const resizeTimeoutRef = useRef<NodeJS.Timeout | null>(null);
   const [isConnecting, setIsConnecting] = useState(false);
@@ -252,6 +253,7 @@ export const GuacamoleDisplay = forwardRef<
     mouse.onmousedown = mouse.onmouseup = mouse.onmousemove = sendMouseState;
 
     const keyboard = new Guacamole.Keyboard(document);
+    keyboardRef.current = keyboard;
     keyboard.onkeydown = (keysym: number) => {
       client.sendKeyEvent(1, keysym);
     };
@@ -323,6 +325,25 @@ export const GuacamoleDisplay = forwardRef<
       });
     }
   }, [isVisible, connect]);
+
+  useEffect(() => {
+    const keyboard = keyboardRef.current;
+    const client = clientRef.current;
+    if (!keyboard || !client) return;
+
+    if (isVisible) {
+      keyboard.onkeydown = (keysym: number) => {
+        client.sendKeyEvent(1, keysym);
+      };
+      keyboard.onkeyup = (keysym: number) => {
+        client.sendKeyEvent(0, keysym);
+      };
+    } else {
+      keyboard.onkeydown = null;
+      keyboard.onkeyup = null;
+      keyboard.reset();
+    }
+  }, [isVisible]);
 
   useEffect(() => {
     return () => {


### PR DESCRIPTION
## Summary
- Fixed RDP keyboard input being sent to all open RDP sessions simultaneously instead of only the active tab
- Root cause: `Guacamole.Keyboard` is instantiated on the global `document` object and its event handlers remain active regardless of tab visibility
- Added a `useEffect` that enables keyboard handlers only when `isVisible` is true, and disables them (with `keyboard.reset()` to release held keys) when the tab becomes hidden

## Related Issues
Closes Termix-SSH/Support#602
Closes Termix-SSH/Support#586
Closes Termix-SSH/Support#580

## Test plan
- [ ] Open two RDP sessions in separate tabs
- [ ] Type in the active RDP tab — only that session should receive input
- [ ] Switch to the other RDP tab — only the newly active session should receive input
- [ ] Open an SSH terminal tab alongside an RDP tab — typing in SSH should not send keys to RDP
- [ ] Switch back to RDP tab — keyboard input should work normally without stuck keys