### PR TITLE
fix: use carriage return for mobile startup snippet execution

### DIFF
--- a/README.md
+++ b/README.md
@@ -169,6 +169,10 @@ networks:
   <a href="https://akamai.com/">
     <img src="https://upload.wikimedia.org/wikipedia/commons/8/8b/Akamai_logo.svg" height="50" alt="Akamai">
   </a>
+  &nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;
+  <a href="https://aws.amazon.com/">
+    <img src="https://upload.wikimedia.org/wikipedia/commons/thumb/9/93/Amazon_Web_Services_Logo.svg/960px-Amazon_Web_Services_Logo.svg.png" height="50" alt="AWS">
+  </a>
 </p>
 
 # Support

--- a/src/ui/mobile/apps/terminal/Terminal.tsx
+++ b/src/ui/mobile/apps/terminal/Terminal.tsx
@@ -709,7 +709,7 @@ const TerminalInner = forwardRef<TerminalHandle, SSHTerminalProps>(
                     ws.send(
                       JSON.stringify({
                         type: "input",
-                        data: snippet.content + "\n",
+                        data: snippet.content + "\r",
                       }),
                     );
                   }


### PR DESCRIPTION
## Summary
- Follow-up to #679 which fixed snippet line endings on desktop
- The mobile app's startup snippet execution had the same issue: using `\n` (LF) instead of `\r` (CR) to trigger command execution
- This caused PowerShell hosts to show a continuation prompt `>>` instead of executing the startup snippet

## Test plan
- [ ] Configure a startup snippet on a mobile terminal profile
- [ ] Connect to a Linux host — snippet should auto-execute
- [ ] Connect to a Windows PowerShell host — snippet should auto-execute instead of showing `>>`