### PR TITLE
Improve Docker container grid list UI

### DIFF
--- a/src/index.css
+++ b/src/index.css
@@ -553,3 +553,7 @@
 .skinny-scrollbar::-webkit-scrollbar-thumb:hover {
   background: var(--scrollbar-thumb-hover);
 }
+
+.h-fade {
+  mask-image: linear-gradient(transparent, #000 6%, #000 94%, transparent);
+}

--- a/src/ui/desktop/apps/features/docker/DockerManager.tsx
+++ b/src/ui/desktop/apps/features/docker/DockerManager.tsx
@@ -661,7 +661,7 @@ function DockerManagerInner({
 
         <div className="flex-1 overflow-hidden min-h-0 relative">
           {viewMode === "list" ? (
-            <div className="h-full min-h-0 px-4 py-4">
+            <div className="h-full min-h-0 px-4 pt-4">
               {sessionId ? (
                 isLoadingContainers && containers.length === 0 ? (
                   <SimpleLoader

--- a/src/ui/desktop/apps/features/docker/components/ContainerList.tsx
+++ b/src/ui/desktop/apps/features/docker/components/ContainerList.tsx
@@ -69,7 +69,7 @@ export function ContainerList({
   }
 
   return (
-    <div className="flex flex-col h-full min-h-0 gap-3">
+    <div className="flex flex-col h-full min-h-0">
       <div className="flex flex-col sm:flex-row gap-2">
         <div className="relative flex-1">
           <Search className="absolute left-3 top-1/2 transform -translate-y-1/2 h-4 w-4 text-muted-foreground" />
@@ -117,7 +117,7 @@ export function ContainerList({
           </div>
         </div>
       ) : (
-        <div className="min-h-0 flex-1 overflow-auto thin-scrollbar pr-1">
+        <div className="min-h-0 flex-1 overflow-auto thin-scrollbar h-fade pr-1 pb-2 pt-4">
           <div className="grid grid-cols-[repeat(auto-fit,minmax(320px,1fr))] gap-3 auto-rows-min content-start w-full pb-2">
             {filteredContainers.map((container) => (
               <ContainerCard


### PR DESCRIPTION
# Overview

Remove the ugly Docker container grid overflow cuts to replace them with nice a nice fading effect

- [x] Added: fading effect at the top and bottom of the grid (new `h-fade` class)
- [x] Removed: useless padding causing a hard cut-off
- [x] Fixed: the ugly™

# Related Issues

None, I just wanted to improve the UI because iirc I'm the one who made that part ugly in the first place.

# Screenshots / Demos

Before (ugly, hard cut, nonsense):
<img width="407" height="79" alt="image" src="https://github.com/user-attachments/assets/ccb8fab2-1422-405d-b471-e6aa2610cc02" />

After (beautiful, gradient, logical):
<img width="405" height="70" alt="image" src="https://github.com/user-attachments/assets/d940f33a-9d56-4bf5-941f-5a98814c8ac8" />

# Checklist

- [x] Code follows project style guidelines
- [x] Supports mobile and desktop UI/app (if applicable)
- [x] I have read [Contributing.md](https://github.com/Termix-SSH/Termix/blob/main/CONTRIBUTING.md)
- [x] This is not a translation request. See [docs](https://docs.termix.site/translations)
