### PR TITLE
fix(admin): fetch user list when Users tab is opened

### DIFF
--- a/src/ui/desktop/apps/admin/AdminSettings.tsx
+++ b/src/ui/desktop/apps/admin/AdminSettings.tsx
@@ -148,7 +148,6 @@ export function AdminSettings({
           console.warn("Failed to fetch current user info", err);
         }
       });
-    fetchUsers();
     fetchSessions();
   }, []);
 
@@ -340,7 +339,15 @@ export function AdminSettings({
         <Separator className="p-0.25 w-full" />
 
         <div className="px-6 py-4 overflow-auto thin-scrollbar">
-          <Tabs defaultValue="registration" className="w-full">
+          <Tabs
+            defaultValue="registration"
+            onValueChange={(value) => {
+              if (value === "users") {
+                fetchUsers();
+              }
+            }}
+            className="w-full"
+          >
             <TabsList className="mb-4 bg-elevated border-2 border-edge">
               <TabsTrigger
                 value="registration"


### PR DESCRIPTION
# Overview

Admin settings no longer load the full user list on every mount. It now loads when the user opens the **Users** tab, reducing unnecessary API traffic and work on initial admin page load.

- [x] Added: `Tabs` `onValueChange` handler to call `fetchUsers()` when switching to the users tab.
- [x] Updated: Initial `useEffect` still fetches sessions but no longer calls `fetchUsers()` unconditionally.
- [x] Fixed: Eager users-list fetch on admin settings open.

# Changes Made

- Behavior change limited to `AdminSettings.tsx` tab wiring.

# Related Issues

- Closes Termix-SSH/Support#640

Root cause (Electron): `fetchUsers()` returns early when `configuredServerUrl` is missing; it previously only ran on mount, so it could no-op permanently. Users are now fetched when the User Management tab is opened, making sure the request only runs once configuration is available.

# Checklist

- [x] Code follows project style guidelines
- [x] Supports mobile and desktop UI/app (if applicable) — desktop admin UI; confirm if mobile has same tabs.
- [x] I have read [Contributing.md](https://github.com/Termix-SSH/Termix/blob/main/CONTRIBUTING.md)
- [x] This is not a translation request. See [docs](https://docs.termix.site/translations)