### PR TITLE
feat: add LOG_TIMESTAMP_FORMAT env var for 24h/ISO log timestamps

### DIFF
--- a/src/backend/utils/logger.ts
+++ b/src/backend/utils/logger.ts
@@ -78,7 +78,17 @@ export class Logger {
   }
 
   private getTimeStamp(): string {
-    return chalk.gray(`[${new Date().toLocaleTimeString()}]`);
+    const now = new Date();
+    const format = process.env.LOG_TIMESTAMP_FORMAT?.toLowerCase();
+    let time: string;
+    if (format === "iso") {
+      time = now.toISOString();
+    } else if (format === "24h") {
+      time = now.toLocaleTimeString("en-GB", { hour12: false });
+    } else {
+      time = now.toLocaleTimeString();
+    }
+    return chalk.gray(`[${time}]`);
   }
 
   private sanitizeContext(context: LogContext): LogContext {


### PR DESCRIPTION
## Summary

- Add `LOG_TIMESTAMP_FORMAT` environment variable to control Docker log timestamp format
- Supported values: `24h` (e.g. `14:58:45`), `iso` (e.g. `2026-04-25T14:58:45.000Z`), or omit for current locale default (`2:58:45 PM`)
- Single-line change in `logger.ts` `getTimeStamp()` method

Usage in `docker-compose.yml`:
```yaml
environment:
  - LOG_TIMESTAMP_FORMAT=24h
```

Closes Termix-SSH/Support#650

## Test plan

- [ ] Set `LOG_TIMESTAMP_FORMAT=24h` → logs show `[14:58:45]`
- [ ] Set `LOG_TIMESTAMP_FORMAT=iso` → logs show `[2026-04-25T14:58:45.000Z]`
- [ ] Unset variable → logs show locale default `[2:58:45 PM]`