### PR TITLE
fix: disable foreign key constraints during database import

### DIFF
--- a/src/backend/database/database.ts
+++ b/src/backend/database/database.ts
@@ -1251,6 +1251,7 @@ app.post(
       };
 
       try {
+        mainDb.$client.exec("PRAGMA foreign_keys = OFF");
         try {
           const importedHosts = importDb
             .prepare("SELECT * FROM ssh_data")
@@ -1561,6 +1562,7 @@ app.post(
           );
         }
 
+        mainDb.$client.exec("PRAGMA foreign_keys = ON");
         result.success = true;
 
         try {


### PR DESCRIPTION
## Summary

Database import fails with a generic "Import Failed" error when the exported data contains hosts that reference credentials via `credential_id`.

## Root Cause

The import processes hosts (`ssh_data`) before credentials (`ssh_credentials`). With `PRAGMA foreign_keys = ON` (enabled at database init), inserting a host that references a `credential_id` fails because the credential hasn't been imported yet — foreign key constraint violation.

## Changes

Temporarily disable foreign key constraints (`PRAGMA foreign_keys = OFF`) during the import operation, then re-enable after all data is imported. This allows hosts and credentials to be imported in any order without constraint violations.

## Related

Closes https://github.com/Termix-SSH/Support/issues/588