### PR TITLE
fix: align OIDC login cookie maxAge with JWT expiration

### DIFF
--- a/src/backend/database/routes/users.ts
+++ b/src/backend/database/routes/users.ts
@@ -1226,7 +1226,7 @@ router.get("/oidc/callback", async (req, res) => {
         const sessionDurationMs =
           deviceInfo.type === "desktop" || deviceInfo.type === "mobile"
             ? 30 * 24 * 60 * 60 * 1000
-            : 2 * 60 * 60 * 1000;
+            : 24 * 60 * 60 * 1000;
         await authManager.registerOIDCUser(id, sessionDurationMs);
       } catch (encryptionError) {
         await db.delete(users).where(eq(users.id, id));
@@ -1323,7 +1323,7 @@ router.get("/oidc/callback", async (req, res) => {
         ? 30 * 24 * 60 * 60 * 1000
         : storedRememberMe
           ? 30 * 24 * 60 * 60 * 1000
-          : 2 * 60 * 60 * 1000;
+          : 24 * 60 * 60 * 1000;
 
     res.clearCookie("jwt", authManager.getClearCookieOptions(req));
 


### PR DESCRIPTION
## Summary
- Follow-up to #658 which fixed cookie maxAge for password login and TOTP login paths
- The OIDC callback login path (`/users/oidc/callback`) still had 2-hour cookie maxAge for web browser sessions, while the JWT token was valid for 24 hours
- Two locations were missed:
  1. **OIDC user registration** (new OIDC user first login) — session duration for web was 2h
  2. **OIDC callback login** (existing user) — non-rememberMe web cookie was 2h
- Changed both from 2h to 24h to match the JWT token expiration

## Related Issues
Closes Termix-SSH/Support#583

## Test plan
- [ ] Log in via OIDC on a web browser WITHOUT "Remember Me" checked
- [ ] Session should persist for 24 hours instead of expiring after 2 hours
- [ ] Log in via OIDC on a web browser WITH "Remember Me" checked — session should persist for 30 days
- [ ] OIDC login on desktop/mobile apps should still get 30-day sessions automatically
- [ ] Verify password login sessions still work correctly (no regression from #658)