### PR TITLE
fix: support SSH multi-factor auth (publickey,password)

### DIFF
--- a/src/backend/ssh/terminal.ts
+++ b/src/backend/ssh/terminal.ts
@@ -2102,6 +2102,10 @@ wss.on("connection", async (ws: WebSocket, req) => {
         if (resolvedCredentials.keyPassword) {
           connectConfig.passphrase = resolvedCredentials.keyPassword;
         }
+
+        if (resolvedCredentials.password) {
+          connectConfig.password = resolvedCredentials.password;
+        }
       } catch (keyError) {
         sshLogger.error("SSH key format error: " + keyError.message);
         ws.send(


### PR DESCRIPTION
## Summary

- When `sshd_config` requires `AuthenticationMethods publickey,password`, Termix fails after the publickey step because the credential's password is never passed to ssh2
- The key auth branch in `terminal.ts` only set `connectConfig.privateKey` — after publickey partial auth succeeded, ssh2 fell back to `keyboard-interactive` (due to `tryKeyboard: true`) instead of `password`, which the server rejected
- Fix: when auth type is `key` and the credential also has a password, set `connectConfig.password` alongside `privateKey` so ssh2 can complete the `password` step after `publickey` succeeds

Closes Termix-SSH/Support#629

## Test plan

- [ ] Configure sshd with `AuthenticationMethods publickey,password` + `KbdInteractiveAuthentication no`
- [ ] Create a credential with auth type `key`, a private key, and a password
- [ ] Connect → publickey succeeds, then password step completes → shell opens
- [ ] Connect with key-only auth (no password on credential) → still works as before
- [ ] Connect with password-only auth → unchanged behavior