### PR TITLE
fix: restore missing getHostPassword import

### DIFF
--- a/src/ui/desktop/navigation/tabs/Tab.tsx
+++ b/src/ui/desktop/navigation/tabs/Tab.tsx
@@ -1,6 +1,7 @@
 import React from "react";
 import { Button } from "@/components/ui/button.tsx";
 import { useTranslation } from "react-i18next";
+import { getHostPassword } from "@/ui/main-axios.ts";
 import { cn } from "@/lib/utils";
 import {
   Home,


### PR DESCRIPTION
## Summary

The `getHostPassword` import was dropped during merge conflict resolution in 3e2de42. This breaks the Copy Password button added in #736 — the function is called but never imported.

One-line fix: re-add the import.