### PR TITLE
fix: await tunnel cleanup to prevent new connection from being killed

### DIFF
--- a/README.md
+++ b/README.md
@@ -169,6 +169,10 @@ networks:
   <a href="https://akamai.com/">
     <img src="https://upload.wikimedia.org/wikipedia/commons/8/8b/Akamai_logo.svg" height="50" alt="Akamai">
   </a>
+  &nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;
+  <a href="https://aws.amazon.com/">
+    <img src="https://upload.wikimedia.org/wikipedia/commons/thumb/9/93/Amazon_Web_Services_Logo.svg/960px-Amazon_Web_Services_Logo.svg.png" height="50" alt="AWS">
+  </a>
 </p>
 
 # Support

--- a/src/backend/ssh/tunnel.ts
+++ b/src/backend/ssh/tunnel.ts
@@ -546,7 +546,7 @@ async function connectSSHTunnel(
 
   tunnelConnecting.add(tunnelName);
 
-  cleanupTunnelResources(tunnelName, true);
+  await cleanupTunnelResources(tunnelName, true);
 
   if (retryAttempt === 0) {
     retryExhaustedTunnels.delete(tunnelName);


### PR DESCRIPTION
## Summary
- Fixed SSH tunnels immediately dying after creation due to a race condition
- Root cause: `connectSSHTunnel()` called `cleanupTunnelResources()` without `await` — the cleanup ran asynchronously, and `killRemoteTunnelByMarker()` completed AFTER the new tunnel was already established, killing the freshly created tunnel instead of just the old one
- Added `await` to ensure the old tunnel is fully cleaned up before the new connection begins

## Related Issue
Closes Termix-SSH/Support#517

## Test plan
- [ ] Create an SSH tunnel — should connect and stay connected
- [ ] Disconnect and reconnect the same tunnel — should work without the new tunnel being killed
- [ ] Create multiple tunnels to the same host — each should remain stable
- [ ] Verify tunnel retry logic still works after connection failures