### PR TITLE
fix(terminal): resolve Electron SSH websocket URL from server config

### DIFF
--- a/src/ui/desktop/apps/features/terminal/Terminal.tsx
+++ b/src/ui/desktop/apps/features/terminal/Terminal.tsx
@@ -23,6 +23,7 @@ import {
   deleteCommandFromHistory,
   getCommandHistory,
   getHostPassword,
+  getServerConfig,
 } from "@/ui/main-axios.ts";
 import { TOTPDialog } from "@/ui/desktop/navigation/dialogs/TOTPDialog.tsx";
 import { SSHAuthDialog } from "@/ui/desktop/navigation/dialogs/SSHAuthDialog.tsx";
@@ -900,7 +901,7 @@ const TerminalInner = forwardRef<TerminalHandle, SSHTerminalProps>(
       }, delay);
     }
 
-    function connectToHost(cols: number, rows: number) {
+    async function connectToHost(cols: number, rows: number) {
       if (isConnectingRef.current) {
         return;
       }
@@ -932,26 +933,52 @@ const TerminalInner = forwardRef<TerminalHandle, SSHTerminalProps>(
         return;
       }
 
-      const baseWsUrl = isDev
-        ? `${window.location.protocol === "https:" ? "wss" : "ws"}://localhost:30002`
-        : isElectron()
-          ? (() => {
-              const configuredUrl = (window as { configuredServerUrl?: string })
-                .configuredServerUrl;
-              // Embedded mode or localhost: connect directly to the WebSocket server port
-              if (isEmbeddedMode() || !configuredUrl) {
-                return "ws://127.0.0.1:30002";
-              }
-              // Remote server: use the /ssh/websocket/ path (expects reverse proxy)
-              const wsProtocol = configuredUrl.startsWith("https://")
-                ? "wss://"
-                : "ws://";
-              const wsHost = configuredUrl
-                .replace(/^https?:\/\//, "")
-                .replace(/\/$/, "");
-              return `${wsProtocol}${wsHost}/ssh/websocket/`;
-            })()
-          : `${getBasePath()}/ssh/websocket/`;
+      let baseWsUrl: string;
+
+      if (isDev) {
+        baseWsUrl = `${window.location.protocol === "https:" ? "wss" : "ws"}://localhost:30002`;
+      } else if (isElectron()) {
+        let configuredUrl = (window as { configuredServerUrl?: string | null })
+          .configuredServerUrl;
+
+        if (!configuredUrl && !isEmbeddedMode()) {
+          try {
+            const serverConfig = await getServerConfig();
+            configuredUrl = serverConfig?.serverUrl || null;
+            if (configuredUrl) {
+              (
+                window as Window &
+                  typeof globalThis & {
+                    configuredServerUrl?: string | null;
+                  }
+              ).configuredServerUrl = configuredUrl;
+            }
+          } catch (error) {
+            console.error("Failed to resolve Electron server URL:", error);
+          }
+        }
+
+        if (isEmbeddedMode()) {
+          baseWsUrl = "ws://127.0.0.1:30002";
+        } else if (!configuredUrl) {
+          console.error("No configured server URL available for Electron SSH");
+          setIsConnected(false);
+          setIsConnecting(false);
+          updateConnectionError(t("errors.failedToLoadServer"));
+          isConnectingRef.current = false;
+          return;
+        } else {
+          const wsProtocol = configuredUrl.startsWith("https://")
+            ? "wss://"
+            : "ws://";
+          const wsHost = configuredUrl
+            .replace(/^https?:\/\//, "")
+            .replace(/\/$/, "");
+          baseWsUrl = `${wsProtocol}${wsHost}/ssh/websocket/`;
+        }
+      } else {
+        baseWsUrl = `${getBasePath()}/ssh/websocket/`;
+      }
 
       if (
         webSocketRef.current &&


### PR DESCRIPTION
# Overview

On Electron, when no `configuredServerUrl` is on `window` yet (non-embedded), the SSH terminal now loads server config to derive the base URL before opening the WebSocket, and surfaces a clear error if the URL cannot be resolved. This improves reconnect flows where the socket URL was wrong or missing.

- [x] Added: Async resolution path using `getServerConfig()` and caching `configuredServerUrl` on `window` when found.
- [x] Updated: `connectToHost` is async and reorganizes dev / Electron / web WebSocket URL construction.
- [x] Fixed: Electron SSH terminal failing or mis-targeting when server URL was not pre-seeded.

# Changes Made

- Embedded mode still uses local `ws://127.0.0.1:30002`; remote Electron uses `/ssh/websocket/` under the configured host with correct `ws`/`wss`.

# Related Issues

- Closes Termix-SSH/Support#635

# Checklist

- [x] Code follows project style guidelines
- [x] Supports mobile and desktop UI/app (if applicable) — desktop Electron terminal path.
- [x] I have read [Contributing.md](https://github.com/Termix-SSH/Termix/blob/main/CONTRIBUTING.md)
- [x] This is not a translation request. See [docs](https://docs.termix.site/translations)