### PR TITLE
feat: check guacd availability before RDP/VNC connection

### DIFF
--- a/src/ui/features/guacamole/GuacamoleApp.tsx
+++ b/src/ui/features/guacamole/GuacamoleApp.tsx
@@ -1,7 +1,7 @@
 import React, { useState, useEffect, useCallback } from "react";
 import { GuacamoleDisplay } from "@/features/guacamole/GuacamoleDisplay.tsx";
 import { FullScreenAppWrapper } from "@/features/FullScreenAppWrapper.tsx";
-import { getGuacamoleTokenFromHost } from "@/main-axios.ts";
+import { getGuacamoleTokenFromHost, getGuacdStatus } from "@/main-axios.ts";
 import { useTranslation } from "react-i18next";
 import { AlertCircle, RefreshCw } from "lucide-react";
 import { Button } from "@/components/button.tsx";
@@ -75,8 +75,19 @@ const GuacamoleAppInner: React.FC<GuacamoleAppInnerProps> = ({
   useEffect(() => {
     setToken(null);
     setError(null);
-    getGuacamoleTokenFromHost(hostId)
-      .then((result) => setToken(result.token))
+    getGuacdStatus()
+      .then((status) => {
+        if (status.guacd.status !== "connected") {
+          setError(
+            "Remote desktop service (guacd) is not available. Please ensure guacd is running and accessible.",
+          );
+          return;
+        }
+        return getGuacamoleTokenFromHost(hostId);
+      })
+      .then((result) => {
+        if (result) setToken(result.token);
+      })
       .catch((err) => setError(err?.message || t("guacamole.failedToConnect")));
   }, [hostId, retryCount]);
 

--- a/src/ui/main-axios.ts
+++ b/src/ui/main-axios.ts
@@ -4501,6 +4501,13 @@ export async function getGuacamoleTokenFromHost(
   }
 }
 
+export async function getGuacdStatus(): Promise<{
+  guacd: { status: string };
+}> {
+  const response = await authApi.get("/guacamole/status");
+  return response.data;
+}
+
 // ============================================================================
 // RBAC MANAGEMENT
 // ============================================================================


### PR DESCRIPTION
## Summary

When guacd is not running (e.g. Unraid without the sidecar, or misconfigured Docker setup), RDP/VNC connections fail with an unhelpful "Desktop service not found" error. Users have no way to know guacd is missing until they try to connect.

## Changes

- Added `getGuacdStatus()` frontend API function that calls `GET /guacamole/status`
- Modified `GuacamoleAppInner` to check guacd connectivity before requesting a connection token
- If guacd is not reachable, shows a clear error: "Remote desktop service (guacd) is not available. Please ensure guacd is running and accessible."

## Related

Closes https://github.com/Termix-SSH/Support/issues/576
Closes https://github.com/Termix-SSH/Support/issues/545