### PR TITLE
fix: properly detect chacha20-poly1305 support before advertising it

### DIFF
--- a/src/backend/utils/ssh-algorithms.ts
+++ b/src/backend/utils/ssh-algorithms.ts
@@ -1,7 +1,9 @@
 import crypto from "crypto";
 import type { ConnectConfig, CipherAlgorithm } from "ssh2";
 
-// Maps SSH cipher names to their OpenSSL equivalents (as used by ssh2 internally)
+const availableCiphers = new Set(crypto.getCiphers());
+
+// Maps SSH cipher names to their OpenSSL equivalents
 const SSH_CIPHER_SSL_NAME: Partial<Record<CipherAlgorithm, string>> = {
   "chacha20-poly1305@openssh.com": "chacha20",
   "aes256-gcm@openssh.com": "aes-256-gcm",
@@ -15,12 +17,31 @@ const SSH_CIPHER_SSL_NAME: Partial<Record<CipherAlgorithm, string>> = {
   "3des-cbc": "des-ede3-cbc",
 };
 
-const availableCiphers = new Set(crypto.getCiphers());
+// Check if ssh2's native crypto binding is available (needed for chacha20-poly1305)
+let ssh2BindingAvailable = false;
+try {
+  require("ssh2/lib/protocol/crypto/build/Release/sshcrypto.node");
+  ssh2BindingAvailable = true;
+} catch {
+  try {
+    // ESM fallback: check if chacha20 works via OpenSSL createCipheriv
+    crypto.createCipheriv("chacha20", Buffer.alloc(32), Buffer.alloc(16));
+    ssh2BindingAvailable = true;
+  } catch {
+    ssh2BindingAvailable = false;
+  }
+}
 
 function filterCiphers(list: CipherAlgorithm[]): CipherAlgorithm[] {
   return list.filter((name) => {
     const sslName = SSH_CIPHER_SSL_NAME[name];
-    return !sslName || availableCiphers.has(sslName);
+    if (!sslName) return true;
+    if (!availableCiphers.has(sslName)) return false;
+    // chacha20-poly1305 requires either native binding or working OpenSSL chacha20
+    if (name === "chacha20-poly1305@openssh.com" && !ssh2BindingAvailable) {
+      return false;
+    }
+    return true;
   });
 }
 


### PR DESCRIPTION
## Summary

SSH connections fail with `Unsupported algorithm: chacha20-poly1305@openssh.com` on some platforms (notably Windows desktop app) because the cipher is included in the advertised list even when the runtime doesn't actually support it.

## Root Cause

`filterCiphers()` only checked if OpenSSL has the `chacha20` cipher name registered, but ssh2's chacha20-poly1305 implementation requires either its native crypto binding (`sshcrypto.node`) or a working OpenSSL chacha20 `createCipheriv` call. On some Windows builds, the OpenSSL reports `chacha20` in `getCiphers()` but the native binding fails to load, causing ssh2 to reject the cipher at connection time.

## Changes

Added a runtime check that verifies chacha20-poly1305 actually works before including it in the cipher list:
1. Try to load ssh2's native crypto binding
2. If that fails, try `crypto.createCipheriv('chacha20', ...)` to verify OpenSSL support
3. Only include `chacha20-poly1305@openssh.com` if one of these checks passes

When chacha20 is not available, the cipher list falls back to AES-GCM and AES-CTR which are universally supported.

## Related

Closes https://github.com/Termix-SSH/Support/issues/560