### PR TITLE
fix: disable keyboard-interactive when host auth is set to None

### DIFF
--- a/README.md
+++ b/README.md
@@ -169,6 +169,10 @@ networks:
   <a href="https://akamai.com/">
     <img src="https://upload.wikimedia.org/wikipedia/commons/8/8b/Akamai_logo.svg" height="50" alt="Akamai">
   </a>
+  &nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;
+  <a href="https://aws.amazon.com/">
+    <img src="https://upload.wikimedia.org/wikipedia/commons/thumb/9/93/Amazon_Web_Services_Logo.svg/960px-Amazon_Web_Services_Logo.svg.png" height="50" alt="AWS">
+  </a>
 </p>
 
 # Support

--- a/src/backend/ssh/terminal.ts
+++ b/src/backend/ssh/terminal.ts
@@ -255,7 +255,7 @@ async function createJumpHostChain(
           host: jumpHostConfig.ip?.replace(/^\[|\]$/g, "") || jumpHostConfig.ip,
           port: jumpHostConfig.port || 22,
           username: jumpHostConfig.username,
-          tryKeyboard: true,
+          tryKeyboard: jumpHostConfig.authType !== "none",
           readyTimeout: 30000,
           hostVerifier: jumpHostVerifier,
         };
@@ -1801,7 +1801,7 @@ wss.on("connection", async (ws: WebSocket, req) => {
       host: ip,
       port,
       username,
-      tryKeyboard: true,
+      tryKeyboard: resolvedCredentials.authType !== "none",
       keepaliveInterval:
         typeof hostKeepaliveInterval === "number"
           ? hostKeepaliveInterval


### PR DESCRIPTION
## Summary
- Fixed spurious "Two-Factor Authentication Required" dialog appearing when connecting to hosts configured with Authentication set to "None"
- Root cause: `tryKeyboard: true` was hardcoded in the SSH connect config regardless of authType — when the SSH server offers keyboard-interactive auth, the client accepted it even though the user explicitly chose no authentication, causing misleading TOTP/password prompts
- Changed `tryKeyboard` to be disabled when `authType === "none"`, applied to both main SSH connections and jump host connections

## Related Issue
Closes Termix-SSH/Support#497

## Test plan
- [ ] Connect to a host with auth set to "None" that supports keyboard-interactive — should NOT show TOTP or password dialog
- [ ] Connect to a host with auth set to "None" that accepts none auth — should connect directly
- [ ] Connect to a host with password auth — keyboard-interactive should still work (password prompt)
- [ ] Connect to a host with key + TOTP — TOTP dialog should still appear correctly
- [ ] Connect via jump host with auth "None" — should not prompt for auth on the jump host