### PR TITLE
fix: start packaged backend from unpacked app directory

### DIFF
--- a/electron-builder.json
+++ b/electron-builder.json
@@ -6,7 +6,7 @@
     "output": "release"
   },
   "asar": true,
-  "asarUnpack": ["dist/backend/**/*", "node_modules/**/*.node"],
+  "asarUnpack": ["dist/backend/**/*", "node_modules/**/*"],
   "files": [
     "dist/**/*",
     "electron/**/*",

--- a/electron/main.cjs
+++ b/electron/main.cjs
@@ -569,6 +569,13 @@ function getBackendEntryPath() {
   return path.join(unpackedRoot, "dist", "backend", "backend", "starter.js");
 }
 
+function getBackendCwd() {
+  if (isDev) {
+    return appRoot;
+  }
+  return appRoot.replace("app.asar", "app.asar.unpacked");
+}
+
 function getBackendDataDir() {
   const userDataPath = app.getPath("userData");
   const dataDir = path.join(userDataPath, "server-data");
@@ -581,6 +588,7 @@ function getBackendDataDir() {
 function startBackendServer() {
   return new Promise((resolve) => {
     const entryPath = getBackendEntryPath();
+    const backendCwd = getBackendCwd();
 
     logToFile("isDev:", isDev, "appRoot:", appRoot);
     logToFile("app.isPackaged:", app.isPackaged);
@@ -596,14 +604,15 @@ function startBackendServer() {
     logToFile("Starting embedded backend server...");
     logToFile("Backend entry:", entryPath);
     logToFile("Data directory:", dataDir);
-    logToFile("Backend cwd:", appRoot);
+    logToFile("Backend cwd:", backendCwd);
 
     logToFile("Checking paths...");
     logToFile("  entryPath exists:", fs.existsSync(entryPath));
     logToFile("  dataDir exists:", fs.existsSync(dataDir));
     logToFile("  appRoot exists:", fs.existsSync(appRoot));
+    logToFile("  backendCwd exists:", fs.existsSync(backendCwd));
 
-    const distPath = path.join(appRoot, "dist");
+    const distPath = path.join(backendCwd, "dist");
     if (fs.existsSync(distPath)) {
       logToFile("  dist directory contents:", fs.readdirSync(distPath));
       const backendPath = path.join(distPath, "backend");
@@ -613,10 +622,11 @@ function startBackendServer() {
     }
 
     backendProcess = fork(entryPath, [], {
-      cwd: appRoot,
+      cwd: backendCwd,
       env: {
         ...process.env,
         DATA_DIR: dataDir,
+        VERSION: app.getVersion(),
         NODE_ENV: "production",
         ELECTRON_EMBEDDED: "true",
         PORT: "30001",


### PR DESCRIPTION
## Summary

Packaged Electron builds were forking the embedded backend with cwd set to app.asar. Since app.asar is a file, Linux packages fail with spawn ENOTDIR before the backend can start.

This uses the unpacked app directory as the backend cwd in packaged builds and unpacks runtime node_modules with the backend so ESM dependencies can resolve from app.asar.unpacked.

Fixes Termix-SSH/Support#667
Fixes Termix-SSH/Support#673
Fixes Termix-SSH/Support#677
Fixes Termix-SSH/Support#685

## Test plan

- [x] node --check electron/main.cjs
- [x] npx prettier --check electron/main.cjs electron-builder.json
- [x] npm run build:backend
- [x] npm run build:linux-portable
- [x] Verified release/linux-unpacked/resources/app.asar.unpacked contains dist/backend/backend and runtime node_modules