### PR TITLE
fix: resolve linux electron backend fork ENOTDIR error

### DIFF
--- a/electron/main.cjs
+++ b/electron/main.cjs
@@ -566,7 +566,7 @@ function getBackendPaths() {
     return { entryPath: path.join(backendDir, "starter.js"), backendCwd: backendDir };
   }
   // fork() does not go through Electron's asar redirector — use the unpacked path
-  const unpackedRoot = appRoot.replace("app.asar", "app.asar.unpacked");
+  const unpackedRoot = appRoot.replace(/app\.asar(?!\.unpacked)/, "app.asar.unpacked");
   const backendDir = path.join(unpackedRoot, "dist", "backend", "backend");
   return { entryPath: path.join(backendDir, "starter.js"), backendCwd: backendDir };
 }
@@ -606,7 +606,9 @@ function startBackendServer() {
     logToFile("  backendCwd exists:", fs.existsSync(backendCwd));
 
     backendProcess = fork(entryPath, [], {
-      cwd: backendCwd,
+      cwd: fs.existsSync(backendCwd) && fs.statSync(backendCwd).isDirectory()
+        ? backendCwd
+        : dataDir,
       env: {
         ...process.env,
         DATA_DIR: dataDir,


### PR DESCRIPTION
## Summary

On Linux (AppImage), the embedded backend server fails to start with `ENOTDIR` because `fork()` receives `app.asar` as `cwd`. Unlike macOS/Windows, Linux AppImage mounts the asar as a file, not a virtual directory, so `fork()` cannot use it as a working directory.

## Root Cause

`appRoot.replace("app.asar", "app.asar.unpacked")` can fail if the path contains `app.asar.unpacked` elsewhere, or if the replacement doesn't produce a valid directory on the filesystem.

## Changes

- Use regex with negative lookahead (`/app\.asar(?!\.unpacked)/`) to ensure only the correct `app.asar` segment is replaced
- Added fallback in `fork()` call: if `backendCwd` is not a real directory, use `dataDir` instead (which is always a real filesystem path)

## Related

Reported on Discord — Linux desktop app fails to launch after fresh install with `spawn ENOTDIR` error.