### PR TITLE
fix: validate terminal link URLs before opening in external browser

### DIFF
--- a/electron/main.cjs
+++ b/electron/main.cjs
@@ -953,7 +953,14 @@ function createWindow() {
   });
 
   mainWindow.webContents.setWindowOpenHandler(({ url }) => {
-    shell.openExternal(url);
+    try {
+      const parsed = new URL(url);
+      if (parsed.protocol === "http:" || parsed.protocol === "https:") {
+        shell.openExternal(url);
+      }
+    } catch {
+      // invalid URL, ignore
+    }
     return { action: "deny" };
   });
 }

--- a/src/ui/features/terminal/Terminal.tsx
+++ b/src/ui/features/terminal/Terminal.tsx
@@ -1938,7 +1938,12 @@ const TerminalInner = forwardRef<TerminalHandle, SSHTerminalProps>(
       const clipboardProvider = new RobustClipboardProvider();
       const clipboardAddon = new ClipboardAddon(undefined, clipboardProvider);
       const unicode11Addon = new Unicode11Addon();
-      const webLinksAddon = new WebLinksAddon();
+      const webLinksAddon = new WebLinksAddon((_event, uri) => {
+        const url = uri.startsWith("http://") || uri.startsWith("https://")
+          ? uri
+          : `https://${uri}`;
+        window.open(url, "_blank");
+      });
 
       fitAddonRef.current = fitAddon;
       terminal.loadAddon(fitAddon);


### PR DESCRIPTION
## Summary

Clicking hyperlinks in the terminal within the Windows desktop app shows an error instead of opening the URL in the browser. The web UI handles the same links correctly.

## Root Cause

Two issues:

1. `WebLinksAddon` default handler calls `window.open(uri)` where `uri` may lack a protocol prefix (e.g. `example.com/path`). In the browser this works (browser auto-prepends `http://`), but in Electron it triggers `setWindowOpenHandler` with an invalid URL.

2. `setWindowOpenHandler` passes the URL directly to `shell.openExternal()` without validation. Invalid or non-http URLs (like `about:blank#blocked`) cause OS-level errors.

## Changes

- Added custom handler to `WebLinksAddon` that ensures URLs have `https://` prefix before calling `window.open`
- Added URL validation in `setWindowOpenHandler` — only opens URLs with `http:` or `https:` protocol via `shell.openExternal`