### PR TITLE
fix: show error toast when file download returns empty content

### DIFF
--- a/src/ui/desktop/apps/features/file-manager/FileManager.tsx
+++ b/src/ui/desktop/apps/features/file-manager/FileManager.tsx
@@ -778,6 +778,8 @@ function FileManagerContent({ initialHost, onClose }: FileManagerProps) {
         toast.success(
           t("fileManager.fileDownloadedSuccessfully", { name: file.name }),
         );
+      } else {
+        toast.error(t("fileManager.failedToDownloadFile"));
       }
     } catch (error: unknown) {
       if (

--- a/src/ui/desktop/navigation/TopNavbar.tsx
+++ b/src/ui/desktop/navigation/TopNavbar.tsx
@@ -456,7 +456,6 @@ export function TopNavbar({
                 onDragOver={handleDragOver}
                 onDrop={handleDrop}
                 onDragEnd={handleDragEnd}
-                e
                 onMouseDown={(e) => {
                   if (e.button === 1 && !disableClose) {
                     e.preventDefault();


### PR DESCRIPTION
## Summary
- Fixed file download silently failing when the server returns an empty response
- When `downloadSSHFile()` succeeds but `response.content` is empty/undefined, the user previously got no feedback — now shows an error toast
- Also removed a stray `e` prop in TopNavbar.tsx tab element (leftover from drag handler editing, caused React unknown prop warning)

## Test plan
- [ ] Download a file from the file manager — should show success toast
- [ ] If a file download returns empty content (e.g., permission denied on server side but no error thrown), should show error toast instead of silent failure
- [ ] Verify tab bar drag-and-drop still works after removing the stray prop