### PR TITLE
fix(guacamole): gate keyboard capture on focus and visibility

### DIFF
--- a/src/ui/desktop/apps/features/guacamole/GuacamoleDisplay.tsx
+++ b/src/ui/desktop/apps/features/guacamole/GuacamoleDisplay.tsx
@@ -55,10 +55,15 @@ export const GuacamoleDisplay = forwardRef<
   const { t } = useTranslation();
   const containerRef = useRef<HTMLDivElement>(null);
   const displayRef = useRef<HTMLDivElement>(null);
+  const displayElementRef = useRef<HTMLElement | null>(null);
   const clientRef = useRef<Guacamole.Client | null>(null);
   const keyboardRef = useRef<Guacamole.Keyboard | null>(null);
   const scaleRef = useRef<number>(1);
   const resizeTimeoutRef = useRef<NodeJS.Timeout | null>(null);
+  const hasKeyboardFocusRef = useRef(false);
+  const windowFocusedRef = useRef(
+    typeof document === "undefined" ? true : document.hasFocus(),
+  );
   const [isConnecting, setIsConnecting] = useState(false);
   const [isReady, setIsReady] = useState(false);
 
@@ -185,6 +190,63 @@ export const GuacamoleDisplay = forwardRef<
     [connectionConfig, onError],
   );
 
