### PR TITLE
fix: improve docker-compose guacd config for ARM64 and network isolation

### DIFF
--- a/docker/docker-compose.yml
+++ b/docker/docker-compose.yml
@@ -1,4 +1,5 @@
 services:
+services:
   termix:
     image: ghcr.io/lukegus/termix:latest
     container_name: termix
@@ -9,6 +10,7 @@ services:
       - termix-data:/app/data
     environment:
       PORT: "8080"
+      GUACD_HOST: "guacd"
     depends_on:
       - guacd
     networks:
@@ -18,8 +20,6 @@ services:
     image: guacamole/guacd:1.6.0
     container_name: guacd
     restart: unless-stopped
-    ports:
-      - "4822:4822"
     networks:
       - termix-net
 


### PR DESCRIPTION
## Summary

The docker-compose config unnecessarily exposes guacd port 4822 to the host and doesn't explicitly set `GUACD_HOST`, which can cause issues on ARM64 (Raspberry Pi, Apple Silicon) where the default `localhost` resolution may not work correctly inside containers.

## Changes

- Removed `ports: 4822:4822` from guacd service — guacd only needs to be reachable within the Docker network, not from the host
- Added `GUACD_HOST: "guacd"` environment variable to the Termix service so it connects to guacd via Docker DNS instead of relying on localhost

This makes the setup work correctly on ARM64 (the `guacamole/guacd:1.6.0` image already has multi-arch support) and improves security by not exposing guacd to the host network.

## Related

Closes https://github.com/Termix-SSH/Support/issues/544