### PR TITLE
fix: prevent browser crash when uploading large files

### DIFF
--- a/src/ui/desktop/apps/features/file-manager/FileManager.tsx
+++ b/src/ui/desktop/apps/features/file-manager/FileManager.tsx
@@ -699,19 +699,14 @@ function FileManagerContent({ initialHost, onClose }: FileManagerProps) {
         reader.onerror = () => reject(reader.error);
 
         reader.onload = () => {
-          if (reader.result instanceof ArrayBuffer) {
-            const bytes = new Uint8Array(reader.result);
-            let binary = "";
-            for (let i = 0; i < bytes.byteLength; i++) {
-              binary += String.fromCharCode(bytes[i]);
-            }
-            const base64 = btoa(binary);
+          if (typeof reader.result === "string") {
+            const base64 = reader.result.split(",")[1] || "";
             resolve(base64);
           } else {
             reject(new Error("Failed to read file"));
           }
         };
-        reader.readAsArrayBuffer(file);
+        reader.readAsDataURL(file);
       });
 
       await uploadSSHFile(


### PR DESCRIPTION
## Summary

- Uploading files >100MB crashes the browser tab with an out-of-memory error
- Root cause: the base64 encoding used a byte-by-byte `String.fromCharCode` loop to build an intermediate binary string, then called `btoa()` — for a 104MB file this creates ~350MB+ of intermediate string allocations
- Fix: replace with `FileReader.readAsDataURL()` which delegates base64 encoding to the browser engine natively, avoiding the intermediate string allocations

```javascript
// Before (OOM on large files):
const bytes = new Uint8Array(reader.result);
let binary = "";
for (let i = 0; i < bytes.byteLength; i++) {
  binary += String.fromCharCode(bytes[i]);
}
const base64 = btoa(binary);

// After (native encoding, no intermediate strings):
reader.readAsDataURL(file);
const base64 = reader.result.split(",")[1];
```

Closes Termix-SSH/Support#577

## Test plan

- [ ] Upload a file >100MB → should complete without crashing the browser tab
- [ ] Upload a small file (<1MB) → still works as before
- [ ] Upload a binary file (e.g. .tar.gz) → content integrity preserved
- [ ] Upload a text file → content preserved