### PR TITLE
fix(docker): improve list layout and overflow for container cards

### DIFF
--- a/src/ui/desktop/apps/features/docker/DockerManager.tsx
+++ b/src/ui/desktop/apps/features/docker/DockerManager.tsx
@@ -661,7 +661,7 @@ function DockerManagerInner({
 
         <div className="flex-1 overflow-hidden min-h-0 relative">
           {viewMode === "list" ? (
-            <div className="h-full px-4 py-4">
+            <div className="h-full min-h-0 px-4 py-4">
               {sessionId ? (
                 isLoadingContainers && containers.length === 0 ? (
                   <SimpleLoader

--- a/src/ui/desktop/apps/features/docker/components/ContainerCard.tsx
+++ b/src/ui/desktop/apps/features/docker/components/ContainerCard.tsx
@@ -267,27 +267,27 @@ export function ContainerCard({
         </CardHeader>
         <CardContent className="space-y-3 px-4 pb-3">
           <div className="space-y-2 text-sm">
-            <div className="flex items-center gap-2">
+            <div className="flex items-center gap-2 min-w-0">
               <span className="text-muted-foreground min-w-[50px] text-xs">
                 {t("docker.image")}
               </span>
-              <span className="truncate text-foreground text-xs">
+              <span className="flex-1 min-w-0 truncate text-foreground text-xs">
                 {container.image}
               </span>
             </div>
-            <div className="flex items-center gap-2">
+            <div className="flex items-center gap-2 min-w-0">
               <span className="text-muted-foreground min-w-[50px] text-xs">
                 {t("docker.idLabel")}
               </span>
-              <span className="font-mono text-xs text-foreground">
+              <span className="flex-1 min-w-0 truncate font-mono text-xs text-foreground">
                 {container.id.substring(0, 12)}
               </span>
             </div>
-            <div className="flex items-start gap-2">
+            <div className="flex items-start gap-2 min-w-0">
               <span className="text-muted-foreground min-w-[50px] text-xs shrink-0">
                 {t("docker.ports")}
               </span>
-              <div className="flex flex-wrap gap-1">
+              <div className="flex flex-1 min-w-0 flex-wrap gap-1">
                 {portsList.length > 0 ? (
                   portsList.map((port, idx) => (
                     <Badge
@@ -308,11 +308,11 @@ export function ContainerCard({
                 )}
               </div>
             </div>
-            <div className="flex items-center gap-2">
+            <div className="flex items-center gap-2 min-w-0">
               <span className="text-muted-foreground min-w-[50px] text-xs">
                 {t("docker.created")}
               </span>
-              <span className="text-foreground text-xs">
+              <span className="flex-1 min-w-0 truncate text-foreground text-xs">
                 {formatCreatedDate(container.created)}
               </span>
             </div>

--- a/src/ui/desktop/apps/features/docker/components/ContainerList.tsx
+++ b/src/ui/desktop/apps/features/docker/components/ContainerList.tsx
@@ -55,7 +55,7 @@ export function ContainerList({
 
   if (containers.length === 0) {
     return (
-      <div className="flex items-center justify-center h-full">
+      <div className="flex items-center justify-center h-full min-h-0">
         <div className="text-center space-y-2">
           <p className="text-muted-foreground text-lg">
             {t("docker.noContainersFound")}
@@ -69,7 +69,7 @@ export function ContainerList({
   }
 
   return (
-    <div className="flex flex-col h-full gap-3">
+    <div className="flex flex-col h-full min-h-0 gap-3">
       <div className="flex flex-col sm:flex-row gap-2">
         <div className="relative flex-1">
           <Search className="absolute left-3 top-1/2 transform -translate-y-1/2 h-4 w-4 text-muted-foreground" />
@@ -106,7 +106,7 @@ export function ContainerList({
       </div>
 
       {filteredContainers.length === 0 ? (
-        <div className="flex items-center justify-center flex-1">
+        <div className="flex items-center justify-center flex-1 min-h-0">
           <div className="text-center space-y-2">
             <p className="text-muted-foreground">
               {t("docker.noContainersMatchFilters")}
@@ -117,17 +117,19 @@ export function ContainerList({
           </div>
         </div>
       ) : (
-        <div className="grid grid-cols-1 lg:grid-cols-2 xl:grid-cols-3 gap-3 overflow-auto thin-scrollbar pb-2">
-          {filteredContainers.map((container) => (
-            <ContainerCard
-              key={container.id}
-              container={container}
-              sessionId={sessionId}
-              onSelect={() => onSelectContainer(container.id)}
-              isSelected={selectedContainerId === container.id}
-              onRefresh={onRefresh}
-            />
-          ))}
+        <div className="min-h-0 flex-1 overflow-auto thin-scrollbar pr-1">
+          <div className="grid grid-cols-[repeat(auto-fit,minmax(320px,1fr))] gap-3 auto-rows-min content-start w-full pb-2">
+            {filteredContainers.map((container) => (
+              <ContainerCard
+                key={container.id}
+                container={container}
+                sessionId={sessionId}
+                onSelect={() => onSelectContainer(container.id)}
+                isSelected={selectedContainerId === container.id}
+                onRefresh={onRefresh}
+              />
+            ))}
+          </div>
         </div>
       )}
     </div>


### PR DESCRIPTION
# Overview

Docker desktop view layout is tightened so flex children can shrink and scroll correctly, long metadata truncates instead of blowing the layout, and the container grid uses responsive `auto-fit` columns with a dedicated scroll region.

- [x] Added: `min-h-0` / `min-w-0` / `flex-1` / `truncate` utilities where needed for list, cards, and empty states.
- [x] Updated: List vs grid wrapper structure; grid uses `repeat(auto-fit, minmax(320px, 1fr))` inside an overflow container.
- [x] Fixed: Docker manager list/card overflow and cramped or overflowing text on narrow widths.

# Changes Made

- Touches `DockerManager.tsx`, `ContainerList.tsx`, and `ContainerCard.tsx` only.

# Related Issues

- Closes Termix-SSH/Support#641

# Checklist

- [x] Code follows project style guidelines
- [x] Supports mobile and desktop UI/app (if applicable) — desktop Docker feature; mark mobile if shared.
- [x] I have read [Contributing.md](https://github.com/Termix-SSH/Termix/blob/main/CONTRIBUTING.md)
- [x] This is not a translation request. See [docs](https://docs.termix.site/translations)