### PR TITLE
fix: pass JWT token in Electron API requests and WebSocket connections

### DIFF
--- a/src/ui/desktop/apps/features/docker/components/ConsoleTerminal.tsx
+++ b/src/ui/desktop/apps/features/docker/components/ConsoleTerminal.tsx
@@ -267,7 +267,13 @@ export function ConsoleTerminal({
             })()
           : `${window.location.protocol === "https:" ? "wss" : "ws"}://${window.location.host}${getBasePath()}/docker/console/`;
 
-      const ws = new WebSocket(baseWsUrl);
+      let wsUrl = baseWsUrl;
+      if (isElectronApp && token) {
+        const separator = wsUrl.includes("?") ? "&" : "?";
+        wsUrl = `${wsUrl}${separator}token=${encodeURIComponent(token)}`;
+      }
+
+      const ws = new WebSocket(wsUrl);
 
       ws.onopen = () => {
         const cols = terminal.cols || 80;

--- a/src/ui/desktop/apps/features/terminal/Terminal.tsx
+++ b/src/ui/desktop/apps/features/terminal/Terminal.tsx
@@ -851,7 +851,13 @@ const TerminalInner = forwardRef<TerminalHandle, SSHTerminalProps>(
         connectionTimeoutRef.current = null;
       }
 
-      const ws = new WebSocket(baseWsUrl);
+      let wsUrl = baseWsUrl;
+      if (isElectron() && jwtToken) {
+        const separator = wsUrl.includes("?") ? "&" : "?";
+        wsUrl = `${wsUrl}${separator}token=${encodeURIComponent(jwtToken)}`;
+      }
+
+      const ws = new WebSocket(wsUrl);
       webSocketRef.current = ws;
       wasDisconnectedBySSH.current = false;
       updateConnectionError(null);

--- a/src/ui/main-axios.ts
+++ b/src/ui/main-axios.ts
@@ -382,6 +382,46 @@ function createApiInstance(
       }
     }
 
+    if (isElectron()) {
+      const localToken = localStorage.getItem("jwt");
+      if (localToken) {
+        if (config.headers.set) {
+          config.headers.set("Authorization", `Bearer ${localToken}`);
+        } else {
+          config.headers["Authorization"] = `Bearer ${localToken}`;
+        }
+        userWasAuthenticated = true;
+      }
+    } else {
+      const tokenCookie = document.cookie
+        .split("; ")
+        .find((row) => row.startsWith("jwt="));
+
+      if (tokenCookie) {
+        const tokenValue = tokenCookie.split("=")[1];
+        if (tokenValue) {
+          const decodedToken = decodeURIComponent(tokenValue);
+          if (config.headers.set) {
+            config.headers.set("Authorization", `Bearer ${decodedToken}`);
+          } else {
+            config.headers["Authorization"] = `Bearer ${decodedToken}`;
+          }
+          userWasAuthenticated = true;
+        }
+      } else {
+        const localToken = localStorage.getItem("jwt");
+        if (localToken) {
+          if (config.headers.set) {
+            config.headers.set("Authorization", `Bearer ${localToken}`);
+          } else {
+            config.headers["Authorization"] = `Bearer ${localToken}`;
+          }
+          userWasAuthenticated = true;
+        }
+      }
+    }
+
+
     return config;
   });
 


### PR DESCRIPTION
## Summary

In Electron mode, JWT is stored in `localStorage`, not cookies. Two auth paths were broken:

1. **HTTP API requests**: the axios request interceptor had `if (!isElectron())` guarding the `Authorization` header — Electron requests had no auth token at all. After ~20 seconds (when the initial cookie expired or was not sent cross-origin), all API calls returned 401
2. **WebSocket connections**: the Desktop terminal and Docker console created WebSocket URLs without appending the token as a query parameter. The backend reads from `url.query.token` as a fallback, but it was never passed. (Mobile already did this correctly at Terminal.tsx L546)

### Changes

- **`src/ui/main-axios.ts`**: Add Electron-specific branch in the request interceptor that reads JWT from `localStorage` and sets `Authorization: Bearer` header
- **`src/ui/desktop/apps/features/terminal/Terminal.tsx`**: Append `?token=` to WebSocket URL in Electron mode
- **`src/ui/desktop/apps/features/docker/components/ConsoleTerminal.tsx`**: Same fix for Docker console WebSocket

Closes Termix-SSH/Support#651
Closes Termix-SSH/Support#646

## Test plan

- [ ] Open Electron desktop app connected to a remote server
- [ ] Login → all API calls should work indefinitely (not just ~20 seconds)
- [ ] SSH terminal connection → should authenticate via WebSocket
- [ ] Docker console → should authenticate via WebSocket
- [ ] Web browser → behavior unchanged (cookie-based auth with header fallback)