### PR TITLE
fix: patch guacamole-lite to support guacd 1.6.0 protocol version

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -2449,9 +2449,6 @@
         "arm"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "LGPL-3.0-or-later",
       "optional": true,
       "os": [
@@ -2469,9 +2466,6 @@
         "arm64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "LGPL-3.0-or-later",
       "optional": true,
       "os": [
@@ -2489,9 +2483,6 @@
         "ppc64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "LGPL-3.0-or-later",
       "optional": true,
       "os": [
@@ -2509,9 +2500,6 @@
         "riscv64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "LGPL-3.0-or-later",
       "optional": true,
       "os": [
@@ -2529,9 +2517,6 @@
         "s390x"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "LGPL-3.0-or-later",
       "optional": true,
       "os": [
@@ -2549,9 +2534,6 @@
         "x64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "LGPL-3.0-or-later",
       "optional": true,
       "os": [
@@ -2569,9 +2551,6 @@
         "arm64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "LGPL-3.0-or-later",
       "optional": true,
       "os": [
@@ -2589,9 +2568,6 @@
         "x64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "LGPL-3.0-or-later",
       "optional": true,
       "os": [
@@ -2609,9 +2585,6 @@
         "arm"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "Apache-2.0",
       "optional": true,
       "os": [
@@ -2635,9 +2608,6 @@
         "arm64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "Apache-2.0",
       "optional": true,
       "os": [
@@ -2661,9 +2631,6 @@
         "ppc64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "Apache-2.0",
       "optional": true,
       "os": [
@@ -2687,9 +2654,6 @@
         "riscv64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "Apache-2.0",
       "optional": true,
       "os": [
@@ -2713,9 +2677,6 @@
         "s390x"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "Apache-2.0",
       "optional": true,
       "os": [
@@ -2739,9 +2700,6 @@
         "x64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "Apache-2.0",
       "optional": true,
       "os": [
@@ -2765,9 +2723,6 @@
         "arm64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "Apache-2.0",
       "optional": true,
       "os": [
@@ -2791,9 +2746,6 @@
         "x64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "Apache-2.0",
       "optional": true,
       "os": [

--- a/package.json
+++ b/package.json
@@ -13,7 +13,7 @@
   "scripts": {
     "format": "prettier --write .",
     "format:check": "prettier --check .",
-    "postinstall": "node scripts/patch-app-builder-lib.cjs",
+    "postinstall": "node scripts/patch-app-builder-lib.cjs && node scripts/patch-guacamole-lite.cjs",
     "prebuild": "node scripts/write-electron-build-info.cjs",
     "lint": "eslint .",
     "lint:fix": "eslint --fix .",

--- a/scripts/patch-guacamole-lite.cjs
+++ b/scripts/patch-guacamole-lite.cjs
@@ -1,0 +1,38 @@
+const fs = require("fs");
+const path = require("path");
+
+const filePath = path.join(
+  __dirname,
+  "..",
+  "node_modules",
+  "guacamole-lite",
+  "lib",
+  "GuacdClient.js",
+);
+
+if (!fs.existsSync(filePath)) {
+  console.log("[patch-guacamole-lite] File not found, skipping");
+  process.exit(0);
+}
+
+let content = fs.readFileSync(filePath, "utf8");
+
+const oldCheck = "if (version === '1_0_0' || version === '1_1_0') {";
+const newCheck =
+  "if (version === '1_0_0' || version === '1_1_0' || version === '1_3_0' || version === '1_5_0') {";
+
+if (content.includes(newCheck)) {
+  console.log("[patch-guacamole-lite] Already patched");
+  process.exit(0);
+}
+
+if (!content.includes(oldCheck)) {
+  console.log("[patch-guacamole-lite] Target code not found, skipping");
+  process.exit(0);
+}
+
+content = content.replace(oldCheck, newCheck);
+fs.writeFileSync(filePath, content);
+console.log(
+  "[patch-guacamole-lite] Patched to support protocol VERSION_1_3_0 and VERSION_1_5_0",
+);


### PR DESCRIPTION
## Summary

VNC connections fail immediately with guacd 1.6.0 because guacamole-lite only supports Guacamole protocol VERSION_1_1_0, while guacd 1.6.0 requires VERSION_1_5_0 for VNC connections.

## Root Cause

guacamole-lite 1.2.0 (latest available) hardcodes support for only `VERSION_1_0_0` and `VERSION_1_1_0`. When guacd 1.6.0 sends `VERSION_1_5_0` in the handshake, guacamole-lite falls back to `VERSION_1_1_0`, which guacd rejects for VNC connections — dropping the connection immediately.

## Changes

- Added `scripts/patch-guacamole-lite.cjs` that patches the version check to accept `VERSION_1_3_0` and `VERSION_1_5_0`
- Added the patch to `postinstall` so it runs automatically after `npm install`

The patch is a single-line change in `GuacdClient.js` that extends the version whitelist. The protocol is backward-compatible — responding with VERSION_1_5_0 simply enables newer features (like the `name` instruction) that guacd expects.

## Related

Closes https://github.com/Termix-SSH/Support/issues/567