### PR TITLE
fix: flush in-memory database to disk on graceful shutdown

### DIFF
--- a/src/backend/starter.ts
+++ b/src/backend/starter.ts
@@ -194,29 +194,32 @@ import {
       duration: Date.now() - initStartTime,
     });
 
-    process.on("SIGINT", () => {
-      systemLogger.info(
-        "Received SIGINT signal, initiating graceful shutdown...",
-        { operation: "shutdown" },
-      );
+    const gracefulShutdown = async (signal: string) => {
+      systemLogger.info(`Received ${signal}, initiating graceful shutdown...`, {
+        operation: "shutdown",
+      });
+      try {
+        const { saveMemoryDatabaseToFile } = await import(
+          "./database/db/index.js"
+        );
+        await saveMemoryDatabaseToFile();
+        systemLogger.info("Database saved to disk before exit", {
+          operation: "shutdown_db_saved",
+        });
+      } catch (error) {
+        systemLogger.error("Failed to save database during shutdown", error, {
+          operation: "shutdown_db_save_failed",
+        });
+      }
       process.exit(0);
-    });
+    };
 
-    process.on("SIGTERM", () => {
-      systemLogger.info(
-        "Received SIGTERM signal, initiating graceful shutdown...",
-        { operation: "shutdown" },
-      );
-      process.exit(0);
-    });
+    process.on("SIGINT", () => gracefulShutdown("SIGINT"));
+    process.on("SIGTERM", () => gracefulShutdown("SIGTERM"));
 
     process.on("message", (msg: { type?: string }) => {
       if (msg?.type === "shutdown") {
-        systemLogger.info(
-          "Received IPC shutdown, initiating graceful shutdown...",
-          { operation: "shutdown" },
-        );
-        process.exit(0);
+        gracefulShutdown("IPC shutdown");
       }
     });
 


### PR DESCRIPTION
## Summary

- SIGTERM/SIGINT/IPC shutdown handlers now await `saveMemoryDatabaseToFile()` before exiting
- Prevents session data loss when Docker container is restarted
- Users no longer need to re-authenticate after `docker compose restart`

## Root Cause

The in-memory SQLite database (sessions, hosts, etc.) was never flushed to disk during shutdown. `process.exit(0)` was called immediately on signal receipt, discarding all unsaved state.

## Related

Closes https://github.com/Termix-SSH/Support/issues/687