### PR TITLE
fix: admin user list not reading OIDC and admin status correctly

### DIFF
--- a/Casks/termix.rb
+++ b/Casks/termix.rb
@@ -1,6 +1,6 @@
 cask "termix" do
   version "2.0.0"
-  sha256 "a752ad4f05b4991b8a2ef986da80a86b79a70c93fe1045c4399fcf348a28c1d0"
+  sha256 "2e381ac504093bfa72d16ee20043640724394729b2ca0e6b26c9eac19aeb6d08"
 
   url "https://github.com/Termix-SSH/Termix/releases/download/release-#{version}-tag/termix_macos_universal_dmg.dmg"
   name "Termix"

--- a/src/ui/desktop/apps/admin/AdminSettings.tsx
+++ b/src/ui/desktop/apps/admin/AdminSettings.tsx
@@ -68,9 +68,9 @@ export function AdminSettings({
     Array<{
       id: string;
       username: string;
-      is_admin: boolean;
-      is_oidc: boolean;
-      password_hash?: string;
+      isAdmin: boolean;
+      isOidc: boolean;
+      passwordHash?: string;
     }>
   >([]);
   const [usersLoading, setUsersLoading] = React.useState(false);
@@ -80,9 +80,9 @@ export function AdminSettings({
   const [selectedUserForEdit, setSelectedUserForEdit] = React.useState<{
     id: string;
     username: string;
-    is_admin: boolean;
-    is_oidc: boolean;
-    password_hash?: string;
+    isAdmin: boolean;
+    isOidc: boolean;
+    passwordHash?: string;
   } | null>(null);
 
   const [currentUser, setCurrentUser] = React.useState<{

--- a/src/ui/desktop/apps/admin/dialogs/UserEditDialog.tsx
+++ b/src/ui/desktop/apps/admin/dialogs/UserEditDialog.tsx
@@ -42,9 +42,9 @@ import {
 interface User {
   id: string;
   username: string;
-  is_admin: boolean;
-  is_oidc: boolean;
-  password_hash?: string;
+  isAdmin: boolean;
+  isOidc: boolean;
+  passwordHash?: string;
 }
 
 interface UserEditDialogProps {
@@ -81,7 +81,7 @@ export function UserEditDialog({
 
   useEffect(() => {
     if (open && user) {
-      setIsAdmin(user.is_admin);
+      setIsAdmin(user.isAdmin);
       loadRoles();
     }
   }, [open, user]);
@@ -332,9 +332,9 @@ export function UserEditDialog({
 
   const getAuthTypeDisplay = (): string => {
     if (!user) return "";
-    if (user.is_oidc && user.password_hash) {
+    if (user.isOidc && user.passwordHash) {
       return t("admin.dualAuth");
-    } else if (user.is_oidc) {
+    } else if (user.isOidc) {
       return t("admin.externalOIDC");
     } else {
       return t("admin.localPassword");
@@ -344,7 +344,7 @@ export function UserEditDialog({
   if (!user) return null;
 
   const showPasswordReset =
-    allowPasswordLogin && (user.password_hash || !user.is_oidc);
+    allowPasswordLogin && (user.passwordHash || !user.isOidc);
 
   return (
     <Dialog open={open} onOpenChange={onOpenChange}>

--- a/src/ui/desktop/apps/admin/tabs/UserManagementTab.tsx
+++ b/src/ui/desktop/apps/admin/tabs/UserManagementTab.tsx
@@ -17,9 +17,9 @@ import { deleteUser } from "@/ui/main-axios.ts";
 interface User {
   id: string;
   username: string;
-  is_admin: boolean;
-  is_oidc: boolean;
-  password_hash?: string;
+  isAdmin: boolean;
+  isOidc: boolean;
+  passwordHash?: string;
 }
 
 interface UserManagementTabProps {
@@ -47,9 +47,9 @@ export function UserManagementTab({
   const { confirmWithToast } = useConfirmation();
 
   const getAuthTypeDisplay = (user: User): string => {
-    if (user.is_oidc && user.password_hash) {
+    if (user.isOidc && user.passwordHash) {
       return t("admin.dualAuth");
-    } else if (user.is_oidc) {
+    } else if (user.isOidc) {
       return t("admin.externalOIDC");
     } else {
       return t("admin.localPassword");
@@ -111,7 +111,7 @@ export function UserManagementTab({
               <TableRow key={user.id}>
                 <TableCell className="font-medium">
                   {user.username}
-                  {user.is_admin && (
+                  {user.isAdmin && (
                     <span className="ml-2 inline-flex items-center px-2 py-1 rounded-full text-xs font-medium bg-muted/50 text-muted-foreground border border-border">
                       {t("admin.adminBadge")}
                     </span>
@@ -129,7 +129,7 @@ export function UserManagementTab({
                     >
                       <Edit className="h-4 w-4" />
                     </Button>
-                    {user.is_oidc && !user.password_hash && (
+                    {user.isOidc && !user.passwordHash && (
                       <Button
                         variant="ghost"
                         size="sm"
@@ -145,7 +145,7 @@ export function UserManagementTab({
                         <Link2 className="h-4 w-4" />
                       </Button>
                     )}
-                    {user.is_oidc && user.password_hash && (
+                    {user.isOidc && user.passwordHash && (
                       <Button
                         variant="ghost"
                         size="sm"
@@ -161,7 +161,7 @@ export function UserManagementTab({
                       size="sm"
                       onClick={() => handleDeleteUserQuick(user.username)}
                       className="text-red-600 hover:text-red-700 hover:bg-red-50"
-                      disabled={user.is_admin}
+                      disabled={user.isAdmin}
                     >
                       <Trash2 className="h-4 w-4" />
                     </Button>


### PR DESCRIPTION
## Summary
- Fixed OIDC link/unlink icons, admin badge, and auth type display not showing correctly in the Admin User Management tab
- Root cause: the `/users/list` API returns camelCase field names from Drizzle ORM (`isOidc`, `isAdmin`, `passwordHash`), but the frontend interfaces and property accesses used snake_case (`is_oidc`, `is_admin`, `password_hash`), causing all these fields to be `undefined` at runtime
- Updated the `User` interface and all property accesses in `AdminSettings.tsx`, `UserManagementTab.tsx`, and `UserEditDialog.tsx` to match the API response format

Note: the `/users/me` endpoint explicitly returns snake_case, so the `currentUser` state (used in `DatabaseSecurityTab`) was left unchanged.

## Related Issues
Closes Termix-SSH/Support#584
Closes Termix-SSH/Support#552

## Test plan
- [ ] Log in as admin, go to Admin Settings → Users tab
- [ ] Verify OIDC users show "External (OIDC)" auth type instead of "Local Password"
- [ ] Verify OIDC-only users show the purple chain link icon (Link2) for account linking
- [ ] Verify dual-auth users (OIDC + password) show the orange unlink icon
- [ ] Verify admin users show the "Admin" badge next to their username
- [ ] Verify the delete button is disabled for admin users
- [ ] Click Edit on an OIDC user — verify admin toggle initializes correctly
- [ ] Verify password reset option shows/hides correctly based on auth type