### PR TITLE
fix(snippets): accept snippets or legacy updates in reorder API

### DIFF
--- a/src/backend/database/routes/snippets-reorder.test.ts
+++ b/src/backend/database/routes/snippets-reorder.test.ts
@@ -1,0 +1,26 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+
+import { extractSnippetReorderUpdates } from "./snippets-reorder.ts";
+
+test("extractSnippetReorderUpdates accepts snippets payloads", () => {
+  const updates = extractSnippetReorderUpdates({
+    snippets: [{ id: 1, order: 0, folder: "" }],
+  });
+
+  assert.deepEqual(updates, [{ id: 1, order: 0, folder: "" }]);
+});
+
+test("extractSnippetReorderUpdates accepts updates payloads", () => {
+  const updates = extractSnippetReorderUpdates({
+    updates: [{ id: 2, order: 1, folder: "shared" }],
+  });
+
+  assert.deepEqual(updates, [{ id: 2, order: 1, folder: "shared" }]);
+});
+
+test("extractSnippetReorderUpdates rejects invalid payloads", () => {
+  assert.equal(extractSnippetReorderUpdates(null), null);
+  assert.equal(extractSnippetReorderUpdates({}), null);
+  assert.deepEqual(extractSnippetReorderUpdates({ snippets: [] }), []);
+});

--- a/src/backend/database/routes/snippets-reorder.ts
+++ b/src/backend/database/routes/snippets-reorder.ts
@@ -1,0 +1,33 @@
+export interface SnippetReorderUpdate {
+  id: number;
+  order: number;
+  folder?: string;
+}
+
+type SnippetReorderRequestBody = {
+  snippets?: unknown;
+  updates?: unknown;
+};
+
+export function extractSnippetReorderUpdates(
+  body: unknown,
+): SnippetReorderUpdate[] | null {
+  if (!body || typeof body !== "object") {
+    return null;
+  }
+
+  const payload = body as SnippetReorderRequestBody;
+  // Keep accepting the legacy `updates` key so older clients do not break
+  // while the web and desktop helpers converge on `snippets`.
+  const snippetsUpdates = Array.isArray(payload.snippets)
+    ? payload.snippets
+    : Array.isArray(payload.updates)
+      ? payload.updates
+      : null;
+
+  if (!snippetsUpdates) {
+    return null;
+  }
+
+  return snippetsUpdates as SnippetReorderUpdate[];
+}

--- a/src/backend/database/routes/snippets.ts
+++ b/src/backend/database/routes/snippets.ts
@@ -7,6 +7,7 @@ import type { Request, Response } from "express";
 import { authLogger, databaseLogger } from "../../utils/logger.js";
 import { AuthManager } from "../../utils/auth-manager.js";
 import { SSH_ALGORITHMS } from "../../utils/ssh-algorithms.js";
+import { extractSnippetReorderUpdates } from "./snippets-reorder.js";
 
 const router = express.Router();
 
@@ -473,7 +474,8 @@ router.delete(
  * /snippets/reorder:
  *   put:
  *     summary: Reorder snippets
- *     description: Bulk updates the order and folder of snippets.
+ *     description: Bulk updates the order and folder of snippets. Accepts
+ *       `snippets` and the legacy `updates` payload key.
  *     tags:
  *       - Snippets
  *     requestBody:
@@ -508,14 +510,14 @@ router.put(
   requireDataAccess,
   async (req: Request, res: Response) => {
     const userId = (req as AuthenticatedRequest).userId;
-    const { snippets: snippetUpdates } = req.body;
+    const snippetUpdates = extractSnippetReorderUpdates(req.body);
 
     if (!isNonEmptyString(userId)) {
       authLogger.warn("Invalid userId for snippet reorder");
       return res.status(400).json({ error: "Invalid userId" });
     }
 
-    if (!Array.isArray(snippetUpdates) || snippetUpdates.length === 0) {
+    if (!snippetUpdates || snippetUpdates.length === 0) {
       authLogger.warn("Invalid snippet reorder data", {
         operation: "snippet_reorder",
         userId,

--- a/src/ui/main-axios.ts
+++ b/src/ui/main-axios.ts
@@ -3851,7 +3851,9 @@ export async function reorderSnippets(
   updates: Array<{ id: number; order: number; folder?: string }>,
 ): Promise<{ success: boolean }> {
   try {
-    const response = await authApi.post("/snippets/reorder", { updates });
+    const response = await authApi.post("/snippets/reorder", {
+      snippets: updates,
+    });
     return response.data;
   } catch (error) {
     throw handleApiError(error, "reorder snippets");


### PR DESCRIPTION
# Overview

Snippet reorder API and client are aligned: the client sends `{ snippets: [...] }`, and the server accepts **`snippets`** or the legacy **`updates`** key so older clients keep working during the transition.

- [x] Added: `extractSnippetReorderUpdates()` helper, `snippets-reorder.ts`, and node:test coverage in `snippets-reorder.test.ts`.
- [x] Updated: `PUT /snippets/reorder` handler and `reorderSnippets()` in `main-axios`; OpenAPI description for the route.
- [x] Fixed: Reorder payload mismatch between client and server.

# Changes Made

- Shared extraction validates presence of an array from either payload key before processing.

# Related Issues

- Closes Termix-SSH/Support#639

# Checklist

- [x] Code follows project style guidelines
- [x] Supports mobile and desktop UI/app (if applicable) — shared API + client helper.
- [x] I have read [Contributing.md](https://github.com/Termix-SSH/Termix/blob/main/CONTRIBUTING.md)
- [x] This is not a translation request. See [docs](https://docs.termix.site/translations)