### PR TITLE
fix: load Caskaydia Cove Nerd Font via @font-face for correct terminal spacing

### DIFF
--- a/src/ui/index.css
+++ b/src/ui/index.css
@@ -3,6 +3,38 @@
 @import "shadcn/tailwind.css";
 @import "@fontsource-variable/jetbrains-mono";
 
+@font-face {
+  font-family: "Caskaydia Cove Nerd Font Mono";
+  src: url("/fonts/CaskaydiaCoveNerdFontMono-Regular.ttf") format("truetype");
+  font-weight: 400;
+  font-style: normal;
+  font-display: swap;
+}
+
+@font-face {
+  font-family: "Caskaydia Cove Nerd Font Mono";
+  src: url("/fonts/CaskaydiaCoveNerdFontMono-Bold.ttf") format("truetype");
+  font-weight: 700;
+  font-style: normal;
+  font-display: swap;
+}
+
+@font-face {
+  font-family: "Caskaydia Cove Nerd Font Mono";
+  src: url("/fonts/CaskaydiaCoveNerdFontMono-Italic.ttf") format("truetype");
+  font-weight: 400;
+  font-style: italic;
+  font-display: swap;
+}
+
+@font-face {
+  font-family: "Caskaydia Cove Nerd Font Mono";
+  src: url("/fonts/CaskaydiaCoveNerdFontMono-BoldItalic.ttf") format("truetype");
+  font-weight: 700;
+  font-style: italic;
+  font-display: swap;
+}
+
 @custom-variant dark (&:is(.dark *));
 @custom-variant dracula (&:is(.dracula *));
 @custom-variant catppuccin (&:is(.catppuccin *));


### PR DESCRIPTION
## Summary

The default terminal font `Caskaydia Cove Nerd Font Mono` was bundled in `public/fonts/` but never loaded via `@font-face` CSS declarations. Browsers fell back to generic `monospace`, causing:

- Incorrect column alignment in command output (e.g. `apt dist-upgrade`)
- Broken TUI/ncurses rendering (box-drawing characters misaligned)

Adds `@font-face` declarations for all 4 variants (Regular, Bold, Italic, BoldItalic) with `font-display: swap`.

## Related

Closes https://github.com/Termix-SSH/Support/issues/710