### PR TITLE
fix: prevent server status failure from blocking host list loading

### DIFF
--- a/src/ui/main-axios.ts
+++ b/src/ui/main-axios.ts
@@ -1006,10 +1006,16 @@ function handleApiError(error: unknown, operation: string): never {
 export async function getSSHHosts(): Promise<SSHHostWithStatus[]> {
   try {
     const hostsResponse = await sshHostApi.get("/db/host");
-    const hosts: SSHHost[] = hostsResponse.data;
+    const hosts: SSHHost[] = Array.isArray(hostsResponse.data)
+      ? hostsResponse.data
+      : [];
 
-    const statusesResponse = await getAllServerStatuses();
-    const statuses = statusesResponse || {};
+    let statuses: Record<number, ServerStatus> = {};
+    try {
+      statuses = (await getAllServerStatuses()) || {};
+    } catch {
+      // Status fetch failure should not prevent host list from loading
+    }
 
     return hosts.map((host) => ({
       ...host,


### PR DESCRIPTION
## Summary
- Fixed host list failing to load when the server status API is unavailable
- Root cause: `getSSHHosts()` called `getAllServerStatuses()` without independent error handling — if the status endpoint failed (e.g. stats service down, network timeout), the entire host list fetch threw, causing dashboard counters to show 0 and host manager to fail
- Wrapped `getAllServerStatuses()` in its own try-catch so status failures are silently ignored (hosts display with "unknown" status instead of not displaying at all)
- Also added `Array.isArray()` guard on `hostsResponse.data` to prevent `e.map is not a function` crashes when the API returns unexpected data

## Related Issues
Closes Termix-SSH/Support#571
Closes Termix-SSH/Support#615

## Test plan
- [ ] Verify host list loads normally when all services are healthy
- [ ] Stop the stats service (port 30005) — host list should still load with "unknown" status
- [ ] Dashboard counters should show correct server/tunnel/credential counts even if stats service is down
- [ ] Host manager should function normally regardless of status API availability