### PR TITLE
feat: implement RFC 8252 system browser OIDC authentication for desktop

### DIFF
--- a/electron/main.cjs
+++ b/electron/main.cjs
@@ -1079,6 +1079,42 @@ ipcMain.handle("get-embedded-server-status", () => {
   };
 });
 
+// OIDC System Browser Authentication (RFC 8252)
+ipcMain.handle("oidc-system-browser-auth", async (_event, authUrl, callbackPort) => {
+  const http = require("http");
+
+  return new Promise((resolve, reject) => {
+    const server = http.createServer((req, res) => {
+      const url = new URL(req.url, `http://localhost:${callbackPort}`);
+      if (url.pathname === "/oidc-callback") {
+        const success = url.searchParams.get("success");
+        const error = url.searchParams.get("error");
+        const token = url.searchParams.get("token");
+
+        res.writeHead(200, { "Content-Type": "text/html" });
+        res.end(`<html><body><h2>${success === "true" ? "Authentication successful!" : "Authentication failed."}</h2><p>You can close this tab and return to Termix.</p><script>window.close()</script></body></html>`);
+
+        server.close();
+        if (success === "true") {
+          resolve({ success: true, token });
+        } else {
+          resolve({ success: false, error: error || "Authentication failed" });
+        }
+      }
+    });
+
+    server.listen(callbackPort, "127.0.0.1", () => {
+      shell.openExternal(authUrl);
+    });
+
+    // Timeout after 5 minutes
+    setTimeout(() => {
+      server.close();
+      reject(new Error("OIDC authentication timed out"));
+    }, 5 * 60 * 1000);
+  });
+});
+
 ipcMain.handle("get-server-config", () => {
   try {
     const userDataPath = app.getPath("userData");

--- a/electron/preload.js
+++ b/electron/preload.js
@@ -43,6 +43,9 @@ contextBridge.exposeInMainWorld("electronAPI", {
       timeoutMs,
     ),
 
+  oidcSystemBrowserAuth: (authUrl, callbackPort) =>
+    ipcRenderer.invoke("oidc-system-browser-auth", authUrl, callbackPort),
+
   invoke: (channel, ...args) => ipcRenderer.invoke(channel, ...args),
 });
 

--- a/src/backend/database/routes/users.ts
+++ b/src/backend/database/routes/users.ts
@@ -817,7 +817,7 @@ router.get("/oidc-config/admin", requireAdmin, async (req, res) => {
  */
 router.get("/oidc/authorize", async (req, res) => {
   try {
-    const { rememberMe } = req.query;
+    const { rememberMe, desktopCallbackPort } = req.query;
     const origin = getRequestOriginWithForceHTTPS(req);
     const backendCallbackUri = `${origin}/users/oidc/callback`;
 
@@ -840,7 +840,9 @@ router.get("/oidc/authorize", async (req, res) => {
 
     const referer = req.get("Referer");
     let frontendOrigin;
-    if (referer) {
+    if (desktopCallbackPort) {
+      frontendOrigin = `http://127.0.0.1:${desktopCallbackPort}/oidc-callback`;
+    } else if (referer) {
       const refererUrl = new URL(referer);
       frontendOrigin = `${refererUrl.protocol}//${refererUrl.host}`;
     } else {
@@ -1333,6 +1335,8 @@ router.get("/oidc/callback", async (req, res) => {
     const redirectUrl = new URL(frontendOrigin);
     redirectUrl.searchParams.set("success", "true");
 
+    const isDesktopCallback = frontendOrigin.startsWith("http://127.0.0.1:");
+
     const maxAge =
       deviceInfo.type === "desktop" || deviceInfo.type === "mobile"
         ? 30 * 24 * 60 * 60 * 1000
@@ -1341,6 +1345,11 @@ router.get("/oidc/callback", async (req, res) => {
           : 24 * 60 * 60 * 1000;
 
     res.clearCookie("jwt", authManager.getClearCookieOptions(req));
+
+    if (isDesktopCallback) {
+      redirectUrl.searchParams.set("token", token);
+      return res.redirect(redirectUrl.toString());
+    }
 
     return res
       .cookie("jwt", token, authManager.getSecureCookieOptions(req, maxAge))

--- a/src/ui/auth/Auth.tsx
+++ b/src/ui/auth/Auth.tsx
@@ -641,6 +641,22 @@ export function Auth({ onLogin }: AuthProps) {
   async function handleOIDCLogin() {
     setOidcLoading(true);
     try {
+      if (isElectron()) {
+        const electronAPI = (window as unknown as { electronAPI?: { oidcSystemBrowserAuth?: (authUrl: string, port: number) => Promise<{ success: boolean; token?: string; error?: string }> } }).electronAPI;
+        if (electronAPI?.oidcSystemBrowserAuth) {
+          const callbackPort = 17832 + Math.floor(Math.random() * 100);
+          const authResponse = await getOIDCAuthorizeUrl(rememberMe, callbackPort);
+          const { auth_url: authUrl } = authResponse;
+          if (!authUrl) throw new Error(t("errors.invalidAuthUrl"));
+          const result = await electronAPI.oidcSystemBrowserAuth(authUrl, callbackPort);
+          if (result.success && result.token) {
+            localStorage.setItem("jwt_token", result.token);
+            window.location.reload();
+            return;
+          }
+          throw new Error(result.error || "Authentication failed");
+        }
+      }
       const authResponse = await getOIDCAuthorizeUrl(rememberMe);
       const { auth_url: authUrl } = authResponse;
       if (!authUrl || authUrl === "undefined")

--- a/src/ui/main-axios.ts
+++ b/src/ui/main-axios.ts
@@ -3121,10 +3121,11 @@ export async function changePassword(oldPassword: string, newPassword: string) {
 
 export async function getOIDCAuthorizeUrl(
   rememberMe = false,
+  desktopCallbackPort?: number,
 ): Promise<OIDCAuthorize> {
   try {
     const response = await authApi.get("/users/oidc/authorize", {
-      params: { rememberMe },
+      params: { rememberMe, desktopCallbackPort },
     });
     return response.data;
   } catch (error) {


### PR DESCRIPTION
## Summary

The desktop app uses an embedded WebView for OIDC authentication, which is incompatible with WebAuthn/Passkeys (used by Pocket ID, Authentik, Authelia, etc.). Per RFC 8252, native apps should use the system browser for OAuth flows.

## How it works

1. User clicks "Login with OIDC" in the desktop app
2. Instead of navigating the WebView, the app:
   - Starts a temporary HTTP server on localhost (random port 17832-17932)
   - Opens the system browser with the OIDC authorization URL
   - Passes `desktopCallbackPort` to the backend so it knows where to redirect
3. User authenticates in their system browser (Passkeys, biometrics, FIDO2 all work)
4. OIDC provider redirects to Termix backend callback
5. Backend completes token exchange, then redirects to `http://127.0.0.1:<port>/oidc-callback?success=true&token=<jwt>`
6. Electron's localhost server receives the token, closes the browser tab, and logs the user in
7. Timeout after 5 minutes if user doesn't complete auth

## Changes

**Electron (main.cjs):**
- Added `oidc-system-browser-auth` IPC handler that opens system browser and listens for callback

**Preload (preload.js):**
- Exposed `oidcSystemBrowserAuth` to renderer

**Backend (users.ts):**
- `/oidc/authorize` accepts optional `desktopCallbackPort` query param
- OIDC callback redirects to localhost with token when desktop port is set

**Frontend (Auth.tsx, main-axios.ts):**
- When in Electron, uses system browser flow instead of `window.location.replace`
- Falls back to WebView navigation for web users

## Security

- Localhost server only accepts connections from 127.0.0.1
- Server is destroyed after receiving one callback or timing out
- Token is passed via URL params over localhost (never exposed to network)
- Compliant with RFC 8252 Section 7 (Loopback Interface Redirect)

## Related

Closes https://github.com/Termix-SSH/Support/issues/693
Closes https://github.com/Termix-SSH/Support/issues/248