### PR TITLE
fix: validate and fallback credentialId during JSON host bulk import

### DIFF
--- a/README.md
+++ b/README.md
@@ -169,6 +169,10 @@ networks:
   <a href="https://akamai.com/">
     <img src="https://upload.wikimedia.org/wikipedia/commons/8/8b/Akamai_logo.svg" height="50" alt="Akamai">
   </a>
+  &nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;
+  <a href="https://aws.amazon.com/">
+    <img src="https://upload.wikimedia.org/wikipedia/commons/thumb/9/93/Amazon_Web_Services_Logo.svg/960px-Amazon_Web_Services_Logo.svg.png" height="50" alt="AWS">
+  </a>
 </p>
 
 # Support

--- a/src/backend/database/routes/host.ts
+++ b/src/backend/database/routes/host.ts
@@ -3206,6 +3206,41 @@ router.post(
           continue;
         }
 
+        if (
+          effectiveConnectionType === "ssh" &&
+          hostData.authType === "credential" &&
+          hostData.credentialId
+        ) {
+          const cred = await db
+            .select({ id: sshCredentials.id })
+            .from(sshCredentials)
+            .where(
+              and(
+                eq(sshCredentials.id, hostData.credentialId),
+                eq(sshCredentials.userId, userId),
+              ),
+            )
+            .limit(1);
+
+          if (cred.length === 0) {
+            const fallback = await db
+              .select({ id: sshCredentials.id })
+              .from(sshCredentials)
+              .where(eq(sshCredentials.userId, userId))
+              .limit(1);
+
+            if (fallback.length > 0) {
+              hostData.credentialId = fallback[0].id;
+            } else {
+              results.failed++;
+              results.errors.push(
+                `Host ${i + 1}: credentialId ${hostData.credentialId} not found and no fallback credential available`,
+              );
+              continue;
+            }
+          }
+        }
+
         const sshDataObj: Record<string, unknown> = {
           userId: userId,
           connectionType: effectiveConnectionType,


### PR DESCRIPTION
## Summary
- Fixed hosts imported via JSON bulk import becoming unusable when the `credentialId` doesn't match any existing credential for the importing user
- The `/bulk-import` endpoint previously only checked that `credentialId` was non-empty, but never verified the credential actually exists in the database for the current user
- Added credential existence validation: if the referenced credential is not found, automatically falls back to the user's first available credential
- If the user has no credentials at all, the host import is skipped with a descriptive error message

## Related Issue
Closes Termix-SSH/Support#622

## Test plan
- [ ] Import a JSON file with valid `credentialId` — should import normally
- [ ] Import a JSON file with a non-existent `credentialId` — should fall back to user's first credential and import successfully
- [ ] Import a JSON file with `credentialId` when user has no credentials — should show error and skip that host
- [ ] Verify imported hosts with fallback credential can connect successfully