### PR TITLE
fix: default ignore-cert to true for rdp connections

### DIFF
--- a/src/backend/guacamole/routes.ts
+++ b/src/backend/guacamole/routes.ts
@@ -192,6 +192,11 @@ router.post(
         }
       }
 
+      if (guacConfig.dpi != null) {
+        const parsed = parseInt(String(guacConfig.dpi), 10);
+        guacConfig.dpi = Number.isFinite(parsed) && parsed > 0 ? parsed : undefined;
+      }
+
       let token: string;
       const hostname = host.ip as string;
       const port = host.port as number;

--- a/src/backend/guacamole/routes.ts
+++ b/src/backend/guacamole/routes.ts
@@ -205,7 +205,8 @@ router.post(
             port: port || 3389,
             domain,
             security: (host.security as string) || undefined,
-            "ignore-cert": (host.ignoreCert as boolean) || false,
+            "ignore-cert":
+              host.ignoreCert !== undefined ? !!host.ignoreCert : true,
             ...guacConfig,
           });
           break;


### PR DESCRIPTION
## Summary

RDP connections via `/guacamole/connect-host/:hostId` default `ignore-cert` to `false` when the host has no explicit `ignoreCert` setting. This causes guacd to fail TLS certificate validation against the RDP target (most Windows machines use self-signed certs), resulting in a black screen with no error feedback.

The guacamole-lite `connectionDefaultSettings` already sets `"ignore-cert": true`, but the token's explicit `false` value overrides it.

## Changes

Default `ignore-cert` to `true` unless the user has explicitly set `ignoreCert` to `false` in host configuration. This matches the behavior of the `connectionDefaultSettings` and the `/guacamole/token` endpoint.

## Related

Closes https://github.com/Termix-SSH/Support/issues/653