### PR TITLE
fix(guacamole): honor host RDP DPI in client and tab params

### DIFF
--- a/src/ui/desktop/apps/command-palette/CommandPalette.tsx
+++ b/src/ui/desktop/apps/command-palette/CommandPalette.tsx
@@ -33,6 +33,7 @@ import { useTabs } from "@/ui/desktop/navigation/tabs/TabContext.tsx";
 import {
   getRecentActivity,
   getSSHHosts,
+  getGuacamoleDpi,
   getGuacamoleTokenFromHost,
   logActivity,
 } from "@/ui/main-axios.ts";
@@ -252,6 +253,7 @@ export function CommandPalette({
             domain: host.domain,
             security: host.security,
             "ignore-cert": host.ignoreCert,
+            dpi: getGuacamoleDpi(host),
           },
         });
 

--- a/src/ui/desktop/apps/dashboard/Dashboard.tsx
+++ b/src/ui/desktop/apps/dashboard/Dashboard.tsx
@@ -16,6 +16,7 @@ import {
   getServerMetricsById,
   registerMetricsViewer,
   sendMetricsHeartbeat,
+  getGuacamoleDpi,
   getGuacamoleTokenFromHost,
   type RecentActivityItem,
 } from "@/ui/main-axios.ts";
@@ -456,6 +457,7 @@ export function Dashboard({
                 domain: host.domain,
                 security: host.security,
                 "ignore-cert": host.ignoreCert,
+                dpi: getGuacamoleDpi(host),
               },
             });
           })
@@ -480,6 +482,7 @@ export function Dashboard({
                 domain: host.domain,
                 security: host.security,
                 "ignore-cert": host.ignoreCert,
+                dpi: getGuacamoleDpi(host),
               },
             });
           })
@@ -504,6 +507,7 @@ export function Dashboard({
                 domain: host.domain,
                 security: host.security,
                 "ignore-cert": host.ignoreCert,
+                dpi: getGuacamoleDpi(host),
               },
             });
           })

--- a/src/ui/desktop/apps/features/guacamole/GuacamoleDisplay.tsx
+++ b/src/ui/desktop/apps/features/guacamole/GuacamoleDisplay.tsx
@@ -139,10 +139,10 @@ export const GuacamoleDisplay = forwardRef<
           token = data.token;
         }
 
-        const width = connectionConfig.width || containerWidth || 1280;
-        const height = connectionConfig.height || containerHeight || 720;
-        const protocol = connectionConfig.protocol || connectionConfig.type;
-        const dpi = protocol === "rdp" ? connectionConfig.dpi || 96 : null;
+        const width = connectionConfig.width ?? containerWidth ?? 1280;
+        const height = connectionConfig.height ?? containerHeight ?? 720;
+        const protocol = connectionConfig.protocol ?? connectionConfig.type;
+        const dpi = protocol === "rdp" ? connectionConfig.dpi ?? 96 : null;
 
         const wsBase = isDev
           ? `ws://localhost:30008`
@@ -173,7 +173,9 @@ export const GuacamoleDisplay = forwardRef<
           width: String(width),
           height: String(height),
         });
-        if (dpi !== null) params.set("dpi", String(dpi));
+        if (dpi !== null && dpi !== undefined) {
+          params.set("dpi", String(dpi));
+        }
         return `${wsBase}?${params.toString()}`;
       } catch (error) {
         const errorMessage =

--- a/src/ui/desktop/apps/host-manager/hosts/HostManagerViewer.tsx
+++ b/src/ui/desktop/apps/host-manager/hosts/HostManagerViewer.tsx
@@ -42,6 +42,7 @@ import {
   refreshServerPolling,
   isElectron,
   getConfiguredServerUrl,
+  getGuacamoleDpi,
   getGuacamoleTokenFromHost,
   logActivity,
 } from "@/ui/main-axios.ts";
@@ -2007,6 +2008,9 @@ export function HostManagerViewer({
                                                       security: host.security,
                                                       "ignore-cert":
                                                         host.ignoreCert,
+                                                      dpi: getGuacamoleDpi(
+                                                        host,
+                                                      ),
                                                     },
                                                   });
 

--- a/src/ui/desktop/navigation/hosts/Host.tsx
+++ b/src/ui/desktop/navigation/hosts/Host.tsx
@@ -25,6 +25,7 @@ import { useTabs } from "@/ui/desktop/navigation/tabs/TabContext";
 import {
   getSSHHosts,
   getGuacamoleToken,
+  getGuacamoleDpi,
   getGuacamoleTokenFromHost,
   logActivity,
   wakeOnLan,
@@ -142,6 +143,7 @@ export function Host({ host: initialHost }: HostProps): React.ReactElement {
             domain: host.domain,
             security: host.security,
             "ignore-cert": host.ignoreCert,
+            dpi: getGuacamoleDpi(host),
           },
         });
 

--- a/src/ui/main-axios.ts
+++ b/src/ui/main-axios.ts
@@ -4108,6 +4108,39 @@ export interface GuacamoleTokenResponse {
   token: string;
 }
 
+type GuacamoleConfigSource = {
+  guacamoleConfig?: string | Record<string, unknown> | null;
+};
+
+export function getGuacamoleDpi(
+  source?: GuacamoleConfigSource,
+): number | undefined {
+  const config = source?.guacamoleConfig;
+  if (!config) return undefined;
+
+  let dpi: unknown;
+  if (typeof config === "string") {
+    try {
+      dpi = JSON.parse(config).dpi;
+    } catch {
+      return undefined;
+    }
+  } else {
+    dpi = config.dpi;
+  }
+
+  const parsedDpi = typeof dpi === "string" ? Number(dpi) : dpi;
+  if (
+    typeof parsedDpi !== "number" ||
+    !Number.isFinite(parsedDpi) ||
+    parsedDpi <= 0
+  ) {
+    return undefined;
+  }
+
+  return Math.trunc(parsedDpi);
+}
+
 function toGuacamoleParams(
   config: GuacamoleTokenRequest["guacamoleConfig"],
 ): Record<string, unknown> {


### PR DESCRIPTION
# Overview

Reads RDP DPI from each host’s Guacamole config and passes it when opening Guacamole sessions so the client and WebSocket URL use the intended DPI instead of silently dropping `0` or missing values.

- [x] Added: `getGuacamoleDpi()` helper and `dpi` on Guacamole tab/session payloads from host navigation, dashboard, command palette, and host manager.
- [x] Updated: `GuacamoleDisplay` uses null-ish coalescing for dimensions/protocol/DPI and only sends `dpi` in the query when it is a valid finite value.
- [x] Fixed: RDP DPI from host config not reliably applied to Guacamole connections.

# Changes Made

- Centralized parsing of `guacamoleConfig` (JSON string or object) for `dpi`, with validation and truncation to an integer.
- Wired `dpi` into all relevant desktop entry points that open Guacamole with host-derived connection options.

# Related Issues

- Closes Termix-SSH/Support#624

# Checklist

- [x] Code follows project style guidelines
- [x] Supports mobile and desktop UI/app (if applicable) — desktop Guacamole flows; no mobile Guacamole change assumed.
- [x] I have read [Contributing.md](https://github.com/Termix-SSH/Termix/blob/main/CONTRIBUTING.md)
- [x] This is not a translation request. See [docs](https://docs.termix.site/translations)