### PR TITLE
fix: reattach SSH session on WebSocket reconnect to prevent SSHGuard blocking

### DIFF
--- a/src/ui/desktop/apps/features/terminal/Terminal.tsx
+++ b/src/ui/desktop/apps/features/terminal/Terminal.tsx
@@ -1053,7 +1053,7 @@ const TerminalInner = forwardRef<TerminalHandle, SSHTerminalProps>(
         const savedSessionId = persistenceEnabled
           ? localStorage.getItem(`termix_session_${tabId}`)
           : null;
-        if (savedSessionId && !isReconnectingRef.current) {
+        if (savedSessionId) {
           sessionIdRef.current = savedSessionId;
           isAttachingSessionRef.current = true;
 


### PR DESCRIPTION
## Summary

- When the WebSocket connection drops (browser tab inactive, network blip), the reconnection logic creates a **new SSH connection with full password authentication** every time instead of reattaching to the existing SSH session
- This causes repeated auth attempts in short succession, triggering SSHGuard/fail2ban on the target host
- Root cause: the session reattach path in `connectToHost()` was guarded by `!isReconnectingRef.current`, which is always `true` during reconnection — so reattach was never attempted
- Fix: remove the `!isReconnectingRef.current` guard so reconnection tries `attachSession` first. If the session has expired, the backend responds with `sessionExpired`, the frontend clears state and falls back to a new connection (1 character change)

Closes Termix-SSH/Support#644

## Test plan

- [ ] Connect to a host with session persistence enabled
- [ ] Cause a WebSocket disconnect (e.g. toggle network briefly)
- [ ] Verify the reconnection reattaches the existing session (no new SSH auth in server logs)
- [ ] Wait for the SSH session to expire, then reconnect → should create a new connection
- [ ] Connect to a host with session persistence disabled → behavior unchanged (always new connection)
- [ ] Verify SSHGuard/fail2ban is no longer triggered by normal usage