### PR TITLE
fix: prevent file upload from crashing backend on permission denied

### DIFF
--- a/README.md
+++ b/README.md
@@ -169,6 +169,10 @@ networks:
   <a href="https://akamai.com/">
     <img src="https://upload.wikimedia.org/wikipedia/commons/8/8b/Akamai_logo.svg" height="50" alt="Akamai">
   </a>
+  &nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;
+  <a href="https://aws.amazon.com/">
+    <img src="https://upload.wikimedia.org/wikipedia/commons/thumb/9/93/Amazon_Web_Services_Logo.svg/960px-Amazon_Web_Services_Logo.svg.png" height="50" alt="AWS">
+  </a>
 </p>
 
 # Support

--- a/src/backend/ssh/file-manager.ts
+++ b/src/backend/ssh/file-manager.ts
@@ -3588,6 +3588,20 @@ app.post("/ssh/file_manager/ssh/uploadFile", async (req, res) => {
         chunks.push(base64Content.slice(i, i + chunkSize));
       }
 
+      if (!sshConn?.isConnected) {
+        fileLogger.error("SSH connection lost before fallback upload", {
+          operation: "file_upload_fallback",
+          sessionId,
+          path: fullPath,
+        });
+        if (!res.headersSent) {
+          return res
+            .status(500)
+            .json({ error: "SSH connection lost during upload" });
+        }
+        return;
+      }
+
       if (chunks.length === 1) {
         const escapedPath = fullPath.replace(/'/g, "'\"'\"'");
 
@@ -3613,6 +3627,10 @@ app.post("/ssh/file_manager/ssh/uploadFile", async (req, res) => {
 
           stream.stderr.on("data", (chunk: Buffer) => {
             errorData += chunk.toString();
+          });
+
+          stream.stderr.on("error", (stderrErr) => {
+            fileLogger.error("Fallback upload stderr error:", stderrErr);
           });
 
           stream.on("close", (code) => {
@@ -3683,6 +3701,10 @@ app.post("/ssh/file_manager/ssh/uploadFile", async (req, res) => {
 
           stream.stderr.on("data", (chunk: Buffer) => {
             errorData += chunk.toString();
+          });
+
+          stream.stderr.on("error", (stderrErr) => {
+            fileLogger.error("Chunked fallback upload stderr error:", stderrErr);
           });
 
           stream.on("close", (code) => {


### PR DESCRIPTION
## Summary
- Fixed file upload causing the entire backend to crash and become unavailable when uploading to a no-permission directory
- Root cause: the fallback upload method (exec-based) attached a `data` handler on `stream.stderr` but no `error` handler — when the stderr stream encountered an error (e.g., during concurrent uploads or connection state changes), the unhandled error event crashed the Node.js process
- Added `stream.stderr.on("error", ...)` handlers to both single-chunk and multi-chunk fallback paths
- Added SSH connection state check before entering the fallback method to prevent operating on a closed connection

## Related Issue
Closes Termix-SSH/Support#585

## Test plan
- [ ] Upload a file to a directory with write permission — should succeed
- [ ] Upload a file to a no-permission directory (e.g., `/usr/local`) — should fail gracefully with error message, not crash
- [ ] While uploading to a no-permission directory, navigate to another directory and upload again — backend should remain stable
- [ ] Verify the backend process stays running after failed uploads (no restart required)