### PR TITLE
fix: remove registration disabled toast that shows on every login

### DIFF
--- a/src/ui/desktop/authentication/Auth.tsx
+++ b/src/ui/desktop/authentication/Auth.tsx
@@ -256,12 +256,6 @@ export function Auth({
   }, [setDbError, firstUserToastShown, showServerConfig, t]);
 
   useEffect(() => {
-    if (!registrationAllowed && !internalLoggedIn) {
-      toast.warning(t("messages.registrationDisabled"));
-    }
-  }, [registrationAllowed, internalLoggedIn, t]);
-
-  useEffect(() => {
     if (!passwordLoginAllowed && oidcConfigured && tab !== "external") {
       setTab("external");
     }

--- a/src/ui/mobile/authentication/Auth.tsx
+++ b/src/ui/mobile/authentication/Auth.tsx
@@ -166,12 +166,6 @@ export function Auth({
   }, []);
 
   useEffect(() => {
-    if (!registrationAllowed && !internalLoggedIn) {
-      toast.warning(t("messages.registrationDisabled"));
-    }
-  }, [registrationAllowed, internalLoggedIn, t]);
-
-  useEffect(() => {
     if (!passwordLoginAllowed && oidcConfigured && tab !== "external") {
       setTab("external");
     }


### PR DESCRIPTION
## Summary
- Removed the proactive "registration disabled" toast warning that appeared on every login page load
- The registration tab is already hidden when registration is disabled, making the toast redundant
- Users who actually attempt to register via API still receive the appropriate error message
- Applied to both desktop and mobile authentication components

## Related Issue
Closes Termix-SSH/Support#543

## Test plan
- [ ] Disable new account registration in admin settings
- [ ] Navigate to the login page — no "registration disabled" toast should appear
- [ ] Verify the registration tab/form is still hidden
- [ ] If registration is attempted via direct API call, error response is still returned