### PR TITLE
fix: enable clipboard paste from host to RDP session

### DIFF
--- a/Casks/termix.rb
+++ b/Casks/termix.rb
@@ -1,6 +1,6 @@
 cask "termix" do
   version "2.0.0"
-  sha256 "a752ad4f05b4991b8a2ef986da80a86b79a70c93fe1045c4399fcf348a28c1d0"
+  sha256 "2e381ac504093bfa72d16ee20043640724394729b2ca0e6b26c9eac19aeb6d08"
 
   url "https://github.com/Termix-SSH/Termix/releases/download/release-#{version}-tag/termix_macos_universal_dmg.dmg"
   name "Termix"

--- a/src/ui/desktop/apps/features/guacamole/GuacamoleDisplay.tsx
+++ b/src/ui/desktop/apps/features/guacamole/GuacamoleDisplay.tsx
@@ -356,6 +356,40 @@ export const GuacamoleDisplay = forwardRef<
     };
   }, [rescaleDisplay]);
 
+  const syncClipboard = useCallback(() => {
+    const client = clientRef.current;
+    if (!client) return;
+    navigator.clipboard
+      .readText()
+      .then((text) => {
+        if (text) {
+          const stream = client.createClipboardStream("text/plain");
+          const writer = new Guacamole.StringWriter(stream);
+          writer.sendText(text);
+          writer.sendEnd();
+        }
+      })
+      .catch(() => {});
+  }, []);
+
+  useEffect(() => {
+    if (isVisible && isReady) {
+      syncClipboard();
+    }
+  }, [isVisible, isReady, syncClipboard]);
+
+  useEffect(() => {
+    const container = containerRef.current;
+    if (!container || !isReady) return;
+
+    const handleFocus = () => syncClipboard();
+    container.addEventListener("mouseenter", handleFocus);
+
+    return () => {
+      container.removeEventListener("mouseenter", handleFocus);
+    };
+  }, [isReady, syncClipboard]);
+
   const connectingMessage = t("guacamole.connecting", {
     type: (
       connectionConfig.protocol ||


### PR DESCRIPTION
## Summary
- Fixed pasting text from host machine to RDP Windows client not working
- Root cause: the Guacamole client only implemented RDP→host clipboard sync (via `client.onclipboard`), but never synced the host clipboard TO the RDP session
- Added automatic clipboard sync using `navigator.clipboard.readText()` + `client.createClipboardStream()`:
  - When the RDP tab becomes visible and the connection is ready
  - When the mouse enters the RDP display area (for split-screen scenarios)
- Clipboard read failures are silently ignored (handles permission denied gracefully)

## Related Issue
Closes Termix-SSH/Support#581

## Test plan
- [ ] Copy text on the host machine
- [ ] Switch to an active RDP tab — press Ctrl+V — text should paste into the remote desktop
- [ ] In split-screen mode, copy text then hover over the RDP pane — Ctrl+V should paste correctly
- [ ] Verify RDP→host clipboard still works (copy text in RDP, paste on host)
- [ ] If clipboard permission is denied by browser, RDP session should still function normally