### PR TITLE
fix: add missing stream error handlers in Docker console

### DIFF
--- a/README.md
+++ b/README.md
@@ -169,6 +169,10 @@ networks:
   <a href="https://akamai.com/">
     <img src="https://upload.wikimedia.org/wikipedia/commons/8/8b/Akamai_logo.svg" height="50" alt="Akamai">
   </a>
+  &nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;
+  <a href="https://aws.amazon.com/">
+    <img src="https://upload.wikimedia.org/wikipedia/commons/thumb/9/93/Amazon_Web_Services_Logo.svg/960px-Amazon_Web_Services_Logo.svg.png" height="50" alt="AWS">
+  </a>
 </p>
 
 # Support

--- a/src/backend/ssh/docker-console.ts
+++ b/src/backend/ssh/docker-console.ts
@@ -75,8 +75,10 @@ async function detectShell(
               }
             });
 
-            stream.stderr.on("data", () => {
-              // Ignore stderr
+            stream.stderr.on("data", () => {});
+            stream.stderr.on("error", () => {});
+            stream.on("error", (streamErr) => {
+              reject(streamErr);
             });
           },
         );
@@ -430,8 +432,10 @@ wss.on("connection", async (ws: WebSocket, req) => {
                         }
                       });
 
-                      stream.stderr.on("data", () => {
-                        // Ignore stderr
+                      stream.stderr.on("data", () => {});
+                      stream.stderr.on("error", () => {});
+                      stream.on("error", (streamErr) => {
+                        reject(streamErr);
                       });
                     },
                   );
@@ -509,8 +513,23 @@ wss.on("connection", async (ws: WebSocket, req) => {
                   }
                 });
 
-                stream.stderr.on("data", () => {
-                  // stderr output ignored
+                stream.stderr.on("data", () => {});
+                stream.stderr.on("error", () => {});
+
+                stream.on("error", (streamErr) => {
+                  sshLogger.error("Docker console stream error", streamErr, {
+                    operation: "docker_console_stream_error",
+                    sessionId,
+                    containerId,
+                  });
+                  if (ws.readyState === WebSocket.OPEN) {
+                    ws.send(
+                      JSON.stringify({
+                        type: "error",
+                        message: `Console error: ${streamErr.message}`,
+                      }),
+                    );
+                  }
                 });
 
                 stream.on("close", () => {


### PR DESCRIPTION
## Summary
- Fixed potential crashes in Docker console sessions due to missing stream error handlers
- Three `client.exec()` calls in docker-console.ts had no `stream.on("error")` or `stream.stderr.on("error")` handlers:
  1. Shell detection (`which bash/sh/ash`) — unhandled stream error caused hanging promise
  2. Shell validation on connect — same issue
  3. Main Docker exec session — unhandled error could crash the process or leave WebSocket in broken state
- Added error handlers to all three locations, properly rejecting promises for the detection/validation paths and sending error messages to the client for the main session

## Test plan
- [ ] Open a Docker container console — should connect normally
- [ ] If the SSH connection drops during a Docker console session, should show error message instead of crashing
- [ ] If the container stops while console is open, should handle gracefully
- [ ] Shell detection should still work correctly (bash → sh → ash fallback)