### PR TITLE
fix: align desktop/mobile jwt expiry with cookie maxAge

### DIFF
--- a/src/backend/utils/auth-manager.ts
+++ b/src/backend/utils/auth-manager.ts
@@ -331,7 +331,11 @@ class AuthManager {
 
     let expiresIn = options.expiresIn;
     if (!expiresIn && !options.pendingTOTP) {
-      if (options.rememberMe) {
+      if (
+        options.rememberMe ||
+        options.deviceType === "desktop" ||
+        options.deviceType === "mobile"
+      ) {
         expiresIn = "30d";
       } else {
         expiresIn = defaultExpiry;


### PR DESCRIPTION
## Summary

Desktop and mobile apps set cookie `maxAge` to 30 days regardless of `rememberMe`, but the JWT token's `expiresIn` only gets 30 days when `rememberMe` is true. Without it, the JWT expires in `session_timeout_hours` (default 24h) while the cookie persists for 30 days.

After the JWT expires, the next request (e.g. after a container restart) fails verification with an expired token error, returning 401 and forcing re-authentication.

## Changes

Treat `deviceType === "desktop"` or `deviceType === "mobile"` the same as `rememberMe` when determining JWT expiry, matching the existing cookie maxAge logic in the login routes.

## Related

Closes https://github.com/Termix-SSH/Support/issues/687
Closes https://github.com/Termix-SSH/Support/issues/616