### PR TITLE
fix: show server config on first launch instead of auto-selecting embedded

### DIFF
--- a/src/ui/desktop/authentication/Auth.tsx
+++ b/src/ui/desktop/authentication/Auth.tsx
@@ -31,6 +31,7 @@ import {
   getOIDCAuthorizeUrl,
   verifyTOTPLogin,
   getServerConfig,
+  saveServerConfig,
   isElectron,
   getEmbeddedServerStatus,
   isEmbeddedMode,
@@ -772,7 +773,7 @@ export function Auth({
             getEmbeddedServerStatus(),
           ]);
 
-          if (status?.embedded && status?.running && !config?.serverUrl) {
+          if (status?.embedded && status?.running && config && !config.serverUrl) {
             setCurrentServerUrl("");
             setShowServerConfig(false);
             return;
@@ -816,7 +817,11 @@ export function Auth({
           onServerConfigured={() => {
             window.location.reload();
           }}
-          onUseEmbedded={() => {
+          onUseEmbedded={async () => {
+            await saveServerConfig({
+              serverUrl: "",
+              lastUpdated: new Date().toISOString(),
+            });
             setShowServerConfig(false);
             setCurrentServerUrl("");
           }}


### PR DESCRIPTION
## Summary
- Fixed the Electron desktop app never showing the server configuration dialog on first launch
- Root cause: `checkServerConfig()` auto-selected the embedded local server when no config was stored (`config === null`), because `!config?.serverUrl` evaluates to `true` for `null` — so first-time users were silently put in local-only mode with no way to enter a remote server URL
- Added `config &&` check to only auto-connect to embedded when the user has **previously chosen** embedded mode (config exists with empty serverUrl)
- When choosing "Use Local Server", the choice is now persisted via `saveServerConfig({ serverUrl: "" })` so subsequent app restarts correctly auto-connect without showing the dialog again

## Related Issue
Closes Termix-SSH/Support#594

## Test plan
- [ ] Fresh install of Electron desktop app — should show server config dialog with both "Use Local Server" and URL input options
- [ ] Choose "Use Local Server" — app connects to embedded backend, dialog doesn't appear on next restart
- [ ] Choose remote server URL — app connects to remote, dialog doesn't appear on next restart
- [ ] Existing users who previously configured a remote server — no change in behavior
- [ ] Web browser users — no change (server config is Electron-only)