### PR TITLE
fix: auto-close tab on graceful SSH disconnect

### DIFF
--- a/src/backend/ssh/terminal.ts
+++ b/src/backend/ssh/terminal.ts
@@ -1472,15 +1472,24 @@ wss.on("connection", async (ws: WebSocket, req) => {
             }
           });
 
-          stream.on("close", () => {
+          stream.on("close", (code: number | null) => {
             const session = sessionManager.getSession(boundSessionId);
             if (session?.attachedWs?.readyState === WebSocket.OPEN) {
-              session.attachedWs.send(
-                JSON.stringify({
-                  type: "disconnected",
-                  message: "Connection lost",
-                }),
-              );
+              if (code != null) {
+                session.attachedWs.send(
+                  JSON.stringify({
+                    type: "session_ended",
+                    code,
+                  }),
+                );
+              } else {
+                session.attachedWs.send(
+                  JSON.stringify({
+                    type: "disconnected",
+                    message: "Connection lost",
+                  }),
+                );
+              }
             }
             if (boundSessionId) {
               sessionManager.destroySession(boundSessionId);

--- a/src/locales/en.json
+++ b/src/locales/en.json
@@ -1656,6 +1656,7 @@
     "automaticFallback": "Automatically trying {{method}} authentication...",
     "totpTimeout": "TOTP verification timeout. Please reconnect.",
     "passwordTimeout": "Password verification timeout. Please reconnect.",
+    "sessionEnded": "Session ended.",
     "connectionRejected": "Connection rejected by server. Please check your authentication and network configuration.",
     "hostKeyRejected": "SSH host key verification rejected. Connection cancelled.",
     "sessionTakenOver": "Session was opened in another tab. Reconnecting...",

--- a/src/ui/desktop/apps/features/terminal/Terminal.tsx
+++ b/src/ui/desktop/apps/features/terminal/Terminal.tsx
@@ -1304,6 +1304,14 @@ const TerminalInner = forwardRef<TerminalHandle, SSHTerminalProps>(
                 );
               }
             }, 100);
+          } else if (msg.type === "session_ended") {
+            wasDisconnectedBySSH.current = true;
+            setIsConnected(false);
+            setIsConnecting(false);
+            shouldNotReconnectRef.current = true;
+            if (onClose) {
+              onClose();
+            }
           } else if (msg.type === "disconnected") {
             wasDisconnectedBySSH.current = true;
             setIsConnected(false);

--- a/src/ui/mobile/apps/terminal/Terminal.tsx
+++ b/src/ui/mobile/apps/terminal/Terminal.tsx
@@ -737,6 +737,13 @@ const TerminalInner = forwardRef<TerminalHandle, SSHTerminalProps>(
                 );
               }
             }, 100);
+          } else if (msg.type === "session_ended") {
+            wasDisconnectedBySSH.current = true;
+            shouldNotReconnectRef.current = true;
+            isConnectingRef.current = false;
+            setIsConnected(false);
+            setIsConnecting(false);
+            updateConnectionError(t("terminal.sessionEnded"));
           } else if (msg.type === "disconnected") {
             wasDisconnectedBySSH.current = true;
             isConnectingRef.current = false;


### PR DESCRIPTION
## Summary

- In v2.1.0, typing `exit` or Ctrl+D leaves the tab open with a "Reconnect / Close" overlay instead of auto-closing like v2.0.0
- Root cause: the stream `close` event sends the same `disconnected` message for both graceful exits and unexpected disconnections
- Fix: use the ssh2 stream close event's exit code parameter to distinguish the two cases:
  - `code != null` (shell exited normally) → send `session_ended` → frontend auto-closes the tab
  - `code == null` (unexpected disconnection) → send `disconnected` → frontend shows reconnect overlay
- Desktop terminal calls `onClose()` on `session_ended` to remove the tab
- Mobile terminal stops reconnection attempts and shows "Session ended"

Closes Termix-SSH/Support#643

## Test plan

- [ ] SSH to a host, type `exit` → tab closes automatically
- [ ] SSH to a host, press Ctrl+D → tab closes automatically
- [ ] SSH to a host, server reboots → reconnect overlay appears (not auto-close)
- [ ] SSH to a host, network drops → reconnect overlay appears
- [ ] Verify on both desktop and mobile web views