### PR TITLE
feat: support SSH connections through Cloudflare Tunnels

### DIFF
--- a/src/backend/ssh/terminal.ts
+++ b/src/backend/ssh/terminal.ts
@@ -2350,6 +2350,55 @@ wss.on("connection", async (ws: WebSocket, req) => {
       hostConfig.jumpHosts.length > 0 &&
       hostConfig.userId;
 
+    // Cloudflare Tunnel: connect via WebSocket proxy
+    const cfConfig = hostConfig.terminalConfig as Record<string, unknown> | undefined;
+    if (cfConfig?.cfAccessClientId && cfConfig?.cfAccessClientSecret) {
+      try {
+        const WebSocket = (await import("ws")).default;
+        const cfHostname = (cfConfig.cfTunnelHostname as string) || ip;
+        const wsUrl = `wss://${cfHostname}/cdn-cgi/access/ssh-connect`;
+        const cfWs = new WebSocket(wsUrl, {
+          headers: {
+            "CF-Access-Client-Id": cfConfig.cfAccessClientId as string,
+            "CF-Access-Client-Secret": cfConfig.cfAccessClientSecret as string,
+          },
+        });
+
+        await new Promise<void>((resolve, reject) => {
+          cfWs.on("open", () => resolve());
+          cfWs.on("error", (err) => reject(err));
+          setTimeout(() => reject(new Error("Cloudflare tunnel timeout")), 30000);
+        });
+
+        const { Duplex } = await import("stream");
+        const duplexStream = new Duplex({
+          read() {},
+          write(chunk, _encoding, callback) {
+            cfWs.send(chunk, callback);
+          },
+        });
+        cfWs.on("message", (data) => duplexStream.push(data));
+        cfWs.on("close", () => duplexStream.push(null));
+
+        connectConfig.sock = duplexStream as unknown as typeof connectConfig.sock;
+        sendLog("handshake", "info", "Connected via Cloudflare Tunnel");
+      } catch (cfError) {
+        sshLogger.error("Cloudflare tunnel connection failed", cfError, {
+          operation: "cf_tunnel_connect",
+          hostId: id,
+        });
+        ws.send(
+          JSON.stringify({
+            type: "error",
+            message: "Cloudflare tunnel connection failed: " +
+              (cfError instanceof Error ? cfError.message : "Unknown error"),
+          }),
+        );
+        cleanupAuthState(connectionTimeout);
+        return;
+      }
+    }
+
     if (hasJumpHosts) {
       try {
         const jumpClient = await createJumpHostChain(


### PR DESCRIPTION
## Summary

Hosts behind Cloudflare Zero Trust (Cloudflare Tunnels) cannot be reached because Termix uses ssh2 directly rather than invoking the system SSH binary with ProxyCommand. This adds native Cloudflare Tunnel support without requiring the `cloudflared` binary.

## How it works

When a host has Cloudflare tunnel credentials configured in its terminal settings, the connection flow becomes:

1. Open a WebSocket to `wss://<hostname>/cdn-cgi/access/ssh-connect` with CF-Access headers
2. Wrap the WebSocket in a Duplex stream
3. Pass the stream as `connectConfig.sock` to ssh2
4. SSH handshake proceeds over the Cloudflare tunnel

No `cloudflared` binary needed — it's pure WebSocket.

## Configuration

Set these in the host's terminal config (Advanced settings):
- `cfAccessClientId` — Cloudflare Access Service Token Client ID
- `cfAccessClientSecret` — Cloudflare Access Service Token Client Secret  
- `cfTunnelHostname` — (optional) The Cloudflare hostname if different from the host IP

## Related

Closes https://github.com/Termix-SSH/Support/issues/530