### PR TITLE
fix: restore mobile app auth token handoff

### DIFF
--- a/src/backend/database/routes/users.ts
+++ b/src/backend/database/routes/users.ts
@@ -51,6 +51,13 @@ import { getRequestOriginWithForceHTTPS } from "../../utils/request-origin.js";
 
 const authManager = AuthManager.getInstance();
 
+function isTermixMobileAppRequest(req: Request): boolean {
+  return (
+    req.get("X-Termix-Mobile-App") === "true" ||
+    (req.get("User-Agent") || "").includes("Termix-Mobile")
+  );
+}
+
 function getOIDCConfigFromEnv(): {
   client_id: string;
   client_secret: string;
@@ -830,6 +837,7 @@ router.get("/oidc/authorize", async (req, res) => {
     }
     const state = nanoid();
     const nonce = nanoid();
+    const isNativeMobileApp = isTermixMobileAppRequest(req);
 
     const referer = req.get("Referer");
     let frontendOrigin;
@@ -858,6 +866,9 @@ router.get("/oidc/authorize", async (req, res) => {
         `oidc_remember_me_${state}`,
         rememberMe === "true" ? "true" : "false",
       );
+    db.$client
+      .prepare("INSERT OR REPLACE INTO settings (key, value) VALUES (?, ?)")
+      .run(`oidc_native_mobile_${state}`, isNativeMobileApp ? "true" : "false");
 
     const authUrl = new URL(config.authorization_url);
     authUrl.searchParams.set("client_id", config.client_id);
@@ -904,6 +915,9 @@ router.get("/oidc/callback", async (req, res) => {
   const storedRememberMeRow = db.$client
     .prepare("SELECT value FROM settings WHERE key = ?")
     .get(`oidc_remember_me_${state}`);
+  const storedNativeMobileRow = db.$client
+    .prepare("SELECT value FROM settings WHERE key = ?")
+    .get(`oidc_native_mobile_${state}`);
 
   if (!storedBackendCallbackRow || !storedFrontendOriginRow) {
     return res
@@ -918,6 +932,8 @@ router.get("/oidc/callback", async (req, res) => {
     .value as string;
   const storedRememberMe =
     (storedRememberMeRow as Record<string, unknown> | null)?.value === "true";
+  const isNativeMobileApp =
+    (storedNativeMobileRow as Record<string, unknown> | null)?.value === "true";
 
   try {
     const storedNonce = db.$client
@@ -988,6 +1004,9 @@ router.get("/oidc/callback", async (req, res) => {
     db.$client
       .prepare("DELETE FROM settings WHERE key = ?")
       .run(`oidc_remember_me_${state}`);
+    db.$client
+      .prepare("DELETE FROM settings WHERE key = ?")
+      .run(`oidc_native_mobile_${state}`);
 
     let userInfo: Record<string, unknown> = null;
     const userInfoUrls: string[] = [];
@@ -1325,6 +1344,9 @@ router.get("/oidc/callback", async (req, res) => {
 
     const redirectUrl = new URL(frontendOrigin);
     redirectUrl.searchParams.set("success", "true");
+    if (isNativeMobileApp) {
+      redirectUrl.searchParams.set("token", token);
+    }
 
     const maxAge =
       deviceInfo.type === "desktop" || deviceInfo.type === "mobile"
@@ -1576,6 +1598,9 @@ router.post("/login", async (req, res) => {
       is_admin: !!userRecord.isAdmin,
       username: userRecord.username,
     };
+    if (isTermixMobileAppRequest(req)) {
+      response.token = token;
+    }
 
     const timeoutRow = db.$client
       .prepare("SELECT value FROM settings WHERE key = 'session_timeout_hours'")
@@ -3394,6 +3419,9 @@ router.post("/totp/verify-login", async (req, res) => {
       is_oidc: !!userRecord.isOidc,
       totp_enabled: !!userRecord.totpEnabled,
     };
+    if (isTermixMobileAppRequest(req)) {
+      response.token = token;
+    }
 
     const timeoutRow = db.$client
       .prepare("SELECT value FROM settings WHERE key = 'session_timeout_hours'")

--- a/src/ui/main-axios.ts
+++ b/src/ui/main-axios.ts
@@ -146,6 +146,7 @@ interface AuthResponse {
   data_unlocked?: boolean;
   requires_totp?: boolean;
   temp_token?: string;
+  token?: string;
   rememberMe?: boolean;
 }
 
@@ -402,8 +403,10 @@ function createApiInstance(
         }
       }
       if (config.headers.set) {
+        config.headers.set("X-Termix-Mobile-App", "true");
         config.headers.set("User-Agent", `Termix-Mobile/${platform}`);
       } else {
+        config.headers["X-Termix-Mobile-App"] = "true";
         config.headers["User-Agent"] = `Termix-Mobile/${platform}`;
       }
     }

--- a/src/ui/mobile/authentication/Auth.tsx
+++ b/src/ui/mobile/authentication/Auth.tsx
@@ -38,15 +38,20 @@ function isReactNativeWebView(): boolean {
   );
 }
 
-function postAuthSuccessToWebView() {
+function postAuthSuccessToWebView(token?: string) {
   if (!isReactNativeWebView()) {
     return;
   }
 
   try {
+    if (token) {
+      localStorage.setItem("jwt", token);
+    }
+
     (window as ReactNativeWindow).ReactNativeWebView?.postMessage(
       JSON.stringify({
         type: "AUTH_SUCCESS",
+        ...(token ? { token } : {}),
         source: "explicit",
         platform: "mobile",
         timestamp: Date.now(),
@@ -262,7 +267,7 @@ export function Auth({
       setUsername(meRes.username || null);
       setUserId(meRes.userId || null);
       setDbError(null);
-      postAuthSuccessToWebView();
+      postAuthSuccessToWebView(res.token);
 
       if (isReactNativeWebView()) {
         setMobileAuthSuccess(true);
@@ -462,7 +467,7 @@ export function Auth({
       setUserId(res.userId || null);
       setDbError(null);
 
-      postAuthSuccessToWebView();
+      postAuthSuccessToWebView(res.token);
 
       if (isReactNativeWebView()) {
         setMobileAuthSuccess(true);
@@ -583,11 +588,12 @@ export function Auth({
     if (success) {
       setOidcLoading(true);
       setError(null);
+      const urlToken = urlParams.get("token") || undefined;
 
       window.history.replaceState({}, document.title, window.location.pathname);
 
       if (isReactNativeWebView()) {
-        postAuthSuccessToWebView();
+        postAuthSuccessToWebView(urlToken);
         setMobileAuthSuccess(true);
         setOidcLoading(false);
         return;


### PR DESCRIPTION
## Summary

Mobile app login requests now identify themselves to the backend so native WebView flows can receive a JWT token without relying on browser cookies.

This preserves the native-app flag through OIDC authorize/callback, includes the token for mobile login and TOTP responses, and posts successful login/OIDC handoff messages from the current dev-2.3.0 auth page back to React Native.

Fixes Termix-SSH/Support#675
Refs Termix-SSH/Support#670

## Test plan

- [x] `npx prettier --check src/backend/database/routes/users.ts src/ui/main-axios.ts src/ui/auth/LoginPage.tsx`
- [x] `npm run build:backend`
- [x] `npm run type-check`
- [x] `git diff --check upstream/dev-2.3.0...HEAD`
