### PR TITLE
fix: use carriage return for snippet execution to support PowerShell

### DIFF
--- a/README.md
+++ b/README.md
@@ -169,6 +169,10 @@ networks:
   <a href="https://akamai.com/">
     <img src="https://upload.wikimedia.org/wikipedia/commons/8/8b/Akamai_logo.svg" height="50" alt="Akamai">
   </a>
+  &nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;
+  <a href="https://aws.amazon.com/">
+    <img src="https://upload.wikimedia.org/wikipedia/commons/thumb/9/93/Amazon_Web_Services_Logo.svg/960px-Amazon_Web_Services_Logo.svg.png" height="50" alt="AWS">
+  </a>
 </p>
 
 # Support

--- a/src/backend/ssh/terminal.ts
+++ b/src/backend/ssh/terminal.ts
@@ -1423,13 +1423,13 @@ wss.on("connection", async (ws: WebSocket, req) => {
           });
 
           if (initialPath && initialPath.trim() !== "") {
-            const cdCommand = `cd "${initialPath.replace(/"/g, '\\"')}" && pwd\n`;
+            const cdCommand = `cd "${initialPath.replace(/"/g, '\\"')}" && pwd\r`;
             stream.write(cdCommand);
           }
 
           if (executeCommand && executeCommand.trim() !== "") {
             setTimeout(() => {
-              const command = `${executeCommand}\n`;
+              const command = `${executeCommand}\r`;
               stream.write(command);
             }, 500);
           }

--- a/src/ui/desktop/apps/tools/SSHToolsSidebar.tsx
+++ b/src/ui/desktop/apps/tools/SSHToolsSidebar.tsx
@@ -736,7 +736,7 @@ export function SSHToolsSidebar({
       selectedSnippetTabIds.forEach((tabId) => {
         const tab = tabs.find((t: TabData) => t.id === tabId);
         if (tab?.terminalRef?.current?.sendInput) {
-          tab.terminalRef.current.sendInput(snippet.content + "\n");
+          tab.terminalRef.current.sendInput(snippet.content + "\r");
         }
       });
       toast.success(

--- a/src/ui/desktop/navigation/TopNavbar.tsx
+++ b/src/ui/desktop/navigation/TopNavbar.tsx
@@ -146,7 +146,7 @@ export function TopNavbar({
   const handleSnippetExecute = (content: string) => {
     const tab = tabs.find((t: TabData) => t.id === currentTab);
     if (tab?.terminalRef?.current?.sendInput) {
-      tab.terminalRef.current.sendInput(content + "\n");
+      tab.terminalRef.current.sendInput(content + "\r");
     }
   };
 


### PR DESCRIPTION
## Summary
- Fixed snippet execution not triggering command execution on Windows PowerShell hosts
- Root cause: snippet and command execution used `\n` (line feed) as the Enter key, but SSH terminals expect `\r` (carriage return) — this is what xterm.js sends when the user physically presses Enter
- Linux shells accept both `\n` and `\r`, so the bug was only visible on Windows PowerShell (PSReadLine treats `\n` as a continuation prompt `>>`)
- Fixed in all 4 locations:
  - `SSHToolsSidebar.tsx` — snippet multi-terminal execution
  - `TopNavbar.tsx` — snippet single-terminal execution
  - `terminal.ts` — `executeCommand` auto-execution after connect
  - `terminal.ts` — `initialPath` cd command after connect

## Related Issue
Closes Termix-SSH/Support#621

## Test plan
- [ ] Execute a snippet on a Linux host (bash/zsh) — should work as before
- [ ] Execute a snippet on a Windows host (PowerShell) — command should execute immediately instead of showing `>>` continuation prompt
- [ ] Connect to a host with `executeCommand` configured — command should auto-execute
- [ ] Connect to a host with `initialPath` configured — should cd to the path