### PR TITLE
fix: implement ssh agent forwarding with in-memory agent

### DIFF
--- a/src/backend/ssh/terminal.ts
+++ b/src/backend/ssh/terminal.ts
@@ -1,5 +1,15 @@
 import { WebSocketServer, WebSocket, type RawData } from "ws";
-import { Client, type ClientChannel, type PseudoTtyOptions } from "ssh2";
+import {
+  Client,
+  type ClientChannel,
+  type PseudoTtyOptions,
+  BaseAgent,
+  utils as ssh2Utils,
+  type ParsedKey,
+  type SignCallback,
+  type SigningRequestOptions,
+  type IdentityCallback,
+} from "ssh2";
 import net from "net";
 import dgram from "dgram";
 import { SSH_ALGORITHMS } from "../utils/ssh-algorithms.js";
@@ -24,6 +34,42 @@ import {
   attachOrCreateTmuxSession,
   queryNewestTmuxSession,
 } from "./tmux-helper.js";
+
+class MemoryAgent extends BaseAgent {
+  private key: ParsedKey;
+
+  constructor(key: ParsedKey) {
+    super();
+    this.key = key;
+  }
+
+  getIdentities(cb: IdentityCallback<ParsedKey>): void {
+    cb(null, [this.key]);
+  }
+
+  sign(
+    pubKey: ParsedKey | Buffer | string,
+    data: Buffer,
+    optionsOrCb: SigningRequestOptions | SignCallback,
+    cb?: SignCallback,
+  ): void {
+    const callback = typeof optionsOrCb === "function" ? optionsOrCb : cb!;
+    const options =
+      typeof optionsOrCb === "function" ? {} : optionsOrCb;
+    try {
+      const algo =
+        options.hash === "sha256"
+          ? "rsa-sha2-256"
+          : options.hash === "sha512"
+            ? "rsa-sha2-512"
+            : undefined;
+      const signature = this.key.sign(data, algo);
+      callback(null, signature);
+    } catch (err) {
+      callback(err instanceof Error ? err : new Error(String(err)));
+    }
+  }
+}
 
 async function performPortKnocking(
   host: string,
@@ -2310,6 +2356,28 @@ wss.on("connection", async (ws: WebSocket, req) => {
         }),
       );
       return;
+    }
+
+    if (
+      hostConfig.terminalConfig?.agentForwarding &&
+      connectConfig.privateKey
+    ) {
+      try {
+        const parsed = ssh2Utils.parseKey(
+          connectConfig.privateKey as Buffer,
+          connectConfig.passphrase as string | undefined,
+        );
+        if (parsed && !(parsed instanceof Error)) {
+          connectConfig.agent = new MemoryAgent(parsed);
+          connectConfig.agentForward = true;
+          sendLog("auth", "info", "SSH agent forwarding enabled");
+        }
+      } catch {
+        sshLogger.warn("Failed to set up agent forwarding", {
+          operation: "agent_forward_setup",
+          hostId: id,
+        });
+      }
     }
 
     if (


### PR DESCRIPTION
## Summary

The "SSH Agent Forwarding" toggle in host advanced settings has no backend implementation. The UI saves the `agentForwarding` flag in `terminalConfig`, but the SSH connection code never reads it or sets up agent forwarding. As a result, `$SSH_AUTH_SOCK` is always empty on the remote host.

## Changes

- Created `MemoryAgent` class extending ssh2's `BaseAgent` that holds the user's parsed private key and responds to identity/sign requests
- When `terminalConfig.agentForwarding` is enabled and a private key is available, parse the key and attach the agent to the connection config with `agentForward: true`
- The remote host will now have `SSH_AUTH_SOCK` set, enabling agent-based operations (e.g. `pam_ssh_agent_auth` for passwordless sudo, multi-hop SSH)

## Related

Closes https://github.com/Termix-SSH/Support/issues/654