### PR TITLE
feat: add host filter for snippets

### DIFF
--- a/src/backend/database/db/index.ts
+++ b/src/backend/database/db/index.ts
@@ -782,6 +782,7 @@ const migrateSchema = () => {
 
   addColumnIfNotExists("snippets", "folder", "TEXT");
   addColumnIfNotExists("snippets", "order", "INTEGER NOT NULL DEFAULT 0");
+  addColumnIfNotExists("snippets", "host_filter", "TEXT");
 
   try {
     sqlite

--- a/src/backend/database/db/schema.ts
+++ b/src/backend/database/db/schema.ts
@@ -302,6 +302,7 @@ export const snippets = sqliteTable("snippets", {
   updatedAt: text("updated_at")
     .notNull()
     .default(sql`CURRENT_TIMESTAMP`),
+  hostFilter: text("host_filter"),
 });
 
 export const snippetFolders = sqliteTable("snippet_folders", {

--- a/src/backend/database/routes/snippets.ts
+++ b/src/backend/database/routes/snippets.ts
@@ -93,6 +93,7 @@ async function getAccessibleSnippet(snippetId: number, userId: string) {
       order: snippets.order,
       createdAt: snippets.createdAt,
       updatedAt: snippets.updatedAt,
+      hostFilter: snippets.hostFilter,
     })
     .from(snippetAccess)
     .innerJoin(snippets, eq(snippetAccess.snippetId, snippets.id))
@@ -1104,7 +1105,7 @@ router.post(
   requireDataAccess,
   async (req: Request, res: Response) => {
     const userId = (req as AuthenticatedRequest).userId;
-    const { name, content, description, folder, order } = req.body;
+    const { name, content, description, folder, order, hostFilter } = req.body;
 
     if (
       !isNonEmptyString(userId) ||
@@ -1146,6 +1147,7 @@ router.post(
         description: description?.trim() || null,
         folder: folder?.trim() || null,
         order: snippetOrder,
+        hostFilter: hostFilter ? JSON.stringify(hostFilter) : null,
       };
 
       const result = await db.insert(snippets).values(insertData).returning();
@@ -1238,6 +1240,7 @@ router.put(
         description: string | null;
         folder: string | null;
         order: number;
+        hostFilter: string | null;
       }> = {
         updatedAt: sql`CURRENT_TIMESTAMP`,
       };
@@ -1251,6 +1254,10 @@ router.put(
       if (updateData.folder !== undefined)
         updateFields.folder = updateData.folder?.trim() || null;
       if (updateData.order !== undefined) updateFields.order = updateData.order;
+      if (updateData.hostFilter !== undefined)
+        updateFields.hostFilter = updateData.hostFilter
+          ? JSON.stringify(updateData.hostFilter)
+          : null;
 
       await db
         .update(snippets)


### PR DESCRIPTION
## Summary

Allow snippets to be associated with specific hosts so they only appear when connected to those hosts. This prevents irrelevant snippets from cluttering the list when working on different servers.

## Changes

**Schema:**
- Added `host_filter` column to `snippets` table (nullable TEXT, stores JSON array of host IDs)
- Added migration for existing databases

**API:**
- Snippet creation (`POST /snippets`) accepts optional `hostFilter` field (array of host IDs)
- Snippet update (`PUT /snippets/:id`) accepts optional `hostFilter` field
- Snippet GET returns `hostFilter` field

## Usage

```json
// Create snippet visible only on hosts 1 and 3
POST /snippets
{
  "name": "git pull",
  "content": "cd /app && git pull origin main",
  "hostFilter": [1, 3]
}

// Remove host filter (show on all hosts)
PUT /snippets/:id
{ "hostFilter": null }
```

Frontend filtering (showing/hiding snippets based on current host) can be implemented in a follow-up PR.

## Related

Closes https://github.com/Termix-SSH/Support/issues/610