### PR TITLE
fix: enable VNC TLS/VeNCrypt support with security mode negotiation

### DIFF
--- a/src/backend/guacamole/guacamole-server.ts
+++ b/src/backend/guacamole/guacamole-server.ts
@@ -75,6 +75,7 @@ const clientOptions = {
     vnc: {
       "swap-red-blue": false,
       cursor: "remote",
+      security: "any",
       width: 1280,
       height: 720,
     },

--- a/src/backend/guacamole/routes.ts
+++ b/src/backend/guacamole/routes.ts
@@ -216,6 +216,7 @@ router.post(
             password,
             {
               port: port || 5900,
+              security: "any",
               ...guacConfig,
             },
           );


### PR DESCRIPTION
## Summary

VNC connections fail when the VNC server requires TLS or VeNCrypt encryption (e.g. wayvnc with `enable_auth=true`). guacd supports these modes but Termix never passes the `security` parameter, so guacd defaults to unencrypted only.

## Changes

- Added `security: "any"` to VNC `connectionDefaultSettings` in guacamole-server.ts
- Added `security: "any"` as default in the `connect-host` route for VNC tokens (can be overridden by user's `guacamoleConfig`)

With `security: "any"`, guacd will negotiate the best available security mode with the VNC server — including TLS and VeNCrypt when the server requires it.

Users who need to force a specific mode can set `security` in their host's guacamole config to `"none"`, `"tls"`, or `"vencrypt"`.

## Related

Closes https://github.com/Termix-SSH/Support/issues/625