### PR TITLE
fix: allow editing host without re-entering password

### DIFF
--- a/src/ui/desktop/apps/host-manager/hosts/HostManagerEditor.tsx
+++ b/src/ui/desktop/apps/host-manager/hosts/HostManagerEditor.tsx
@@ -496,7 +496,9 @@ export function HostManagerEditor({
       if (data.authType === "password") {
         if (
           !data.password ||
-          (typeof data.password === "string" && data.password.trim() === "")
+          (typeof data.password === "string" &&
+            data.password.trim() === "" &&
+            data.password !== "existing_password")
         ) {
           ctx.addIssue({
             code: z.ZodIssueCode.custom,
@@ -635,7 +637,11 @@ export function HostManagerEditor({
       return false;
 
     if (authTab === "password") {
-      if (!watchedFields.password || watchedFields.password.trim() === "")
+      if (
+        !watchedFields.password ||
+        (watchedFields.password !== "existing_password" &&
+          watchedFields.password.trim() === "")
+      )
         return false;
     } else if (authTab === "key") {
       if (!watchedFields.key || !watchedFields.keyType) return false;
@@ -858,7 +864,8 @@ export function HostManagerEditor({
           formData.password = cleanedHost.password;
         }
       } else if (defaultAuthType === "password") {
-        formData.password = cleanedHost.password || "";
+        formData.password =
+          cleanedHost.password || (editingHost.id ? "existing_password" : "");
       } else if (defaultAuthType === "key") {
         formData.key = editingHost.id ? "existing_key" : editingHost.key;
         formData.keyPassword = cleanedHost.keyPassword || "";
@@ -994,6 +1001,13 @@ export function HostManagerEditor({
         } else if (data.key === "existing_key") {
           delete submitData.key;
         }
+      }
+
+      if (
+        data.authType === "password" &&
+        data.password === "existing_password"
+      ) {
+        delete submitData.password;
       }
 
       let savedHost;


### PR DESCRIPTION
## Summary

- When editing an existing host with password auth, the backend strips the password from the API response (via `stripSensitiveFields`). The form then has an empty password field, which fails validation — the "Update Host" button is disabled even for non-auth changes like adding a folder
- Use an `"existing_password"` sentinel value (mirroring the existing `"existing_key"` pattern for SSH keys) to represent an unchanged password during editing
- Skip form validation for the sentinel value in both `isFormValid` and `superRefine`
- Omit the sentinel from the update payload so the backend preserves the existing password

Closes Termix-SSH/Support#645

## Test plan

- [ ] Create a host with password auth, no folder
- [ ] Edit the host, add a folder name → "Update Host" button should be enabled
- [ ] Click update → host saves with folder, password unchanged
- [ ] Edit the host, change the password to a new value → saves the new password
- [ ] Create a new host with password auth → still requires entering a password
- [ ] Edit a host with key/credential auth → behavior unchanged