### PR TITLE
feat: support read-only Docker container mode

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -53,11 +53,9 @@ ENV DATA_DIR=/app/data \
 RUN apt-get update && apt-get install -y nginx gettext-base openssl ca-certificates gosu wget && \
     update-ca-certificates && \
     rm -rf /var/lib/apt/lists/* && \
-    mkdir -p /app/data /app/uploads /app/data/.opk /app/nginx /app/nginx/logs /app/nginx/cache /app/nginx/client_body && \
-    chown -R node:node /app && \
-    chmod 755 /app/data /app/uploads /app/data/.opk /app/nginx && \
-    touch /app/nginx/nginx.conf && \
-    chown node:node /app/nginx/nginx.conf
+    mkdir -p /app/data /app/uploads /app/data/.opk /app/nginx /tmp/nginx && \
+    chown -R node:node /app /tmp/nginx && \
+    chmod 755 /app/data /app/uploads /app/data/.opk /app/nginx /tmp/nginx
 
 COPY docker/nginx.conf /app/nginx/nginx.conf.template
 COPY docker/nginx-https.conf /app/nginx/nginx-https.conf.template

--- a/docker/entrypoint.sh
+++ b/docker/entrypoint.sh
@@ -7,14 +7,14 @@ PGID=${PGID:-1000}
 if [ "$(id -u)" = "0" ]; then
     if [ "$PUID" = "0" ]; then
         echo "Running as root (PUID=0, PGID=$PGID)"
-        chown -R root:root /app/data /app/uploads /app/nginx 2>/dev/null || true
+        chown -R root:root /app/data /app/uploads /tmp/nginx 2>/dev/null || true
     else
         echo "Setting up user permissions (PUID: $PUID, PGID: $PGID)..."
 
         groupmod -o -g "$PGID" node 2>/dev/null || true
         usermod -o -u "$PUID" node 2>/dev/null || true
 
-        chown -R node:node /app/data /app/uploads /app/nginx 2>/dev/null || true
+        chown -R node:node /app/data /app/uploads /tmp/nginx 2>/dev/null || true
 
         echo "User node is now UID: $PUID, GID: $PGID"
 
@@ -38,7 +38,8 @@ else
     NGINX_CONF_SOURCE="/app/nginx/nginx.conf.template"
 fi
 
-envsubst '${PORT} ${SSL_PORT} ${SSL_CERT_PATH} ${SSL_KEY_PATH}' < $NGINX_CONF_SOURCE > /app/nginx/nginx.conf
+mkdir -p /tmp/nginx
+envsubst '${PORT} ${SSL_PORT} ${SSL_CERT_PATH} ${SSL_KEY_PATH}' < $NGINX_CONF_SOURCE > /tmp/nginx/nginx.conf
 
 mkdir -p /app/data /app/uploads /app/data/.opk
 chmod 755 /app/data /app/uploads /app/data/.opk 2>/dev/null || true
@@ -132,7 +133,7 @@ EOF
 fi
 
 echo "Starting nginx..."
-nginx -c /app/nginx/nginx.conf
+nginx -c /tmp/nginx/nginx.conf
 
 echo "Starting backend services..."
 cd /app

--- a/docker/nginx-https.conf
+++ b/docker/nginx-https.conf
@@ -1,7 +1,7 @@
 worker_processes 1;
 master_process off;
-pid /app/nginx/nginx.pid;
-error_log /app/nginx/logs/error.log warn;
+pid /tmp/nginx/nginx.pid;
+error_log /tmp/nginx/error.log warn;
 
 events {
     worker_connections 1024;
@@ -11,13 +11,13 @@ http {
     include /etc/nginx/mime.types;
     default_type application/octet-stream;
 
-    access_log /app/nginx/logs/access.log;
+    access_log /tmp/nginx/access.log;
 
-    client_body_temp_path /app/nginx/client_body;
-    proxy_temp_path /app/nginx/proxy_temp;
-    fastcgi_temp_path /app/nginx/fastcgi_temp;
-    uwsgi_temp_path /app/nginx/uwsgi_temp;
-    scgi_temp_path /app/nginx/scgi_temp;
+    client_body_temp_path /tmp/nginx/client_body;
+    proxy_temp_path /tmp/nginx/proxy_temp;
+    fastcgi_temp_path /tmp/nginx/fastcgi_temp;
+    uwsgi_temp_path /tmp/nginx/uwsgi_temp;
+    scgi_temp_path /tmp/nginx/scgi_temp;
 
     sendfile on;
     keepalive_timeout 65;

--- a/docker/nginx.conf
+++ b/docker/nginx.conf
@@ -1,7 +1,7 @@
 worker_processes 1;
 master_process off;
-pid /app/nginx/nginx.pid;
-error_log /app/nginx/logs/error.log warn;
+pid /tmp/nginx/nginx.pid;
+error_log /tmp/nginx/error.log warn;
 
 events {
     worker_connections 1024;
@@ -11,13 +11,13 @@ http {
     include /etc/nginx/mime.types;
     default_type application/octet-stream;
 
-    access_log /app/nginx/logs/access.log;
+    access_log /tmp/nginx/access.log;
 
-    client_body_temp_path /app/nginx/client_body;
-    proxy_temp_path /app/nginx/proxy_temp;
-    fastcgi_temp_path /app/nginx/fastcgi_temp;
-    uwsgi_temp_path /app/nginx/uwsgi_temp;
-    scgi_temp_path /app/nginx/scgi_temp;
+    client_body_temp_path /tmp/nginx/client_body;
+    proxy_temp_path /tmp/nginx/proxy_temp;
+    fastcgi_temp_path /tmp/nginx/fastcgi_temp;
+    uwsgi_temp_path /tmp/nginx/uwsgi_temp;
+    scgi_temp_path /tmp/nginx/scgi_temp;
 
     sendfile on;
     keepalive_timeout 65;


### PR DESCRIPTION
## Summary

- Move all nginx runtime files (generated config, pid, logs, temp directories) from `/app/nginx/` to `/tmp/nginx/`
- Template files (`nginx.conf.template`, `nginx-https.conf.template`) stay in `/app/nginx/` as read-only assets
- `entrypoint.sh` creates `/tmp/nginx/` at startup and writes the generated `nginx.conf` there
- Dockerfile no longer creates runtime directories (`logs/`, `cache/`, `client_body/`) under `/app/nginx/`

This allows running the container with `read_only: true`:

```yaml
services:
  termix:
    read_only: true
    tmpfs:
      - /tmp
    # ...
```

Closes Termix-SSH/Support#647

## Test plan

- [ ] Build and run with default config → nginx starts normally
- [ ] Run with `read_only: true` + `tmpfs: /tmp` → container starts successfully
- [ ] Run with `ENABLE_SSL=true` + `read_only: true` → HTTPS config generated in `/tmp/nginx/`
- [ ] Verify nginx logs appear in `/tmp/nginx/`
- [ ] Verify all proxy routes still work (terminal, file manager, docker, etc.)