### PR TITLE
fix: fetch password from API for Copy Password button

### DIFF
--- a/src/ui/desktop/navigation/tabs/Tab.tsx
+++ b/src/ui/desktop/navigation/tabs/Tab.tsx
@@ -75,15 +75,13 @@ export function Tab({
 
     if (!hasSshPw && !hasSudoPw) return;
 
-    let passwordToCopy = "";
+    const field = hasSshPw ? "password" : "sudoPassword";
+    const passwordToCopy = await getHostPassword(hostConfig.id, field);
 
-    if (hasSshPw) {
-      passwordToCopy = hostConfig.password || "";
-    } else if (hasSudoPw) {
-      passwordToCopy = hostConfig.sudoPassword;
+    if (!passwordToCopy) {
+      toast.error(t("nav.failedToCopyPassword"));
+      return;
     }
-
-    if (!passwordToCopy) return;
 
     try {
       await navigator.clipboard.writeText(passwordToCopy);


### PR DESCRIPTION
## Summary

The "Copy Password" button in terminal tabs silently fails because the backend strips `password` from host API responses (`stripSensitiveFields`), leaving only `hasPassword: true`. The handler was reading `hostConfig.password` which is always `undefined`.

- Use `getHostPassword()` to fetch the password on demand via `/db/host/:id/password`
- The API endpoint and client wrapper already existed (added in #669) but were never called

No security concern — the endpoint requires JWT auth, data access permission, and scopes queries to `userId`.

Closes Termix-SSH/Support#614

## Test plan
- [ ] Click "Copy Password" on a password-auth SSH tab → password copied
- [ ] Click "Copy Password" on a sudo-password tab → sudo password copied
- [ ] Works on both HTTP and HTTPS contexts
- [ ] Works in Firefox and Chromium-based browsers