### PR TITLE
Fix WebSocket reconnection and add connection lost overlay

### DIFF
--- a/src/backend/ssh/terminal.ts
+++ b/src/backend/ssh/terminal.ts
@@ -339,7 +339,7 @@ const wss = new WebSocketServer({
 
       const existingConnections = userConnections.get(payload.userId);
 
-      if (existingConnections && existingConnections.size >= 3) {
+      if (existingConnections && existingConnections.size >= 10) {
         return false;
       }
 
@@ -430,8 +430,24 @@ wss.on("connection", async (ws: WebSocket, req) => {
   let isAwaitingAuthCredentials = false;
   let opksshTempFiles: { keyPath: string; certPath: string } | null = null;
 
+  let wsAlive = true;
+
+  ws.on("pong", () => {
+    wsAlive = true;
+  });
+
   const wsPingInterval = setInterval(() => {
     if (ws.readyState === WebSocket.OPEN) {
+      if (!wsAlive) {
+        sshLogger.warn("WebSocket pong timeout - terminating zombie connection", {
+          operation: "ws_pong_timeout",
+          userId,
+          sessionId: currentSessionId,
+        });
+        ws.terminate();
+        return;
+      }
+      wsAlive = false;
       ws.ping();
     }
   }, 30000);

--- a/src/ui/desktop/DesktopApp.tsx
+++ b/src/ui/desktop/DesktopApp.tsx
@@ -29,6 +29,161 @@ import { useTheme } from "@/components/theme-provider";
 import { dbHealthMonitor } from "@/lib/db-health-monitor.ts";
 import { useTranslation } from "react-i18next";
 
+const MAX_OVERLAY_RECONNECT_ATTEMPTS = 5;
+const OVERLAY_BASE_DELAY = 2000;
+const OVERLAY_MAX_DELAY = 30000;
+
+function ConnectionLostOverlay({
+  onReconnected,
+}: {
+  onReconnected: () => void;
+}) {
+  const { t } = useTranslation();
+  const [attempt, setAttempt] = useState(0);
+  const [status, setStatus] = useState<"reconnecting" | "failed">(
+    "reconnecting",
+  );
+  const [nextRetryIn, setNextRetryIn] = useState(0);
+  const timerRef = useRef<NodeJS.Timeout | null>(null);
+  const countdownRef = useRef<NodeJS.Timeout | null>(null);
+  const unmountedRef = useRef(false);
+
+  const tryReconnect = useCallback(async () => {
+    if (unmountedRef.current) return;
+
+    try {
+      await getUserInfo();
+      if (!unmountedRef.current) {
+        onReconnected();
+      }
+    } catch {
+      if (unmountedRef.current) return;
+      setAttempt((prev) => {
+        const next = prev + 1;
+        if (next >= MAX_OVERLAY_RECONNECT_ATTEMPTS) {
+          setStatus("failed");
+        } else {
+          const delay = Math.min(
+            OVERLAY_BASE_DELAY * Math.pow(2, next),
+            OVERLAY_MAX_DELAY,
+          );
+          setNextRetryIn(Math.ceil(delay / 1000));
+
+          countdownRef.current = setInterval(() => {
+            if (unmountedRef.current) return;
+            setNextRetryIn((prev) => {
+              if (prev <= 1) {
+                if (countdownRef.current) clearInterval(countdownRef.current);
+                return 0;
+              }
+              return prev - 1;
+            });
+          }, 1000);
+
+          timerRef.current = setTimeout(() => {
+            if (!unmountedRef.current) tryReconnect();
+          }, delay);
+        }
+        return next;
+      });
+    }
+  }, [onReconnected]);
+
+  useEffect(() => {
+    unmountedRef.current = false;
+    const initialDelay = setTimeout(() => {
+      tryReconnect();
+    }, OVERLAY_BASE_DELAY);
+
+    return () => {
+      unmountedRef.current = true;
+      clearTimeout(initialDelay);
+      if (timerRef.current) clearTimeout(timerRef.current);
+      if (countdownRef.current) clearInterval(countdownRef.current);
+    };
+  }, [tryReconnect]);
+
+  const handleRetry = () => {
+    if (timerRef.current) clearTimeout(timerRef.current);
+    if (countdownRef.current) clearInterval(countdownRef.current);
+    setAttempt(0);
+    setStatus("reconnecting");
+    setNextRetryIn(0);
+    tryReconnect();
+  };
+
+  const handleReload = () => {
+    window.location.reload();
+  };
+
+  return (
+    <div className="fixed inset-0 z-[9999] flex items-center justify-center bg-black/60 backdrop-blur-sm">
+      <div className="bg-card border border-border rounded-xl shadow-2xl p-8 max-w-md w-full mx-4 text-center">
+        <div className="mb-4">
+          {status === "reconnecting" ? (
+            <div className="w-10 h-10 border-3 border-primary border-t-transparent rounded-full animate-spin mx-auto" />
+          ) : (
+            <div className="w-10 h-10 rounded-full bg-destructive/10 flex items-center justify-center mx-auto">
+              <svg
+                className="w-5 h-5 text-destructive"
+                fill="none"
+                viewBox="0 0 24 24"
+                stroke="currentColor"
+                strokeWidth={2}
+              >
+                <path
+                  strokeLinecap="round"
+                  strokeLinejoin="round"
+                  d="M12 9v2m0 4h.01M21 12a9 9 0 11-18 0 9 9 0 0118 0z"
+                />
+              </svg>
+            </div>
+          )}
+        </div>
+
+        <h2 className="text-lg font-semibold text-foreground mb-2">
+          {t("common.connectionLost", "Connection Lost")}
+        </h2>
+        <p className="text-sm text-muted-foreground mb-6">
+          {status === "reconnecting"
+            ? nextRetryIn > 0
+              ? t(
+                  "common.reconnectingIn",
+                  `Reconnecting in ${nextRetryIn}s... (attempt ${attempt}/${MAX_OVERLAY_RECONNECT_ATTEMPTS})`,
+                  { seconds: nextRetryIn, attempt, max: MAX_OVERLAY_RECONNECT_ATTEMPTS },
+                )
+              : t(
+                  "common.reconnectingNow",
+                  `Reconnecting... (attempt ${attempt}/${MAX_OVERLAY_RECONNECT_ATTEMPTS})`,
+                  { attempt, max: MAX_OVERLAY_RECONNECT_ATTEMPTS },
+                )
+            : t(
+                "common.reconnectFailed",
+                "Could not reconnect to the server.",
+              )}
+        </p>
+
+        <div className="flex gap-3 justify-center">
+          {status === "failed" && (
+            <button
+              onClick={handleRetry}
+              className="px-4 py-2 text-sm font-medium rounded-lg bg-primary text-primary-foreground hover:bg-primary/90 transition-colors"
+            >
+              {t("common.retry", "Retry")}
+            </button>
+          )}
+          <button
+            onClick={handleReload}
+            className="px-4 py-2 text-sm font-medium rounded-lg border border-border text-foreground hover:bg-accent transition-colors"
+          >
+            {t("common.reload", "Reload")}
+          </button>
+        </div>
+      </div>
+    </div>
+  );
+}
+
 function AppContent({
   onAuthStateChange,
 }: {
@@ -325,30 +480,6 @@ function AppContent({
     );
   }
 
-  if (dbConnectionFailed) {
-    return (
-      <div className="h-screen w-screen overflow-hidden bg-background">
-        <div className="fixed inset-0 flex items-center justify-center z-[10000] bg-background">
-          <Dashboard
-            isAuthenticated={false}
-            authLoading={false}
-            onAuthSuccess={handleAuthSuccess}
-            isTopbarOpen={isTopbarOpen}
-            onSelectView={() => {}}
-            initialDbError="Database connection failed"
-          />
-        </div>
-        <Toaster
-          position="bottom-right"
-          richColors={false}
-          closeButton
-          duration={5000}
-          offset={20}
-        />
-      </div>
-    );
-  }
-
   return (
     <div className="h-screen w-screen overflow-hidden bg-background">
       <CommandPalette
@@ -618,6 +749,15 @@ function AppContent({
             </>
           )}
         </div>
+      )}
+
+      {dbConnectionFailed && (
+        <ConnectionLostOverlay
+          onReconnected={() => {
+            setDbConnectionFailed(false);
+            toast.success(t("common.backendReconnected"));
+          }}
+        />
       )}
 
       <Toaster

--- a/src/ui/desktop/apps/features/terminal/Terminal.tsx
+++ b/src/ui/desktop/apps/features/terminal/Terminal.tsx
@@ -151,6 +151,8 @@ const TerminalInner = forwardRef<TerminalHandle, SSHTerminalProps>(
     const resizeTimeout = useRef<NodeJS.Timeout | null>(null);
     const wasDisconnectedBySSH = useRef(false);
     const pingIntervalRef = useRef<NodeJS.Timeout | null>(null);
+    const pongReceivedRef = useRef(true);
+    const pongTimeoutRef = useRef<NodeJS.Timeout | null>(null);
     const [isConnected, setIsConnected] = useState(false);
     const [isConnecting, setIsConnecting] = useState(false);
     const [isFitted, setIsFitted] = useState(false);
@@ -202,7 +204,7 @@ const TerminalInner = forwardRef<TerminalHandle, SSHTerminalProps>(
     const isFittingRef = useRef(false);
     const reconnectTimeoutRef = useRef<NodeJS.Timeout | null>(null);
     const reconnectAttempts = useRef(0);
-    const maxReconnectAttempts = 3;
+    const maxReconnectAttempts = 8;
     const isUnmountingRef = useRef(false);
     const shouldNotReconnectRef = useRef(false);
     const isReconnectingRef = useRef(false);
@@ -596,6 +598,10 @@ const TerminalInner = forwardRef<TerminalHandle, SSHTerminalProps>(
             clearInterval(pingIntervalRef.current);
             pingIntervalRef.current = null;
           }
+          if (pongTimeoutRef.current) {
+            clearTimeout(pongTimeoutRef.current);
+            pongTimeoutRef.current = null;
+          }
           if (reconnectTimeoutRef.current) {
             clearTimeout(reconnectTimeoutRef.current);
             reconnectTimeoutRef.current = null;
@@ -901,8 +907,15 @@ const TerminalInner = forwardRef<TerminalHandle, SSHTerminalProps>(
           ws.send(JSON.stringify({ type: "input", data }));
         });
 
+        pongReceivedRef.current = true;
         pingIntervalRef.current = setInterval(() => {
           if (ws.readyState === WebSocket.OPEN) {
+            if (!pongReceivedRef.current) {
+              console.warn("[WebSocket] Pong timeout - connection appears dead, closing");
+              ws.close();
+              return;
+            }
+            pongReceivedRef.current = false;
             ws.send(JSON.stringify({ type: "ping" }));
           }
         }, 30000);
@@ -911,6 +924,10 @@ const TerminalInner = forwardRef<TerminalHandle, SSHTerminalProps>(
       ws.addEventListener("message", (event) => {
         try {
           const msg = JSON.parse(event.data);
+          if (msg.type === "pong") {
+            pongReceivedRef.current = true;
+            return;
+          }
           if (msg.type === "data") {
             if (typeof msg.data === "string") {
               const syntaxHighlightingEnabled =
@@ -1413,8 +1430,10 @@ const TerminalInner = forwardRef<TerminalHandle, SSHTerminalProps>(
 
         setIsConnected(false);
         isConnectingRef.current = false;
-        if (terminal) {
-          terminal.clear();
+
+        if (pongTimeoutRef.current) {
+          clearTimeout(pongTimeoutRef.current);
+          pongTimeoutRef.current = null;
         }
 
         if (totpTimeoutRef.current) {
@@ -1423,17 +1442,21 @@ const TerminalInner = forwardRef<TerminalHandle, SSHTerminalProps>(
         }
 
         if (event.code === 1006) {
-          console.error(
-            "[WebSocket] Abnormal closure detected - possible HTTPS/proxy issue",
+          console.warn(
+            "[WebSocket] Abnormal closure detected - attempting reconnection",
           );
           addLog({
-            type: "error",
+            type: "warning",
             stage: "connection",
             message: t("terminal.websocketAbnormalClose"),
           });
-          updateConnectionError(t("terminal.websocketAbnormalClose"));
-          setIsConnecting(false);
-          shouldNotReconnectRef.current = true;
+
+          if (wasConnectedRef.current) {
+            attemptReconnection();
+          } else {
+            updateConnectionError(t("terminal.websocketAbnormalClose"));
+            setIsConnecting(false);
+          }
           return;
         }
 
@@ -1449,10 +1472,6 @@ const TerminalInner = forwardRef<TerminalHandle, SSHTerminalProps>(
           shouldNotReconnectRef.current = true;
 
           localStorage.removeItem("jwt");
-
-          setTimeout(() => {
-            window.location.reload();
-          }, 1000);
 
           return;
         }
@@ -1890,6 +1909,10 @@ const TerminalInner = forwardRef<TerminalHandle, SSHTerminalProps>(
           if (pingIntervalRef.current) {
             clearInterval(pingIntervalRef.current);
             pingIntervalRef.current = null;
+          }
+          if (pongTimeoutRef.current) {
+            clearTimeout(pongTimeoutRef.current);
+            pongTimeoutRef.current = null;
           }
 
           const persistenceEnabled =

--- a/src/ui/mobile/apps/terminal/Terminal.tsx
+++ b/src/ui/mobile/apps/terminal/Terminal.tsx
@@ -126,7 +126,7 @@ const TerminalInner = forwardRef<TerminalHandle, SSHTerminalProps>(
     const isFittingRef = useRef(false);
     const reconnectTimeoutRef = useRef<NodeJS.Timeout | null>(null);
     const reconnectAttempts = useRef(0);
-    const maxReconnectAttempts = 3;
+    const maxReconnectAttempts = 8;
     const isUnmountingRef = useRef(false);
     const shouldNotReconnectRef = useRef(false);
     const isReconnectingRef = useRef(false);
@@ -843,17 +843,21 @@ const TerminalInner = forwardRef<TerminalHandle, SSHTerminalProps>(
         }
 
         if (event.code === 1006) {
-          console.error(
-            "[WebSocket] Abnormal closure detected - possible HTTPS/proxy issue",
+          console.warn(
+            "[WebSocket] Abnormal closure detected - attempting reconnection",
           );
           addLog({
-            type: "error",
+            type: "warning",
             stage: "connection",
             message: t("terminal.websocketAbnormalClose"),
           });
-          updateConnectionError(t("terminal.websocketAbnormalClose"));
-          setIsConnecting(false);
-          shouldNotReconnectRef.current = true;
+
+          if (wasConnectedRef.current) {
+            attemptReconnection();
+          } else {
+            updateConnectionError(t("terminal.websocketAbnormalClose"));
+            setIsConnecting(false);
+          }
           return;
         }
 
@@ -869,10 +873,6 @@ const TerminalInner = forwardRef<TerminalHandle, SSHTerminalProps>(
           shouldNotReconnectRef.current = true;
 
           localStorage.removeItem("jwt");
-
-          setTimeout(() => {
-            window.location.reload();
-          }, 1000);
 
           return;
         }


### PR DESCRIPTION
# Overview

Fix WebSocket disconnections causing terminal tabs to be lost and replace the full-page reload with a non-destructive reconnection overlay.

- [x] Fixed: WebSocket code 1006 (abnormal closure) now triggers reconnection instead of giving up permanently
- [x] Fixed: Auth failure (code 1008) no longer reloads the entire page, destroying all open tabs
- [x] Fixed: Zombie WebSocket connections no longer silently eat the connection limit
- [x] Added: "Connection Lost" overlay with auto-reconnect backoff, Retry and Reload buttons
- [x] Updated: Max reconnect attempts raised from 3 to 8, connection limit from 3 to 10

# Changes Made

**Backend (`terminal.ts`):**
- Added pong timeout detection, connections that don't respond within 30s are terminated, freeing up slots
- Raised per-user WebSocket connection limit from 3 to 10 to handle reconnection races

**Frontend (`Terminal.tsx`, desktop + mobile):**
- Code 1006 now attempts reconnection when the session was previously connected (was blocked entirely before)
- Code 1008 shows an inline error instead of calling `window.location.reload()`
- Added client-side pong tracking to detect dead connections within 30s
- Removed unconditional `terminal.clear()` on close to preserve output during reconnection
- Raised max reconnect attempts from 3 to 8

**Frontend (`DesktopApp.tsx`):**
- Replaced the full `Dashboard` render on backend disconnect with a translucent overlay
- Overlay auto-reconnects with exponential backoff (2s → 30s cap)
- Retry button appears after 5 failed attempts, Reload button always available
- All tabs and terminal state preserved underneath

# Related Issues

- Related to Termix-SSH/Support#538
- Related to Termix-SSH/Support#542

# Checklist

- [x] Code follows project style guidelines
- [x] Supports mobile and desktop UI/app (if applicable)
- [x] I have read [Contributing.md](https://github.com/Termix-SSH/Termix/blob/main/CONTRIBUTING.md)
- [x] This is not a translation request. See [docs](https://docs.termix.site/translations)