### PR TITLE
fix: pass JWT token in WebSocket URL for Electron desktop app

### DIFF
--- a/src/ui/desktop/apps/features/docker/components/ConsoleTerminal.tsx
+++ b/src/ui/desktop/apps/features/docker/components/ConsoleTerminal.tsx
@@ -263,7 +263,13 @@ export function ConsoleTerminal({
             })()
           : `${window.location.protocol === "https:" ? "wss" : "ws"}://${window.location.host}${getBasePath()}/docker/console/`;
 
-      const ws = new WebSocket(baseWsUrl);
+      let wsUrl = baseWsUrl;
+      if (isElectronApp && token) {
+        const separator = wsUrl.includes("?") ? "&" : "?";
+        wsUrl = `${wsUrl}${separator}token=${encodeURIComponent(token)}`;
+      }
+
+      const ws = new WebSocket(wsUrl);
 
       ws.onopen = () => {
         const cols = terminal.cols || 80;

--- a/src/ui/desktop/apps/features/terminal/Terminal.tsx
+++ b/src/ui/desktop/apps/features/terminal/Terminal.tsx
@@ -996,7 +996,13 @@ const TerminalInner = forwardRef<TerminalHandle, SSHTerminalProps>(
         connectionTimeoutRef.current = null;
       }
 
-      const ws = new WebSocket(baseWsUrl);
+      let wsUrl = baseWsUrl;
+      if (isElectron() && jwtToken) {
+        const separator = wsUrl.includes("?") ? "&" : "?";
+        wsUrl = `${wsUrl}${separator}token=${encodeURIComponent(jwtToken)}`;
+      }
+
+      const ws = new WebSocket(wsUrl);
       webSocketRef.current = ws;
       wasDisconnectedBySSH.current = false;
       updateConnectionError(null);


### PR DESCRIPTION
## Summary

- In Electron mode, JWT tokens are stored in `localStorage` (not cookies). WebSocket connections don't carry `localStorage` data, so the backend receives no auth token and closes with code 1008 ("Authentication required")
- Append the JWT token as a `?token=` query parameter to WebSocket URLs when running in Electron — the backend already supports reading from `url.query.token` (terminal.ts L418)
- Fix applies to both terminal and Docker console WebSocket connections
- Mobile terminal already does this correctly (L546), desktop was missing it

Closes Termix-SSH/Support#651

## Test plan

- [ ] Open the Electron desktop app connected to a remote Termix server
- [ ] SSH to any host → should connect successfully (no more 1008 error)
- [ ] Open a Docker console → should connect successfully
- [ ] Browser web app → still works as before (cookies still used)
- [ ] Verify the token is URL-encoded in the query parameter