### PR TITLE
feat: support runtime base path configuration via BASE_PATH env var

### DIFF
--- a/docker/entrypoint.sh
+++ b/docker/entrypoint.sh
@@ -135,6 +135,12 @@ fi
 echo "Starting nginx..."
 nginx -c /tmp/nginx/nginx.conf
 
+# Inject runtime BASE_PATH into frontend if configured
+if [ -n "$BASE_PATH" ]; then
+    echo "Injecting BASE_PATH: $BASE_PATH"
+    find /app/html -name "index.html" -exec sed -i "s|window.__TERMIX_BASE_PATH__ = \"\"|window.__TERMIX_BASE_PATH__ = \"$BASE_PATH\"|g" {} \;
+fi
+
 echo "Starting backend services..."
 cd /app
 export NODE_ENV=production

--- a/index.html
+++ b/index.html
@@ -47,6 +47,7 @@
     </style>
   </head>
   <body>
+    <script>window.__TERMIX_BASE_PATH__ = "";</script>
     <div id="root"></div>
     <script type="module" src="/src/main.tsx"></script>
   </body>

--- a/src/ui/lib/base-path.ts
+++ b/src/ui/lib/base-path.ts
@@ -1,4 +1,9 @@
 export function getBasePath(): string {
+  const runtime = (window as unknown as Record<string, unknown>)
+    .__TERMIX_BASE_PATH__ as string | undefined;
+  if (runtime) {
+    return runtime.endsWith("/") ? runtime.slice(0, -1) : runtime;
+  }
   const base = import.meta.env.BASE_URL || "/";
   if (base === "./" || base === "/") return "";
   return base.endsWith("/") ? base.slice(0, -1) : base;


### PR DESCRIPTION
## Summary

The current base path is baked into the build output via `VITE_BASE_PATH`, making it impossible for Docker users to change the base path without rebuilding. This adds runtime base path resolution via a `BASE_PATH` environment variable.

## Changes

- Added `window.__TERMIX_BASE_PATH__` placeholder in `index.html`
- Modified `getBasePath()` to read the runtime value first, falling back to the build-time `import.meta.env.BASE_URL`
- Added `sed` injection in `entrypoint.sh` to replace the placeholder with the `BASE_PATH` env var at container startup

## Usage

```yaml
services:
  termix:
    image: ghcr.io/lukegus/termix:latest
    environment:
      BASE_PATH: "/termix"
```

When `BASE_PATH` is not set, behavior is unchanged (empty base path).

## Related

Closes https://github.com/Termix-SSH/Support/issues/666