+  const refreshKeyboardHandlers = useCallback(() => {
+    const keyboard = keyboardRef.current;
+    const client = clientRef.current;
+    const displayElement = displayElementRef.current;
+
+    if (!keyboard) return;
+
+    const documentVisible =
+      typeof document === "undefined" || document.visibilityState === "visible";
+    const displayIsFocused =
+      !!displayElement &&
+      typeof document !== "undefined" &&
+      document.activeElement === displayElement;
+    const shouldCaptureInput =
+      !!client &&
+      !!displayElement &&
+      isVisible &&
+      documentVisible &&
+      windowFocusedRef.current &&
+      (hasKeyboardFocusRef.current || displayIsFocused);
+
+    if (!shouldCaptureInput) {
+      keyboard.onkeydown = null;
+      keyboard.onkeyup = null;
+      keyboard.reset();
+      return;
+    }
+
+    keyboard.onkeydown = (keysym: number) => {
+      if (!clientRef.current) return;
+      if (!isVisible || !windowFocusedRef.current) return;
+
+      const activeDisplay = displayElementRef.current;
+      const stillFocused =
+        !!activeDisplay &&
+        typeof document !== "undefined" &&
+        document.activeElement === activeDisplay;
+
+      if (!hasKeyboardFocusRef.current && !stillFocused) return;
+      clientRef.current.sendKeyEvent(1, keysym);
+    };
+
+    keyboard.onkeyup = (keysym: number) => {
+      if (!clientRef.current) return;
+      if (!isVisible || !windowFocusedRef.current) return;
+
+      const activeDisplay = displayElementRef.current;
+      const stillFocused =
+        !!activeDisplay &&
+        typeof document !== "undefined" &&
+        document.activeElement === activeDisplay;
+
+      if (!hasKeyboardFocusRef.current && !stillFocused) return;
+      clientRef.current.sendKeyEvent(0, keysym);
+    };
+  }, [isVisible]);
+
   const rescaleDisplay = useCallback((immediate: boolean = false) => {
     if (!clientRef.current || !containerRef.current) return;
 
@@ -241,6 +303,7 @@ export const GuacamoleDisplay = forwardRef<
 
     const display = client.getDisplay();
     const displayElement = display.getElement();
+    displayElementRef.current = displayElement;
 
     if (displayRef.current) {
       displayRef.current.innerHTML = "";
@@ -278,12 +341,21 @@ export const GuacamoleDisplay = forwardRef<
 
     const keyboard = new Guacamole.Keyboard(displayElement);
     keyboardRef.current = keyboard;
-    keyboard.onkeydown = (keysym: number) => {
-      client.sendKeyEvent(1, keysym);
+
+    const handleDisplayFocus = () => {
+      hasKeyboardFocusRef.current = true;
+      refreshKeyboardHandlers();
     };
-    keyboard.onkeyup = (keysym: number) => {
-      client.sendKeyEvent(0, keysym);
+
+    const handleDisplayBlur = () => {
+      hasKeyboardFocusRef.current = false;
+      refreshKeyboardHandlers();
     };
+
+    displayElement.addEventListener("focus", handleDisplayFocus);
+    displayElement.addEventListener("blur", handleDisplayBlur);
+    displayElement.addEventListener("mousedown", handleDisplayFocus);
+    refreshKeyboardHandlers();
 
     client.onstatechange = (state: number) => {
       switch (state) {
@@ -304,8 +376,8 @@ export const GuacamoleDisplay = forwardRef<
         case 5:
           setIsConnecting(false);
           setIsReady(false);
-          keyboard.onkeydown = null;
-          keyboard.onkeyup = null;
+          hasKeyboardFocusRef.current = false;
+          refreshKeyboardHandlers();
           onDisconnect?.();
           break;
       }
@@ -336,7 +408,14 @@ export const GuacamoleDisplay = forwardRef<
     };
 
     client.connect();
-  }, [getWebSocketUrl, onConnect, onDisconnect, onError, rescaleDisplay]);
+  }, [
+    getWebSocketUrl,
+    onConnect,
+    onDisconnect,
+    onError,
+    refreshKeyboardHandlers,
+    rescaleDisplay,
+  ]);
 
   const hasInitiatedRef = useRef(false);
   const isMountedRef = useRef(false);
@@ -356,23 +435,44 @@ export const GuacamoleDisplay = forwardRef<
   }, [isVisible, connect]);
 
   useEffect(() => {
-    const keyboard = keyboardRef.current;
-    const client = clientRef.current;
-    if (!keyboard || !client) return;
-
-    if (isVisible) {
-      keyboard.onkeydown = (keysym: number) => {
-        client.sendKeyEvent(1, keysym);
-      };
-      keyboard.onkeyup = (keysym: number) => {
-        client.sendKeyEvent(0, keysym);
-      };
-    } else {
-      keyboard.onkeydown = null;
-      keyboard.onkeyup = null;
-      keyboard.reset();
+    if (!isVisible) {
+      hasKeyboardFocusRef.current = false;
     }
-  }, [isVisible]);
+
+    refreshKeyboardHandlers();
+  }, [isVisible, refreshKeyboardHandlers]);
+
+  useEffect(() => {
+    const handleWindowFocus = () => {
+      windowFocusedRef.current = true;
+      refreshKeyboardHandlers();
+    };
+
+    const handleWindowBlur = () => {
+      windowFocusedRef.current = false;
+      hasKeyboardFocusRef.current = false;
+      refreshKeyboardHandlers();
+    };
+
+    const handleVisibilityChange = () => {
+      windowFocusedRef.current =
+        document.visibilityState === "visible" && document.hasFocus();
+      if (document.visibilityState !== "visible") {
+        hasKeyboardFocusRef.current = false;
+      }
+      refreshKeyboardHandlers();
+    };
+
+    window.addEventListener("focus", handleWindowFocus);
+    window.addEventListener("blur", handleWindowBlur);
+    document.addEventListener("visibilitychange", handleVisibilityChange);
+
+    return () => {
+      window.removeEventListener("focus", handleWindowFocus);
+      window.removeEventListener("blur", handleWindowBlur);
+      document.removeEventListener("visibilitychange", handleVisibilityChange);
+    };
+  }, [refreshKeyboardHandlers]);
 
   useEffect(() => {
     return () => {
@@ -386,6 +486,7 @@ export const GuacamoleDisplay = forwardRef<
         clientRef.current.disconnect();
         clientRef.current = null;
       }
+      displayElementRef.current = null;
     };
   }, []);
 


### PR DESCRIPTION
# Overview

Guacamole keyboard handling is refactored so key events are only forwarded when the session should capture input: correct visibility, window focus, and focus on (or explicit interaction with) the display. This reduces stray keystrokes and stuck keys when switching tabs or windows.

- [x] Added: `refreshKeyboardHandlers()`, refs for display element, keyboard focus, and window focus; listeners for display focus/blur/mousedown and window focus/blur/`visibilitychange`.
- [x] Updated: Connection and visibility effects delegate to the centralized refresh logic; disconnect clears focus state via the same path.
- [x] Fixed: Unreliable or leaky Guacamole keyboard capture relative to focus/visibility.

# Changes Made

- `GuacamoleDisplay.tsx` only; behavior is intentionally gated on `document.activeElement`, `document.visibilityState`, and internal focus flags.

# Related Issues

- Closes Termix-SSH/Support#642

# Checklist

- [x] Code follows project style guidelines
- [x] Supports mobile and desktop UI/app (if applicable) — desktop Guacamole; mobile differs if applicable.
- [x] I have read [Contributing.md](https://github.com/Termix-SSH/Termix/blob/main/CONTRIBUTING.md)
- [x] This is not a translation request. See [docs](https://docs.termix.site/translations)