### PR TITLE
fix: implement guacamole drive redirection file transfer

### DIFF
--- a/src/backend/guacamole/routes.ts
+++ b/src/backend/guacamole/routes.ts
@@ -201,6 +201,10 @@ router.post(
 
       switch (connectionType) {
         case "rdp":
+          if (guacConfig["enable-drive"] && !guacConfig["drive-path"]) {
+            guacConfig["drive-path"] = "/drive";
+            guacConfig["create-drive-path"] = true;
+          }
           token = tokenService.createRdpToken(hostname, username, password, {
             port: port || 3389,
             domain,

--- a/src/ui/features/guacamole/GuacamoleDisplay.tsx
+++ b/src/ui/features/guacamole/GuacamoleDisplay.tsx
@@ -388,6 +388,20 @@ export const GuacamoleDisplay = forwardRef<
       Guacamole.AudioPlayer.getInstance(stream, mimetype);
     };
 
+    client.onfile = (stream: Guacamole.InputStream, mimetype: string, filename: string) => {
+      const reader = new Guacamole.BlobReader(stream, mimetype);
+      reader.onend = () => {
+        const blob = reader.getBlob();
+        const url = URL.createObjectURL(blob);
+        const a = document.createElement("a");
+        a.href = url;
+        a.download = filename;
+        a.click();
+        URL.revokeObjectURL(url);
+      };
+      stream.sendAck("OK", Guacamole.Status.Code.SUCCESS);
+    };
+
     client.connect();
   }, [
     getWebSocketUrl,


### PR DESCRIPTION
## Summary

Guacamole drive redirection (virtual drive) doesn't work — files placed in the remote "Download" folder don't download to the browser, and drag-and-drop upload doesn't work.

## Root Cause

Two issues:

1. **Frontend missing `client.onfile` handler** — When guacd sends a file to the client (user copies file to the Download folder on remote), the Guacamole client receives a `file` instruction. Without an `onfile` handler, the stream is never acknowledged and the transfer fails silently.

2. **Missing `drive-path` and `create-drive-path` defaults** — When users enable drive in the UI without specifying a path, guacd needs a valid filesystem path. Without `create-drive-path: true`, guacd refuses to create the directory and reports "FILE OPEN REFUSED".

## Changes

**Frontend (`GuacamoleDisplay.tsx`):**
- Added `client.onfile` handler that receives file streams via `BlobReader` and triggers browser download

**Backend (`routes.ts`):**
- When `enable-drive` is true but no `drive-path` is set, default to `/drive` with `create-drive-path: true`

## Note

For Docker deployments, the guacd container needs write access to the drive path. Users may need to add a volume mount to guacd for persistent drive storage.

## Related

Closes https://github.com/Termix-SSH/Support/issues/623