### PR TITLE
fix: override package.json type to commonjs for electron builds

### DIFF
--- a/electron-builder.json
+++ b/electron-builder.json
@@ -35,7 +35,8 @@
     "!public/icons/**/*"
   ],
   "extraMetadata": {
-    "main": "electron/main.cjs"
+    "main": "electron/main.cjs",
+    "type": "commonjs"
   },
   "buildDependenciesFromSource": false,
   "nodeGypRebuild": false,


### PR DESCRIPTION
## Summary

macOS Electron app crashes on launch with:
```
ReferenceError: exports is not defined in ES module scope
This file is being treated as an ES module because it has a '.js' extension
and package.json contains "type": "module"
```

This causes SSH connections to fail with "Connection closed unexpectedly" because the backend services don't fully initialize.

## Root Cause

`package.json` has `"type": "module"` for the Vite/backend build system. `electron-builder` uses `extraMetadata` to override the `main` field to `electron/main.cjs`, but doesn't override `type`. While `.cjs` files should always be treated as CommonJS regardless of the `type` field, some Electron versions on macOS still resolve other `.js` requires through the ESM loader when `type: module` is present.

## Changes

Added `"type": "commonjs"` to `extraMetadata` in `electron-builder.json`. This ensures the packaged app's `package.json` uses CommonJS resolution, which is what Electron's main process expects.

## Related

Closes https://github.com/Termix-SSH/Support/issues/553