### PR TITLE
fix: add auth token to database export/import in Electron app

### DIFF
--- a/Casks/termix.rb
+++ b/Casks/termix.rb
@@ -1,6 +1,6 @@
 cask "termix" do
   version "2.0.0"
-  sha256 "a752ad4f05b4991b8a2ef986da80a86b79a70c93fe1045c4399fcf348a28c1d0"
+  sha256 "2e381ac504093bfa72d16ee20043640724394729b2ca0e6b26c9eac19aeb6d08"
 
   url "https://github.com/Termix-SSH/Termix/releases/download/release-#{version}-tag/termix_macos_universal_dmg.dmg"
   name "Termix"

--- a/src/ui/desktop/apps/admin/tabs/DatabaseSecurityTab.tsx
+++ b/src/ui/desktop/apps/admin/tabs/DatabaseSecurityTab.tsx
@@ -66,11 +66,19 @@ export function DatabaseSecurityTab({
           ? `http://localhost:30001/database/export`
           : `${window.location.protocol}//${window.location.host}${getBasePath()}/database/export`;
 
+      const headers: Record<string, string> = {
+        "Content-Type": "application/json",
+      };
+      if (isElectron()) {
+        const token = localStorage.getItem("jwt");
+        if (token) {
+          headers["Authorization"] = `Bearer ${token}`;
+        }
+      }
+
       const response = await fetch(apiUrl, {
         method: "POST",
-        headers: {
-          "Content-Type": "application/json",
-        },
+        headers,
         credentials: "include",
         body: JSON.stringify(
           requiresExportPassword ? { password: exportPassword } : {},
@@ -145,8 +153,17 @@ export function DatabaseSecurityTab({
         formData.append("password", importPassword);
       }
 
+      const importHeaders: Record<string, string> = {};
+      if (isElectron()) {
+        const token = localStorage.getItem("jwt");
+        if (token) {
+          importHeaders["Authorization"] = `Bearer ${token}`;
+        }
+      }
+
       const response = await fetch(apiUrl, {
         method: "POST",
+        headers: importHeaders,
         credentials: "include",
         body: formData,
       });


### PR DESCRIPTION
## Summary
- Fixed "Missing authentication token" error when exporting/importing the database from the Electron desktop app
- Root cause: the database export and import `fetch()` calls used `credentials: "include"` to send cookies, but Electron does not automatically attach cookies to fetch requests like browsers do
- Added `Authorization: Bearer <token>` header from localStorage when running in Electron, matching the pattern used by the axios API interceptor elsewhere in the codebase

## Related Issue
Closes Termix-SSH/Support#587

## Test plan
- [ ] Open the Electron desktop app and log in
- [ ] Go to Admin Settings → Database & Security
- [ ] Click "Export SQLite Database" — should download successfully without auth error
- [ ] Try importing a previously exported SQLite file — should succeed without auth error
- [ ] Verify export/import still works in the web browser (no regression)