### PR TITLE
fix: port WebSocket token query param fallback from main

### DIFF
--- a/src/backend/ssh/docker-console.ts
+++ b/src/backend/ssh/docker-console.ts
@@ -258,6 +258,12 @@ wss.on("connection", async (ws: WebSocket, req) => {
   }
 
   if (!token) {
+    const urlObj = new URL(req.url || "", "http://localhost");
+    const qp = urlObj.searchParams.get("token");
+    if (qp) token = qp;
+  }
+
+  if (!token) {
     ws.close(1008, "Authentication required");
     return;
   }

--- a/src/backend/ssh/terminal.ts
+++ b/src/backend/ssh/terminal.ts
@@ -506,6 +506,12 @@ wss.on("connection", async (ws: WebSocket, req) => {
     }
 
     if (!token) {
+      const urlObj = new URL(req.url || "", "http://localhost");
+      const qp = urlObj.searchParams.get("token");
+      if (qp) token = qp;
+    }
+
+    if (!token) {
       ws.close(1008, "Authentication required");
       return;
     }

--- a/src/ui/features/terminal/Terminal.tsx
+++ b/src/ui/features/terminal/Terminal.tsx
@@ -884,6 +884,10 @@ const TerminalInner = forwardRef<TerminalHandle, SSHTerminalProps>(
             .replace(/^https?:\/\//, "")
             .replace(/\/$/, "");
           baseWsUrl = `${wsProtocol}${wsHost}/ssh/websocket/`;
+          const storedJwt = localStorage.getItem("jwt");
+          if (storedJwt) {
+            baseWsUrl += `?token=${encodeURIComponent(storedJwt)}`;
+          }
         }
       } else {
         baseWsUrl = `${getBasePath()}/ssh/websocket/`;


### PR DESCRIPTION
## Summary

Cherry-pick of `be43718` from `main` into `dev-2.3.0`.

Adds fallback to read JWT token from WebSocket URL query parameter (`?token=xxx`) when cookie-based auth is unavailable (desktop/Electron apps connecting cross-origin).

Without this fix, desktop app SSH connections fail with "Authentication failed - please re-login" because WebSocket connections don't carry cookies cross-port.

## Related

Closes https://github.com/Termix-SSH/Support/issues/696