### PR TITLE
feat: sync admin status from OIDC group membership on login

### DIFF
--- a/src/backend/database/routes/users.ts
+++ b/src/backend/database/routes/users.ts
@@ -521,6 +521,7 @@ router.post("/oidc-config", authenticateJWT, async (req, res) => {
       name_path,
       scopes,
       allowed_users,
+      admin_group,
     } = req.body;
 
     const isDisableRequest =
@@ -579,6 +580,7 @@ router.post("/oidc-config", authenticateJWT, async (req, res) => {
         name_path,
         scopes: scopes || "openid email profile",
         allowed_users: allowed_users || "",
+        admin_group: admin_group || "",
       };
 
       let encryptedConfig;
@@ -1300,8 +1302,26 @@ router.get("/oidc/callback", async (req, res) => {
 
     const userRecord = user[0];
 
+    // Sync admin status based on OIDC group membership
+    if (config.admin_group) {
+      const groups = (userInfo.groups || userInfo.roles || []) as string[];
+      const shouldBeAdmin = groups.includes(config.admin_group);
+      if (!!userRecord.isAdmin !== shouldBeAdmin) {
+        await db
+          .update(users)
+          .set({ isAdmin: shouldBeAdmin })
+          .where(eq(users.id, userRecord.id));
+        userRecord.isAdmin = shouldBeAdmin;
+        authLogger.info("OIDC admin status synced", {
+          operation: "oidc_admin_group_sync",
+          userId: userRecord.id,
+          group: config.admin_group,
+          isAdmin: shouldBeAdmin,
+        });
+      }
+    }
+
     try {
-      await authManager.authenticateOIDCUser(userRecord.id, deviceInfo.type);
     } catch (setupError) {
       authLogger.error("Failed to setup OIDC user encryption", setupError, {
         operation: "oidc_user_encryption_setup_failed",


### PR DESCRIPTION
## Summary

OIDC users are always created as non-admin. To grant admin access, another admin must manually change their permissions. This adds automatic admin assignment/removal based on OIDC group membership.

## Changes

- Added `admin_group` field to OIDC configuration (saved alongside other OIDC settings)
- On every OIDC login, checks `userInfo.groups` (or `userInfo.roles`) for the configured admin group name
- If user is in the group → grant admin. If not → revoke admin.
- Syncs on every login, so removing a user from the OIDC group automatically removes their admin access on next login.

## Configuration

In Admin Settings → OIDC, set the "Admin Group" field to your OIDC group name (e.g. `termix-admins`).

The OIDC provider must include the `groups` claim in the userinfo response. You may need to add `groups` to the requested scopes.

## Related

Closes https://github.com/Termix-SSH/Support/issues/574