### PR TITLE
fix: add sudo fallback for file read/write in editor

### DIFF
--- a/src/backend/ssh/file-manager.ts
+++ b/src/backend/ssh/file-manager.ts
@@ -3058,6 +3058,50 @@ app.get("/ssh/file_manager/ssh/readFile", (req, res) => {
 
           stream.on("close", (code) => {
             if (code !== 0) {
+              const isPermissionDenied =
+                errorData.toLowerCase().includes("permission denied");
+
+              if (isPermissionDenied && sshConn.sudoPassword) {
+                execWithSudo(
+                  sshConn,
+                  `cat '${escapedPath}'`,
+                  sshConn.sudoPassword,
+                  (sudoErr, sudoStream) => {
+                    if (sudoErr) {
+                      return res.status(403).json({
+                        error: "Permission denied",
+                        needsSudo: true,
+                      });
+                    }
+                    let sudoData = Buffer.alloc(0);
+                    let sudoErrorData = "";
+                    sudoStream.on("data", (chunk: Buffer) => {
+                      sudoData = Buffer.concat([sudoData, chunk]);
+                    });
+                    sudoStream.stderr.on("data", (chunk: Buffer) => {
+                      sudoErrorData += chunk.toString();
+                    });
+                    sudoStream.on("close", (sudoCode) => {
+                      if (sudoCode !== 0) {
+                        return res.status(403).json({
+                          error: `Permission denied: ${sudoErrorData}`,
+                          needsSudo: true,
+                        });
+                      }
+                      const isBinary = detectBinary(sudoData);
+                      res.json({
+                        content: isBinary
+                          ? sudoData.toString("base64")
+                          : sudoData.toString("utf8"),
+                        isBinary,
+                        size: sudoData.length,
+                      });
+                    });
+                  },
+                );
+                return;
+              }
+
               fileLogger.error(
                 `SSH readFile command failed with code ${code}: ${errorData.replace(/\n/g, " ").trim()}`,
               );
@@ -3490,12 +3534,39 @@ app.post("/ssh/file_manager/ssh/writeFile", async (req, res) => {
               }
             });
           } else {
+            const isPermDenied = errorData.toLowerCase().includes("permission denied");
+            if (isPermDenied && sshConn.sudoPassword) {
+              const sudoWriteCmd = `echo '${base64Content}' | base64 -d | sudo tee '${escapedPath}' > /dev/null && echo "SUCCESS"`;
+              execWithSudo(sshConn, `bash -c "echo '${base64Content}' | base64 -d > '${escapedPath}' && echo SUCCESS"`, sshConn.sudoPassword, (sudoErr, sudoStream) => {
+                if (sudoErr) {
+                  if (!res.headersSent) {
+                    res.status(403).json({ error: "Permission denied", needsSudo: true });
+                  }
+                  return;
+                }
+                let sudoOut = "";
+                sudoStream.on("data", (chunk: Buffer) => { sudoOut += chunk.toString(); });
+                sudoStream.on("close", () => {
+                  if (sudoOut.includes("SUCCESS")) {
+                    restoreOriginalMode(null, () => {
+                      if (!res.headersSent) {
+                        res.json({ message: "File written successfully", path: filePath });
+                      }
+                    });
+                  } else if (!res.headersSent) {
+                    res.status(403).json({ error: "Permission denied", needsSudo: true });
+                  }
+                });
+              });
+              return;
+            }
             fileLogger.error(
               `Fallback write failed with code ${code}: ${errorData}`,
             );
             if (!res.headersSent) {
               res.status(500).json({
                 error: `Write failed: ${errorData}`,
+                needsSudo: isPermDenied,
                 toast: { type: "error", message: `Write failed: ${errorData}` },
               });
             }


### PR DESCRIPTION
## Summary

Opening root-owned files in the editor shows "File is empty" and saving files with insufficient permissions shows a generic error. The file manager has sudo support (password prompt), but the editor's read/write operations never attempt sudo.

## Changes

**readFile endpoint:**
- When `cat` fails with "Permission denied" and the session has a `sudoPassword` set, automatically retry with `execWithSudo`
- Returns `needsSudo: true` in the error response if sudo is needed but no password is configured

**writeFile endpoint (fallback path):**
- When the base64 write command fails with "Permission denied" and `sudoPassword` is available, retry the write via sudo
- Returns `needsSudo: true` if permission is denied without sudo password

## Behavior

- If host has sudo password configured (host settings → SSH → Sudo Password): reads/writes automatically use sudo on permission failure
- If no sudo password configured: returns a clear "Permission denied" error with `needsSudo: true` flag (frontend can prompt for password)

## Related

Closes https://github.com/Termix-SSH/Support/issues/526