### PR TITLE
fix: persist OIDC login session across Electron app restarts

### DIFF
--- a/src/ui/desktop/authentication/Auth.tsx
+++ b/src/ui/desktop/authentication/Auth.tsx
@@ -683,6 +683,13 @@ export function Auth({
             }
           }
 
+          if (isElectron()) {
+            const token = getCookie("jwt");
+            if (token) {
+              localStorage.setItem("jwt", token);
+            }
+          }
+
           setInternalLoggedIn(true);
           setLoggedIn(true);
           setIsAdmin(!!meRes.is_admin);


### PR DESCRIPTION
## Summary
- Fixed "ghost session" where the Electron desktop app shows a stale UI after restart but all API calls fail when logged in via OIDC
- Root cause: password login explicitly stores the JWT token in `localStorage` for Electron, but OIDC callback login only receives the token as an HTTP cookie — Electron doesn't reliably persist cookies across app restarts
- Added `localStorage.setItem("jwt", token)` after successful OIDC callback when running in Electron, matching the existing pattern used by password login
- The axios interceptor already reads from localStorage for Electron requests, so no other changes needed

## Related Issue
Closes Termix-SSH/Support#607

## Test plan
- [ ] Configure OIDC provider and log in via the Windows/macOS/Linux desktop app
- [ ] Verify SSH connections and data loading works
- [ ] Close the app completely and reopen it
- [ ] Session should persist — no need to log in again
- [ ] Verify password login still persists across restarts (no regression)
- [ ] Verify web browser OIDC login still works normally