### PR TITLE
fix: show reconnect overlay when SSH server reboots

### DIFF
--- a/src/backend/ssh/terminal.ts
+++ b/src/backend/ssh/terminal.ts
@@ -1913,7 +1913,7 @@ wss.on("connection", async (ws: WebSocket, req) => {
             }),
           );
         }
-      } else if (!sshStream) {
+      } else {
         if (ws.readyState === WebSocket.OPEN) {
           ws.send(
             JSON.stringify({


### PR DESCRIPTION
## Summary

- When the remote server reboots during an active SSH session, the terminal hangs with a blinking cursor and no reconnect option appears
- Root cause: `sshConn.on("close")` only sent the `disconnected` WebSocket message when `sshStream` was null. During a reboot, the stream reference still exists, so the condition `else if (!sshStream)` was false — the frontend never got notified
- Additionally, the stream's own `close` handler relies on `sessionManager.getSession()`, but `sshConn.on("close")` already destroys the session first, so the stream handler's `disconnected` message also fails to send
- Fix: change `else if (!sshStream)` to `else` so the disconnect notification is always sent regardless of stream state (1 line change)

Closes Termix-SSH/Support#648

## Test plan

- [ ] SSH to a host, run `sudo reboot` → reconnect overlay should appear
- [ ] After server comes back up, click "Reconnect" → session resumes
- [ ] Normal disconnect (close tab, logout) → behavior unchanged
- [ ] Network interruption → existing reconnection logic still works