### PR TITLE
Enhance VNC token generation to include optional username parameter and refactor username input handling in HostGeneralTab

### DIFF
--- a/src/backend/guacamole/routes.ts
+++ b/src/backend/guacamole/routes.ts
@@ -63,7 +63,7 @@ router.post("/token", async (req, res) => {
         );
         break;
       case "vnc":
-        token = tokenService.createVncToken(hostname, password, {
+        token = tokenService.createVncToken(hostname, username || undefined, password, {
           port: port || 5900,
           ...options,
         });
@@ -206,7 +206,7 @@ router.post(
           });
           break;
         case "vnc":
-          token = tokenService.createVncToken(hostname, password, {
+          token = tokenService.createVncToken(hostname, username || undefined, password, {
             port: port || 5900,
             ...guacConfig,
           });

--- a/src/backend/guacamole/token-service.ts
+++ b/src/backend/guacamole/token-service.ts
@@ -141,6 +141,7 @@ export class GuacamoleTokenService {
 
   createVncToken(
     hostname: string,
+    username?: string,
     password?: string,
     options: Partial<GuacamoleConnectionSettings["settings"]> = {},
   ): string {
@@ -149,6 +150,7 @@ export class GuacamoleTokenService {
         type: "vnc",
         settings: {
           hostname,
+          ...(username ? { username } : {}),
           password,
           port: 5900,
           ...options,

--- a/src/ui/desktop/apps/host-manager/hosts/tabs/HostGeneralTab.tsx
+++ b/src/ui/desktop/apps/host-manager/hosts/tabs/HostGeneralTab.tsx
@@ -224,52 +224,50 @@ export function HostGeneralTab({
           )}
         />
 
-        {connectionType !== "vnc" && (
-          <FormField
-            control={form.control}
-            name="username"
-            render={({ field }) => {
-              const isCredentialAuth = authTab === "credential";
-              const credentialId = form.watch("credentialId");
-              const overrideEnabled = form.watch("overrideCredentialUsername");
-              const selectedCredential = credentials.find(
-                (c) => c.id === credentialId,
-              );
-              const shouldDisable =
-                isCredentialAuth &&
-                selectedCredential?.username &&
-                !overrideEnabled;
+        <FormField
+          control={form.control}
+          name="username"
+          render={({ field }) => {
+            const isCredentialAuth = authTab === "credential";
+            const credentialId = form.watch("credentialId");
+            const overrideEnabled = form.watch("overrideCredentialUsername");
+            const selectedCredential = credentials.find(
+              (c) => c.id === credentialId,
+            );
+            const shouldDisable =
+              isCredentialAuth &&
+              selectedCredential?.username &&
+              !overrideEnabled;
 
-              return (
-                <FormItem className="col-span-6">
-                  <FormLabel>{t("hosts.username")}</FormLabel>
-                  <FormControl>
-                    <Input
-                      placeholder={t("placeholders.username")}
-                      disabled={shouldDisable}
-                      {...field}
-                      onChange={(e) => {
-                        field.onChange(e.target.value);
-                        if (
-                          isCredentialAuth &&
-                          selectedCredential &&
-                          !selectedCredential.username &&
-                          e.target.value.trim() !== ""
-                        ) {
-                          form.setValue("overrideCredentialUsername", true);
-                        }
-                      }}
-                      onBlur={(e) => {
-                        field.onChange(e.target.value.trim());
-                        field.onBlur();
-                      }}
-                    />
-                  </FormControl>
-                </FormItem>
-              );
-            }}
-          />
-        )}
+            return (
+              <FormItem className="col-span-6">
+                <FormLabel>{t("hosts.username")}</FormLabel>
+                <FormControl>
+                  <Input
+                    placeholder={t("placeholders.username")}
+                    disabled={shouldDisable}
+                    {...field}
+                    onChange={(e) => {
+                      field.onChange(e.target.value);
+                      if (
+                        isCredentialAuth &&
+                        selectedCredential &&
+                        !selectedCredential.username &&
+                        e.target.value.trim() !== ""
+                      ) {
+                        form.setValue("overrideCredentialUsername", true);
+                      }
+                    }}
+                    onBlur={(e) => {
+                      field.onChange(e.target.value.trim());
+                      field.onBlur();
+                    }}
+                  />
+                </FormControl>
+              </FormItem>
+            );
+          }}
+        />
       </div>
       <div className="grid grid-cols-12 gap-4 mt-3">
         <FormField


### PR DESCRIPTION
# Overview

This PR updates the VNC connection flow to support passing an optional username, aligning both backend and frontend to handle this new capability.

- [X] Added: Optional `username` support for VNC connections
- [X] Updated: Backend token generation and API routes to include username
~- [ ] Removed: ...~
- [X] Fixed: VNC to macOS (as mentioned here: https://github.com/Termix-SSH/Support/issues/567#issuecomment-4180579131)

# Changes Made

- Backend:
  - Added optional `username` parameter to `createVncToken` in `GuacamoleTokenService`
  - Included `username` in VNC connection settings when provided
  - Updated VNC API routes to pass the `username` parameter during token creation

- Frontend:
  - Updated `HostGeneralTab` form to always display the username field
  - Enabled users to input a username for VNC connections (previously hidden for VNC)

# Related Issues

- Related to #[567](https://github.com/Termix-SSH/Support/issues/567)

~# Screenshots / Demos~

_(Optional: add before/after screenshots, GIFs, or console output)_

# Checklist

- [X] Code follows project style guidelines
~- [ ] Supports mobile and desktop UI/app (if applicable)~
- [X] I have read [Contributing.md](https://github.com/Termix-SSH/Termix/blob/main/CONTRIBUTING.md)
- [X] This is not a translation request. See [docs](https://docs.termix.site/translations)