### PR TITLE
feat: prompt user for SSH key passphrase on use

### DIFF
--- a/src/backend/ssh/terminal.ts
+++ b/src/backend/ssh/terminal.ts
@@ -898,6 +898,8 @@ wss.on("connection", async (ws: WebSocket, req) => {
           credentialsData.hostConfig.key = credentialsData.sshKey;
           credentialsData.hostConfig.keyPassword = credentialsData.keyPassword;
           credentialsData.hostConfig.authType = "key";
+        } else if (credentialsData.keyPassword) {
+          credentialsData.hostConfig.keyPassword = credentialsData.keyPassword;
         }
 
         isAwaitingAuthCredentials = false;
@@ -1735,6 +1737,31 @@ wss.on("connection", async (ws: WebSocket, req) => {
             hostId: id,
             message:
               "OPKSSH authentication failed or expired. Please authenticate again.",
+          }),
+        );
+        return;
+      }
+
+      if (
+        err.message.includes("Cannot parse privateKey") &&
+        err.message.includes("no passphrase")
+      ) {
+        sendLog(
+          "auth",
+          "error",
+          "SSH key is encrypted but no passphrase was provided",
+        );
+        isAwaitingAuthCredentials = true;
+        if (currentSessionId) {
+          sessionManager.destroySession(currentSessionId);
+          currentSessionId = null;
+        }
+        cleanupAuthState(connectionTimeout);
+        ws.send(
+          JSON.stringify({
+            type: "passphrase_required",
+            message:
+              "The SSH key is encrypted. Please enter the passphrase to unlock it.",
           }),
         );
         return;

--- a/src/locales/en.json
+++ b/src/locales/en.json
@@ -2223,6 +2223,8 @@
     "sshProvideCredentialsDescription": "Please provide your SSH credentials to connect to this server.",
     "sshPasswordDescription": "Enter the password for this SSH connection.",
     "sshKeyPasswordDescription": "If your SSH key is encrypted, enter the passphrase here.",
+    "passphraseRequired": "Passphrase Required",
+    "passphraseRequiredDescription": "The SSH key is encrypted. Please enter the passphrase to unlock it.",
     "step1ScanQR": "Step 1: Scan the QR code with your authenticator app",
     "manualEntryCode": "Manual Entry Code",
     "cannotScanQRText": "If you can't scan the QR code, enter this code manually in your authenticator app",

--- a/src/ui/desktop/apps/features/terminal/Terminal.tsx
+++ b/src/ui/desktop/apps/features/terminal/Terminal.tsx
@@ -27,6 +27,7 @@ import {
 } from "@/ui/main-axios.ts";
 import { TOTPDialog } from "@/ui/desktop/navigation/dialogs/TOTPDialog.tsx";
 import { SSHAuthDialog } from "@/ui/desktop/navigation/dialogs/SSHAuthDialog.tsx";
+import { PassphraseDialog } from "@/ui/desktop/navigation/dialogs/PassphraseDialog.tsx";
 import { WarpgateDialog } from "@/ui/desktop/navigation/dialogs/WarpgateDialog.tsx";
 import { OPKSSHDialog } from "@/ui/desktop/navigation/dialogs/OPKSSHDialog.tsx";
 import { HostKeyVerificationDialog } from "@/ui/desktop/navigation/dialogs/HostKeyVerificationDialog.tsx";
@@ -288,6 +289,7 @@ const TerminalInner = forwardRef<TerminalHandle, SSHTerminalProps>(
     const [authDialogReason, setAuthDialogReason] = useState<
       "no_keyboard" | "auth_failed" | "timeout"
     >("no_keyboard");
+    const [showPassphraseDialog, setShowPassphraseDialog] = useState(false);
     const [keyboardInteractiveDetected, setKeyboardInteractiveDetected] =
       useState(false);
     const [warpgateAuthRequired, setWarpgateAuthRequired] = useState(false);
@@ -700,6 +702,32 @@ const TerminalInner = forwardRef<TerminalHandle, SSHTerminalProps>(
 
     function handleAuthDialogCancel() {
       setShowAuthDialog(false);
+      if (onClose) onClose();
+    }
+
+    function handlePassphraseSubmit(passphrase: string) {
+      if (webSocketRef.current && terminal) {
+        webSocketRef.current.send(
+          JSON.stringify({
+            type: "reconnect_with_credentials",
+            data: {
+              cols: terminal.cols,
+              rows: terminal.rows,
+              keyPassword: passphrase,
+              hostConfig: {
+                ...hostConfig,
+                keyPassword: passphrase,
+              },
+            },
+          }),
+        );
+        setShowPassphraseDialog(false);
+        setIsConnecting(true);
+      }
+    }
+
+    function handlePassphraseCancel() {
+      setShowPassphraseDialog(false);
       if (onClose) onClose();
     }
 
@@ -1497,6 +1525,13 @@ const TerminalInner = forwardRef<TerminalHandle, SSHTerminalProps>(
           } else if (msg.type === "auth_method_not_available") {
             setAuthDialogReason("no_keyboard");
             setShowAuthDialog(true);
+            setIsConnecting(false);
+            if (connectionTimeoutRef.current) {
+              clearTimeout(connectionTimeoutRef.current);
+              connectionTimeoutRef.current = null;
+            }
+          } else if (msg.type === "passphrase_required") {
+            setShowPassphraseDialog(true);
             setIsConnecting(false);
             if (connectionTimeoutRef.current) {
               clearTimeout(connectionTimeoutRef.current);
@@ -2620,6 +2655,19 @@ const TerminalInner = forwardRef<TerminalHandle, SSHTerminalProps>(
           reason={authDialogReason}
           onSubmit={handleAuthDialogSubmit}
           onCancel={handleAuthDialogCancel}
+          hostInfo={{
+            ip: hostConfig.ip,
+            port: hostConfig.port,
+            username: hostConfig.username,
+            name: hostConfig.name,
+          }}
+          backgroundColor={backgroundColor}
+        />
+
+        <PassphraseDialog
+          isOpen={showPassphraseDialog}
+          onSubmit={handlePassphraseSubmit}
+          onCancel={handlePassphraseCancel}
           hostInfo={{
             ip: hostConfig.ip,
             port: hostConfig.port,

--- a/src/ui/desktop/navigation/dialogs/PassphraseDialog.tsx
+++ b/src/ui/desktop/navigation/dialogs/PassphraseDialog.tsx
@@ -1,0 +1,88 @@
+import React from "react";
+import { Button } from "@/components/ui/button.tsx";
+import { PasswordInput } from "@/components/ui/password-input.tsx";
+import { Label } from "@/components/ui/label.tsx";
+import { KeyRound } from "lucide-react";
+import { useTranslation } from "react-i18next";
+
+interface PassphraseDialogProps {
+  isOpen: boolean;
+  onSubmit: (passphrase: string) => void;
+  onCancel: () => void;
+  hostInfo: { ip: string; port: number; username: string; name?: string };
+  backgroundColor?: string;
+}
+
+export function PassphraseDialog({
+  isOpen,
+  onSubmit,
+  onCancel,
+  hostInfo,
+  backgroundColor,
+}: PassphraseDialogProps) {
+  const { t } = useTranslation();
+
+  if (!isOpen) return null;
+
+  const hostDisplay = hostInfo.name
+    ? `${hostInfo.name} (${hostInfo.username}@${hostInfo.ip}:${hostInfo.port})`
+    : `${hostInfo.username}@${hostInfo.ip}:${hostInfo.port}`;
+
+  return (
+    <div className="absolute inset-0 flex items-center justify-center z-500 animate-in fade-in duration-200">
+      <div
+        className="absolute inset-0 bg-canvas rounded-md"
+        style={{ backgroundColor: backgroundColor || undefined }}
+      />
+      <div className="bg-elevated border-2 border-edge rounded-lg p-6 max-w-md w-full mx-4 relative z-10 animate-in fade-in zoom-in-95 duration-200">
+        <div className="mb-4">
+          <div className="flex items-center gap-2">
+            <KeyRound className="w-5 h-5 text-primary" />
+            <h3 className="text-lg font-semibold">
+              {t("auth.passphraseRequired")}
+            </h3>
+          </div>
+          <p className="text-sm text-muted-foreground mt-1">{hostDisplay}</p>
+        </div>
+        <form
+          onSubmit={(e) => {
+            e.preventDefault();
+            const input = e.currentTarget.elements.namedItem(
+              "passphrase",
+            ) as HTMLInputElement;
+            if (input && input.value) {
+              onSubmit(input.value);
+            }
+          }}
+          className="space-y-4"
+        >
+          <div>
+            <Label htmlFor="passphrase">
+              {t("auth.passphraseRequiredDescription")}
+            </Label>
+            <PasswordInput
+              id="passphrase"
+              name="passphrase"
+              autoFocus
+              placeholder={t("placeholders.keyPassword")}
+              className="mt-1.5"
+            />
+          </div>
+          <div className="flex gap-2">
+            <Button type="submit" className="flex-1">
+              {t("common.connect")}
+            </Button>
+            <Button
+              type="button"
+              variant="outline"
+              onClick={onCancel}
+              className="flex-1"
+            >
+              {t("common.cancel")}
+            </Button>
+          </div>
+        </form>
+      </div>
+    </div>
+  );
+}

--- a/src/ui/mobile/apps/terminal/Terminal.tsx
+++ b/src/ui/mobile/apps/terminal/Terminal.tsx
@@ -30,6 +30,7 @@ import {
 import type { TerminalConfig } from "@/types";
 import { TOTPDialog } from "@/ui/desktop/navigation/dialogs/TOTPDialog.tsx";
 import { SSHAuthDialog } from "@/ui/desktop/navigation/dialogs/SSHAuthDialog.tsx";
+import { PassphraseDialog } from "@/ui/desktop/navigation/dialogs/PassphraseDialog.tsx";
 import { WarpgateDialog } from "@/ui/desktop/navigation/dialogs/WarpgateDialog.tsx";
 import {
   ConnectionLogProvider,
@@ -119,6 +120,7 @@ const TerminalInner = forwardRef<TerminalHandle, SSHTerminalProps>(
     const [authDialogReason, setAuthDialogReason] = useState<
       "no_keyboard" | "auth_failed" | "timeout"
     >("no_keyboard");
+    const [showPassphraseDialog, setShowPassphraseDialog] = useState(false);
     const [warpgateAuthRequired, setWarpgateAuthRequired] = useState(false);
     const [warpgateAuthUrl, setWarpgateAuthUrl] = useState<string>("");
     const [warpgateSecurityKey, setWarpgateSecurityKey] = useState<string>("");
@@ -330,6 +332,32 @@ const TerminalInner = forwardRef<TerminalHandle, SSHTerminalProps>(
 
     function handleAuthDialogCancel() {
       setShowAuthDialog(false);
+      webSocketRef.current?.close();
+    }
+
+    function handlePassphraseSubmit(passphrase: string) {
+      if (webSocketRef.current && terminal) {
+        webSocketRef.current.send(
+          JSON.stringify({
+            type: "reconnect_with_credentials",
+            data: {
+              cols: terminal.cols,
+              rows: terminal.rows,
+              keyPassword: passphrase,
+              hostConfig: {
+                ...hostConfig,
+                keyPassword: passphrase,
+              },
+            },
+          }),
+        );
+        setShowPassphraseDialog(false);
+        setIsConnecting(true);
+      }
+    }
+
+    function handlePassphraseCancel() {
+      setShowPassphraseDialog(false);
       webSocketRef.current?.close();
     }
 
@@ -810,6 +838,13 @@ const TerminalInner = forwardRef<TerminalHandle, SSHTerminalProps>(
               clearTimeout(connectionTimeoutRef.current);
               connectionTimeoutRef.current = null;
             }
+          } else if (msg.type === "passphrase_required") {
+            setShowPassphraseDialog(true);
+            setIsConnecting(false);
+            if (connectionTimeoutRef.current) {
+              clearTimeout(connectionTimeoutRef.current);
+              connectionTimeoutRef.current = null;
+            }
           } else if (msg.type === "tmux_sessions_available") {
             // On mobile, auto-attach to the first available session
             const sessions = msg.sessions as Array<{ name: string }>;
@@ -1197,6 +1232,19 @@ const TerminalInner = forwardRef<TerminalHandle, SSHTerminalProps>(
           reason={authDialogReason}
           onSubmit={handleAuthDialogSubmit}
           onCancel={handleAuthDialogCancel}
+          hostInfo={{
+            ip: hostConfig.ip,
+            port: hostConfig.port,
+            username: hostConfig.username,
+            name: hostConfig.name,
+          }}
+          backgroundColor={backgroundColor}
+        />
+
+        <PassphraseDialog
+          isOpen={showPassphraseDialog}
+          onSubmit={handlePassphraseSubmit}
+          onCancel={handlePassphraseCancel}
           hostInfo={{
             ip: hostConfig.ip,
             port: hostConfig.port,


### PR DESCRIPTION
## Summary

- When an encrypted SSH private key has no stored passphrase, prompt the user via a lightweight dialog instead of failing with `Cannot parse privateKey: Encrypted private OpenSSH key detected, but no passphrase given`
- Backend detects the passphrase error and sends a `passphrase_required` WebSocket message to the frontend
- A new `PassphraseDialog` component (single password input, minimal UI) handles the prompt on both desktop and mobile terminals
- User-entered passphrase is sent back via the existing `reconnect_with_credentials` message flow — no new protocol needed
- Hosts with a stored `keyPassword` continue to work as before (no behavioral change)

Closes Termix-SSH/Support#354

## Test plan

- [ ] Create a passphrase-protected SSH key, add it to a credential **without** filling in Key Password
- [ ] Connect to a host using that credential → passphrase dialog should appear
- [ ] Enter correct passphrase → connection succeeds
- [ ] Enter wrong passphrase → error message shown
- [ ] Connect with a credential that **has** a stored keyPassword → connects directly, no dialog
- [ ] Verify on both desktop and mobile web views