### PR TITLE
fix: auto-set sudo password in file manager from host config

### DIFF
--- a/src/backend/ssh/file-manager.ts
+++ b/src/backend/ssh/file-manager.ts
@@ -862,7 +862,7 @@ app.post("/ssh/file_manager/ssh/connect", async (req, res) => {
   );
 
   // Resolve credentials server-side when frontend doesn't provide them
-  let resolvedCredentials = { password, sshKey, keyPassword, authType };
+  let resolvedCredentials = { password, sshKey, keyPassword, authType, sudoPassword: undefined as string | undefined };
   if (hostId && userId && !password && !sshKey) {
     try {
       const { resolveHostById } = await import("./host-resolver.js");
@@ -873,6 +873,7 @@ app.post("/ssh/file_manager/ssh/connect", async (req, res) => {
           sshKey: resolvedHost.key,
           keyPassword: resolvedHost.keyPassword,
           authType: resolvedHost.authType,
+          sudoPassword: resolvedHost.sudoPassword as string | undefined,
         };
         connectionLogs.push(
           createConnectionLog(
@@ -900,6 +901,7 @@ app.post("/ssh/file_manager/ssh/connect", async (req, res) => {
           sshKey: resolvedHost.key,
           keyPassword: resolvedHost.keyPassword,
           authType: resolvedHost.authType,
+          sudoPassword: resolvedHost.sudoPassword as string | undefined,
         };
         connectionLogs.push(
           createConnectionLog(
@@ -1194,6 +1196,7 @@ app.post("/ssh/file_manager/ssh/connect", async (req, res) => {
       activeOperations: 0,
       channelOpener: new ChannelOpenSerializer(),
       userId,
+      sudoPassword: resolvedCredentials.sudoPassword,
     };
     scheduleSessionCleanup(sessionId);
     res.json({


### PR DESCRIPTION
## Summary

The file manager has sudo support (prompts for password when a permission error occurs), but it never reads the `sudoPassword` field already configured on the host. Users who set a sudo password in host settings still get prompted every time they need elevated access in the file manager.

## Changes

- Read `sudoPassword` from the resolved host data during file manager SSH connection
- Automatically set it on the session at creation time
- When the host has a sudo password configured, file manager operations that require sudo will use it automatically without prompting

## How to use

1. Edit host → SSH tab → set "Sudo Password"
2. Open file manager for that host
3. Operations requiring sudo (editing system files, navigating restricted directories) will automatically use the configured password

Users without a sudo password configured will still get the manual prompt as before.