### PR TITLE
fix: decode oidc client_secret before token exchange

### DIFF
--- a/src/backend/database/routes/users.ts
+++ b/src/backend/database/routes/users.ts
@@ -949,6 +949,18 @@ router.get("/oidc/callback", async (req, res) => {
       config = JSON.parse(
         (configRow as Record<string, unknown>).value as string,
       );
+
+      if (config.client_secret?.startsWith("encrypted:")) {
+        config.client_secret = Buffer.from(
+          config.client_secret.substring(10),
+          "base64",
+        ).toString("utf8");
+      } else if (config.client_secret?.startsWith("encoded:")) {
+        config.client_secret = Buffer.from(
+          config.client_secret.substring(8),
+          "base64",
+        ).toString("utf8");
+      }
     }
 
     const tokenResponse = await fetch(config.token_url, {


### PR DESCRIPTION
## Summary

The OIDC callback route reads `client_secret` from the database but does not decode it before sending it to the OIDC provider. When the secret is stored with `encrypted:` or `encoded:` base64 prefix (fallback path when admin data key is unavailable), the raw prefixed string is sent as the client secret, causing the provider to reject it with "Invalid client secret".

## Changes

Decode `client_secret` in the callback route before performing the token exchange, matching the same decoding logic already present in the `/oidc-config/admin` GET endpoint.

## Related

Closes https://github.com/Termix-SSH/Support/issues/656