### PR TITLE
feat(oidc): add OIDC_ALLOW_REGISTRATION env to bypass allow_registration for OIDC sign-up

### DIFF
--- a/src/backend/database/routes/users.ts
+++ b/src/backend/database/routes/users.ts
@@ -1142,7 +1142,11 @@ router.get("/oidc/callback", async (req, res) => {
         }
       }
 
-      if (!isFirstUser) {
+      const oidcAllowRegistration =
+        (process.env.OIDC_ALLOW_REGISTRATION || "").trim().toLowerCase() ===
+        "true";
+
+      if (!isFirstUser && !oidcAllowRegistration) {
         try {
           const regRow = db.$client
             .prepare(


### PR DESCRIPTION
## Summary

- Adds an `OIDC_ALLOW_REGISTRATION` environment variable that lets admins keep password-based registration closed while still allowing new accounts to be provisioned via a trusted OIDC IdP.
- When `OIDC_ALLOW_REGISTRATION=true`, the OIDC callback skips the global `allow_registration` settings check; the existing `OIDC_ALLOWED_USERS` whitelist continues to gate who can sign up.
- Password registration (`POST /users/create`) is unchanged — it still honors the `allow_registration` setting.

## Why

Currently the `allow_registration` flag in the `settings` table blocks **both** registration paths:
- Password registration in [`POST /users/create`](src/backend/database/routes/users.ts#L333-L338)
- OIDC sign-up in [`GET /users/oidc/callback`](src/backend/database/routes/users.ts#L1145-L1173)

A common deployment pattern is "close password sign-up to the public, but onboard real users through SSO with `OIDC_ALLOWED_USERS` filtering" (e.g. authentik / Keycloak with a domain or email whitelist). Today this is impossible without flipping `allow_registration` on, which simultaneously re-opens password sign-up to anyone who hits the API.

This is observable in the logs as repeated `op:oidc_registration_disabled` warnings even when OIDC is properly configured and the user is in `OIDC_ALLOWED_USERS`.

## Behavior matrix

| `allow_registration` (DB) | `OIDC_ALLOW_REGISTRATION` (env) | Password sign-up | OIDC sign-up (in whitelist) |
| --- | --- | --- | --- |
| `false` | unset / `false` | blocked | blocked (current behavior) |
| `false` | `true` | blocked | **allowed** (new) |
| `true`  | any | allowed | allowed |

First-user bootstrap, the `OIDC_ALLOWED_USERS` whitelist, and the `GET/PATCH /users/registration-allowed` endpoints are not touched. No DB migration, no UI change.

## Test plan

- [x] `npm run build` passes (TypeScript type-check clean).
- [x] With `allow_registration=false` and `OIDC_ALLOW_REGISTRATION` unset: a new OIDC user is rejected with `?error=registration_disabled` (existing behavior).
- [x] With `allow_registration=false` and `OIDC_ALLOW_REGISTRATION=true`: a new OIDC user in `OIDC_ALLOWED_USERS` is created successfully on first login; password `POST /users/create` still returns the registration-disabled error.
- [x] With `OIDC_ALLOW_REGISTRATION=true` but the OIDC user not in `OIDC_ALLOWED_USERS`: rejected with `?error=user_not_allowed` (whitelist still enforced).