### PR TITLE
feat: add CA-signed certificate authentication for SSH credentials

### DIFF
--- a/Casks/termix.rb
+++ b/Casks/termix.rb
@@ -1,6 +1,6 @@
 cask "termix" do
   version "2.2.1"
-  sha256 "d0eedef5d32a4aa68c1ba27c67bbc9d1d281310a3b27d2589f10134b86e81ba2"
+  sha256 "7fe7bde53df568c3212a212e6dc0ca4b77c24a3d3d9b740dddadcd765330e93d"
 
   url "https://github.com/Termix-SSH/Termix/releases/download/release-#{version}-tag/termix_macos_universal_dmg.dmg"
   name "Termix"

--- a/src/backend/database/db/index.ts
+++ b/src/backend/database/db/index.ts
@@ -710,6 +710,8 @@ const migrateSchema = () => {
   addColumnIfNotExists("ssh_credentials", "public_key", "TEXT");
   addColumnIfNotExists("ssh_credentials", "detected_key_type", "TEXT");
 
+  addColumnIfNotExists("ssh_credentials", "cert_public_key", "TEXT");
+
   addColumnIfNotExists("ssh_credentials", "system_password", "TEXT");
   addColumnIfNotExists("ssh_credentials", "system_key", "TEXT");
   addColumnIfNotExists("ssh_credentials", "system_key_password", "TEXT");

--- a/src/backend/database/db/schema.ts
+++ b/src/backend/database/db/schema.ts
@@ -234,6 +234,8 @@ export const sshCredentials = sqliteTable("ssh_credentials", {
   keyType: text("key_type"),
   detectedKeyType: text("detected_key_type"),
 
+  certPublicKey: text("cert_public_key", { length: 8192 }),
+
   systemPassword: text("system_password"),
   systemKey: text("system_key", { length: 16384 }),
   systemKeyPassword: text("system_key_password"),

--- a/src/backend/database/routes/credentials.ts
+++ b/src/backend/database/routes/credentials.ts
@@ -147,6 +147,7 @@ router.post(
       key,
       keyPassword,
       keyType,
+      certPublicKey,
     } = req.body;
 
     if (!isNonEmptyString(userId) || !isNonEmptyString(name)) {
@@ -230,6 +231,8 @@ router.post(
         keyPassword: plainKeyPassword,
         keyType: keyType || null,
         detectedKeyType: keyInfo?.keyType || null,
+        certPublicKey:
+          authType === "key" && certPublicKey ? certPublicKey.trim() : null,
         usageCount: 0,
         lastUsed: null,
       };
@@ -440,6 +443,9 @@ router.get(
       if (credential.publicKey) {
         output.publicKey = credential.publicKey;
       }
+      if (credential.certPublicKey) {
+        output.certPublicKey = credential.certPublicKey;
+      }
       if (credential.keyPassword) {
         output.keyPassword = credential.keyPassword;
       }
@@ -571,6 +577,9 @@ router.put(
       }
       if (updateData.keyPassword !== undefined) {
         updateFields.keyPassword = updateData.keyPassword || null;
+      }
+      if (updateData.certPublicKey !== undefined) {
+        updateFields.certPublicKey = updateData.certPublicKey?.trim() || null;
       }
 
       if (Object.keys(updateFields).length === 0) {
@@ -947,6 +956,7 @@ function formatCredentialOutput(
     authType: credential.authType,
     username: credential.username || null,
     publicKey: credential.publicKey,
+    hasCertPublicKey: !!credential.certPublicKey,
     keyType: credential.keyType,
     detectedKeyType: credential.detectedKeyType,
     usageCount: credential.usageCount || 0,

--- a/src/backend/ssh/auth-manager.ts
+++ b/src/backend/ssh/auth-manager.ts
@@ -10,6 +10,7 @@ interface ResolvedCredentials {
   key?: Buffer;
   keyPassword?: string;
   authType?: string;
+  certPublicKey?: string;
 }
 
 interface HostConfig {
@@ -81,6 +82,7 @@ export class SSHAuthManager {
             : undefined,
           keyPassword: (cred.keyPassword as string) || undefined,
           authType: (cred.authType as string) || "none",
+          certPublicKey: (cred.certPublicKey as string) || undefined,
         };
       }
     } else {

--- a/src/backend/ssh/docker-console.ts
+++ b/src/backend/ssh/docker-console.ts
@@ -258,6 +258,12 @@ wss.on("connection", async (ws: WebSocket, req) => {
   }
 
   if (!token) {
+    const urlObj = new URL(req.url || "", "http://localhost");
+    const qp = urlObj.searchParams.get("token");
+    if (qp) token = qp;
+  }
+
+  if (!token) {
     ws.close(1008, "Authentication required");
     return;
   }

--- a/src/backend/ssh/host-resolver.ts
+++ b/src/backend/ssh/host-resolver.ts
@@ -126,13 +126,17 @@ export async function resolveHostById(
       if (credentials.length > 0) {
         const cred = credentials[0] as Record<string, unknown>;
         host.password = cred.password;
-        host.key = cred.key;
+        // Prefer the normalised private key; fall back to raw key field
+        host.key = (cred.privateKey || cred.key) as string | null;
         host.keyPassword = cred.keyPassword;
         host.keyType = cred.keyType;
+        // CA-signed certificate for cert-based auth
+        (host as Record<string, unknown>).certPublicKey =
+          cred.certPublicKey || null;
         if (!host.overrideCredentialUsername) {
           host.username = cred.username;
         }
-        host.authType = cred.key ? "key" : cred.password ? "password" : "none";
+        host.authType = host.key ? "key" : host.password ? "password" : "none";
       }
     } catch (e) {
       sshLogger.warn("Failed to resolve credential for host", {

--- a/src/backend/ssh/opkssh-cert-auth.ts
+++ b/src/backend/ssh/opkssh-cert-auth.ts
@@ -1,8 +1,11 @@
-// OPKSSH certificate authentication workarounds for ssh2.
+// SSH certificate authentication workarounds for ssh2.
 // ssh2 doesn't support OpenSSH cert auth natively — this module grafts
 // the certificate onto the parsed key, wraps ECDSA signing to convert
 // DER → SSH wire format, and patches Protocol.authPK to use the base
 // algorithm in the signature wrapper (required by OpenSSH's sshkey_check_sigtype).
+//
+// setupOPKSSHCertAuth: for OPKSSH-issued ephemeral certificates (no passphrase)
+// setupCACertAuth:     for user-managed CA-signed -cert.pub files (passphrase supported)
 
 import type {
   AnyAuthMethod,
@@ -62,44 +65,39 @@ type OPKSSHNextAuthHandler = (
   authInfo: AuthenticationType | AnyAuthMethod | false,
 ) => void;
 
-export async function setupOPKSSHCertAuth(
+// ── Internal implementation ──────────────────────────────────────────────────
+// Grafts an OpenSSH certificate onto an already-parsed private key object and
+// patches the ssh2 client so that certificate-based publickey auth succeeds.
+
+async function _applyCertToConnection(
   config: ConnectConfig,
   client: Client,
-  token: OPKSSHToken,
-  username: string,
+  privKey: ParsedPrivateKey,
+  certStr: string,
 ): Promise<void> {
-  const { createRequire } = await import("node:module");
-  const esmRequire = createRequire(import.meta.url);
-  const {
-    utils: { parseKey },
-  } = esmRequire("ssh2");
-
-  const parsed = parseKey(Buffer.from(token.privateKey));
-  if (parsed instanceof Error || !parsed) {
-    throw new Error("Failed to parse OPKSSH private key");
-  }
-  const privKey = (
-    Array.isArray(parsed) ? parsed[0] : parsed
-  ) as ParsedPrivateKey;
-
   // Extract cert type and blob from the stored certificate
-  const certParts = token.sshCert.trim().split(/\s+/);
+  const certParts = certStr.trim().split(/\s+/);
+  if (certParts.length < 2) {
+    throw new Error(
+      "Invalid certificate format: expected '<type> <base64>' string",
+    );
+  }
   const certType = certParts[0];
-  privKey.type = certType;
   const certBlob = Buffer.from(certParts[1], "base64");
 
-  // Replace the internal public SSH blob with the full certificate
+  // Graft cert type and blob onto the parsed private key
+  privKey.type = certType;
   const pubSSHSym = Object.getOwnPropertySymbols(privKey).find(
     (s) => String(s) === "Symbol(Public key SSH)",
   );
   if (!pubSSHSym) {
     throw new Error(
-      "Cannot find public SSH symbol on parsed key, ssh2 internals may have changed",
+      "Cannot find public SSH symbol on parsed key; ssh2 internals may have changed",
     );
   }
   privKey[pubSSHSym] = certBlob;
 
-  // Wrap sign() for ECDSA cert keys
+  // Wrap sign() for ECDSA cert keys (DER → SSH wire format)
   if (privKey.type.startsWith("ecdsa-")) {
     const origSign = privKey.sign.bind(privKey);
     privKey.sign = (data: Buffer, algo?: string) => {
@@ -145,7 +143,7 @@ export async function setupOPKSSHCertAuth(
       certAuthAttempted = true;
       next({
         type: "publickey",
-        username,
+        username: (config as Record<string, unknown>).username as string,
         key: privKey as unknown as PublicKeyAuthMethod["key"],
       });
     } else {
@@ -295,4 +293,76 @@ export async function setupOPKSSHCertAuth(
     };
     return connectedClient;
   };
+}
+
+// ── Public API ───────────────────────────────────────────────────────────────
+
+/**
+ * Set up OPKSSH certificate authentication on an ssh2 Client.
+ * The OPKSSH private key is assumed to be unencrypted (no passphrase).
+ */
+export async function setupOPKSSHCertAuth(
+  config: ConnectConfig,
+  client: Client,
+  token: OPKSSHToken,
+  username: string,
+): Promise<void> {
+  const { createRequire } = await import("node:module");
+  const esmRequire = createRequire(import.meta.url);
+  const {
+    utils: { parseKey },
+  } = esmRequire("ssh2");
+
+  // Store username in config so the authHandler can access it
+  (config as Record<string, unknown>).username = username;
+
+  const parsed = parseKey(Buffer.from(token.privateKey));
+  if (parsed instanceof Error || !parsed) {
+    throw new Error("Failed to parse OPKSSH private key");
+  }
+  const privKey = (
+    Array.isArray(parsed) ? parsed[0] : parsed
+  ) as ParsedPrivateKey;
+
+  await _applyCertToConnection(config, client, privKey, token.sshCert);
+}
+
+/**
+ * Set up CA-signed certificate authentication on an ssh2 Client.
+ * Supports passphrase-protected private keys.
+ * The cert content is the full text of the -cert.pub file
+ * (e.g. "ssh-ed25519-cert-v01@openssh.com AAAA...").
+ */
+export async function setupCACertAuth(
+  config: ConnectConfig,
+  client: Client,
+  privateKey: Buffer | string,
+  certPublicKey: string,
+  username: string,
+  passphrase?: string,
+): Promise<void> {
+  const { createRequire } = await import("node:module");
+  const esmRequire = createRequire(import.meta.url);
+  const {
+    utils: { parseKey },
+  } = esmRequire("ssh2");
+
+  // Store username in config so the authHandler can access it
+  (config as Record<string, unknown>).username = username;
+
+  const keyBuf = Buffer.isBuffer(privateKey)
+    ? privateKey
+    : Buffer.from(privateKey, "utf8");
+
+  const parsed = passphrase ? parseKey(keyBuf, passphrase) : parseKey(keyBuf);
+
+  if (parsed instanceof Error || !parsed) {
+    const errMsg = parsed instanceof Error ? parsed.message : "unknown error";
+    throw new Error(`Failed to parse private key for CA cert auth: ${errMsg}`);
+  }
+  const privKey = (
+    Array.isArray(parsed) ? parsed[0] : parsed
+  ) as ParsedPrivateKey;
+
+  await _applyCertToConnection(config, client, privKey, certPublicKey);
 }

--- a/src/backend/ssh/terminal.ts
+++ b/src/backend/ssh/terminal.ts
@@ -433,6 +433,12 @@ wss.on("connection", async (ws: WebSocket, req) => {
     }
 
     if (!token) {
+      const urlObj = new URL(req.url || "", "http://localhost");
+      const qp = urlObj.searchParams.get("token");
+      if (qp) token = qp;
+    }
+
+    if (!token) {
       ws.close(1008, "Authentication required");
       return;
     }

--- a/src/backend/ssh/terminal.ts
+++ b/src/backend/ssh/terminal.ts
@@ -1245,6 +1245,7 @@ wss.on("connection", async (ws: WebSocket, req) => {
       keyPassword,
       keyType,
       authType,
+      certPublicKey: undefined as string | undefined,
     };
     const authMethodNotAvailable = false;
     if (id && userId && !password && !key) {
@@ -1259,6 +1260,8 @@ wss.on("connection", async (ws: WebSocket, req) => {
             keyPassword: keyPassword || resolvedHost.keyPassword,
             keyType: resolvedHost.keyType,
             authType: resolvedHost.authType,
+            certPublicKey: (resolvedHost as unknown as Record<string, unknown>)
+              .certPublicKey as string | undefined,
           };
           sendLog(
             "auth",
@@ -1286,6 +1289,8 @@ wss.on("connection", async (ws: WebSocket, req) => {
             keyPassword: keyPassword || resolvedHost.keyPassword,
             keyType: resolvedHost.keyType,
             authType: resolvedHost.authType,
+            certPublicKey: (resolvedHost as unknown as Record<string, unknown>)
+              .certPublicKey as string | undefined,
           };
         }
       } catch (error) {
@@ -2238,6 +2243,45 @@ wss.on("connection", async (ws: WebSocket, req) => {
 
         if (resolvedCredentials.password) {
           connectConfig.password = resolvedCredentials.password;
+        }
+
+        // Apply CA-signed certificate if one is stored in the credential
+        if (
+          resolvedCredentials.certPublicKey &&
+          resolvedCredentials.certPublicKey.trim()
+        ) {
+          try {
+            const { setupCACertAuth } = await import("./opkssh-cert-auth.js");
+            await setupCACertAuth(
+              connectConfig,
+              sshConn,
+              connectConfig.privateKey as Buffer,
+              resolvedCredentials.certPublicKey,
+              username,
+              resolvedCredentials.keyPassword,
+            );
+            sendLog("auth", "info", "CA certificate authentication configured");
+            sshLogger.info("CA cert auth configured", {
+              operation: "ca_cert_auth_configured",
+              userId,
+              hostId: id,
+            });
+          } catch (certError) {
+            sendLog(
+              "auth",
+              "warning",
+              "CA certificate setup failed – falling back to key-only auth",
+            );
+            sshLogger.warn("CA cert auth setup failed", {
+              operation: "ca_cert_auth_setup_failed",
+              userId,
+              hostId: id,
+              error:
+                certError instanceof Error
+                  ? certError.message
+                  : String(certError),
+            });
+          }
         }
       } catch (keyError) {
         sshLogger.error("SSH key format error: " + keyError.message);

--- a/src/backend/utils/ssh-key-utils.ts
+++ b/src/backend/utils/ssh-key-utils.ts
@@ -103,6 +103,27 @@ function detectKeyTypeFromContent(keyContent: string): string {
 function detectPublicKeyTypeFromContent(publicKeyContent: string): string {
   const content = publicKeyContent.trim();
 
+  // OpenSSH certificate types (must be checked before plain key types)
+  if (content.startsWith("ssh-ed25519-cert-v01@openssh.com ")) {
+    return "ssh-ed25519-cert-v01@openssh.com";
+  }
+  if (content.startsWith("ssh-rsa-cert-v01@openssh.com ")) {
+    return "ssh-rsa-cert-v01@openssh.com";
+  }
+  if (content.startsWith("ecdsa-sha2-nistp256-cert-v01@openssh.com ")) {
+    return "ecdsa-sha2-nistp256-cert-v01@openssh.com";
+  }
+  if (content.startsWith("ecdsa-sha2-nistp384-cert-v01@openssh.com ")) {
+    return "ecdsa-sha2-nistp384-cert-v01@openssh.com";
+  }
+  if (content.startsWith("ecdsa-sha2-nistp521-cert-v01@openssh.com ")) {
+    return "ecdsa-sha2-nistp521-cert-v01@openssh.com";
+  }
+  if (content.startsWith("sk-ssh-ed25519-cert-v01@openssh.com ")) {
+    return "sk-ssh-ed25519-cert-v01@openssh.com";
+  }
+
+  // Plain public keys
   if (content.startsWith("ssh-rsa ")) {
     return "ssh-rsa";
   }

--- a/src/locales/en.json
+++ b/src/locales/en.json
@@ -189,7 +189,17 @@
     "failedToDeployKey": "Failed to deploy SSH key",
     "clickToRenameFolder": "Click to rename folder",
     "renameFolder": "Rename folder",
-    "idLabel": "ID:"
+    "idLabel": "ID:",
+    "caCertificate": "CA Certificate (-cert.pub)",
+    "caCertificateDescription": "Optional: Upload or paste the CA-signed certificate file (e.g. id_ed25519-cert.pub). Required when your SSH server uses certificate-based authorization.",
+    "uploadCertFile": "Upload -cert.pub File",
+    "clearCert": "Clear",
+    "certLoaded": "Certificate loaded",
+    "certPublicKeyLabel": "CA Certificate",
+    "certTypeLabel": "Certificate type",
+    "pasteOrUploadCert": "Paste or upload a -cert.pub certificate...",
+    "hasCaCert": "Has CA Certificate",
+    "noCaCert": "No CA Certificate"
   },
   "quickConnect": {
     "title": "Quick Connect",

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -201,6 +201,10 @@ export interface Credential {
   password?: string;
   key?: string;
   publicKey?: string;
+  /** CA-signed certificate file content (e.g. id_ed25519-cert.pub) */
+  certPublicKey?: string;
+  /** True when a cert is stored but certPublicKey content is redacted in list responses */
+  hasCertPublicKey?: boolean;
   keyPassword?: string;
   keyType?: string;
   usageCount: number;
@@ -222,6 +226,8 @@ export interface CredentialBackend {
   key: string;
   privateKey?: string;
   publicKey?: string;
+  /** CA-signed certificate file content (e.g. id_ed25519-cert.pub) */
+  certPublicKey?: string;
   keyPassword: string | null;
   keyType?: string;
   detectedKeyType: string;
@@ -241,6 +247,8 @@ export interface CredentialData {
   password?: string;
   key?: string;
   publicKey?: string;
+  /** CA-signed certificate file content (e.g. id_ed25519-cert.pub) */
+  certPublicKey?: string | null;
   keyPassword?: string;
   keyType?: string;
 }

--- a/src/ui/desktop/apps/features/terminal/Terminal.tsx
+++ b/src/ui/desktop/apps/features/terminal/Terminal.tsx
@@ -866,6 +866,10 @@ const TerminalInner = forwardRef<TerminalHandle, SSHTerminalProps>(
             .replace(/^https?:\/\//, "")
             .replace(/\/$/, "");
           baseWsUrl = `${wsProtocol}${wsHost}/ssh/websocket/`;
+          const storedJwt = localStorage.getItem("jwt");
+          if (storedJwt) {
+            baseWsUrl += `?token=${encodeURIComponent(storedJwt)}`;
+          }
         }
       } else {
         baseWsUrl = `${getBasePath()}/ssh/websocket/`;

--- a/src/ui/desktop/apps/host-manager/credentials/CredentialEditor.tsx
+++ b/src/ui/desktop/apps/host-manager/credentials/CredentialEditor.tsx
@@ -132,6 +132,8 @@ export function CredentialEditor({
       password: z.string().optional(),
       key: z.any().optional().nullable(),
       publicKey: z.string().optional(),
+      /** CA-signed certificate file content (id_ed25519-cert.pub) */
+      certPublicKey: z.string().optional(),
       keyPassword: z.string().optional(),
       keyType: z
         .enum([
@@ -184,6 +186,7 @@ export function CredentialEditor({
       password: "",
       key: null,
       publicKey: "",
+      certPublicKey: "",
       keyPassword: "",
       keyType: "auto",
     },
@@ -215,6 +218,7 @@ export function CredentialEditor({
       if (authTab === "password") {
         form.setValue("key", null, { shouldValidate: true });
         form.setValue("publicKey", "", { shouldValidate: true });
+        form.setValue("certPublicKey", "", { shouldValidate: true });
         form.setValue("keyPassword", "", { shouldValidate: true });
         form.setValue("keyType", "auto", { shouldValidate: true });
       } else if (authTab === "key") {
@@ -253,6 +257,7 @@ export function CredentialEditor({
         } else if (defaultAuthType === "key") {
           formData.key = fullCredentialDetails.key || "";
           formData.publicKey = fullCredentialDetails.publicKey || "";
+          formData.certPublicKey = fullCredentialDetails.certPublicKey || "";
           formData.keyPassword = fullCredentialDetails.keyPassword || "";
           formData.keyType =
             (fullCredentialDetails.keyType as string) || ("auto" as const);
@@ -273,6 +278,7 @@ export function CredentialEditor({
         password: "",
         key: null,
         publicKey: "",
+        certPublicKey: "",
         keyPassword: "",
         keyType: "auto",
       });
@@ -404,6 +410,7 @@ export function CredentialEditor({
       } else if (data.authType === "key") {
         submitData.key = data.key;
         submitData.publicKey = data.publicKey;
+        submitData.certPublicKey = data.certPublicKey || null;
         submitData.keyPassword = data.keyPassword;
         submitData.keyType = data.keyType;
       }

--- a/src/ui/desktop/apps/host-manager/credentials/CredentialViewer.tsx
+++ b/src/ui/desktop/apps/host-manager/credentials/CredentialViewer.tsx
@@ -444,6 +444,29 @@ const CredentialViewer: React.FC<CredentialViewerProps> = ({
                         "keyPassword",
                         t("credentials.keyPassphrase"),
                       )}
+
+                    {/* CA Certificate indicator */}
+                    <div className="flex items-center space-x-3 p-3 bg-surface rounded-lg">
+                      <Shield className="h-4 w-4 text-foreground-subtle" />
+                      <div>
+                        <div className="text-sm font-medium text-foreground-secondary">
+                          {t("credentials.caCertificate")}
+                        </div>
+                        {credentialDetails.hasCertPublicKey ||
+                        credentialDetails.certPublicKey ? (
+                          <Badge
+                            variant="outline"
+                            className="text-green-600 border-green-600 mt-1"
+                          >
+                            {t("credentials.certLoaded")}
+                          </Badge>
+                        ) : (
+                          <span className="text-xs text-muted-foreground">
+                            {t("credentials.noCaCert")}
+                          </span>
+                        )}
+                      </div>
+                    </div>
                   </div>
                 )}
 

--- a/src/ui/desktop/apps/host-manager/credentials/tabs/CredentialAuthenticationTab.tsx
+++ b/src/ui/desktop/apps/host-manager/credentials/tabs/CredentialAuthenticationTab.tsx
@@ -6,6 +6,7 @@ import {
 } from "@/components/ui/form.tsx";
 import { PasswordInput } from "@/components/ui/password-input.tsx";
 import { Button } from "@/components/ui/button.tsx";
+import { Badge } from "@/components/ui/badge.tsx";
 import {
   Tabs,
   TabsContent,
@@ -23,6 +24,20 @@ import {
   generatePublicKeyFromPrivate,
 } from "@/ui/main-axios.ts";
 import type { CredentialAuthenticationTabProps } from "./shared/tab-types";
+
+/** Map an OpenSSH cert type string to a human-readable label. */
+function getCertTypeName(certContent: string): string {
+  const firstWord = certContent.trim().split(/\s+/)[0] ?? "";
+  const map: Record<string, string> = {
+    "ssh-ed25519-cert-v01@openssh.com": "Ed25519 Certificate",
+    "ssh-rsa-cert-v01@openssh.com": "RSA Certificate",
+    "ecdsa-sha2-nistp256-cert-v01@openssh.com": "ECDSA P-256 Certificate",
+    "ecdsa-sha2-nistp384-cert-v01@openssh.com": "ECDSA P-384 Certificate",
+    "ecdsa-sha2-nistp521-cert-v01@openssh.com": "ECDSA P-521 Certificate",
+    "sk-ssh-ed25519-cert-v01@openssh.com": "SK-Ed25519 Certificate",
+  };
+  return map[firstWord] ?? (firstWord.includes("-cert-") ? firstWord : "");
+}
 
 export function CredentialAuthenticationTab({
   form,
@@ -489,6 +504,121 @@ export function CredentialAuthenticationTab({
                 )}
               />
             </div>
+            {/* CA Certificate (-cert.pub) */}
+            <div className="mt-3 p-3 border border-muted rounded-md">
+              <FormLabel className="mb-1 font-bold block">
+                {t("credentials.caCertificate")}
+              </FormLabel>
+              <p className="text-xs text-muted-foreground mb-2">
+                {t("credentials.caCertificateDescription")}
+              </p>
+              <Controller
+                control={form.control}
+                name="certPublicKey"
+                render={({ field }) => {
+                  const certTypeName = field.value
+                    ? getCertTypeName(field.value)
+                    : "";
+                  return (
+                    <FormItem className="flex flex-col gap-2">
+                      <div className="flex gap-2 items-center">
+                        <div className="relative inline-block flex-1">
+                          <input
+                            id="cert-upload"
+                            type="file"
+                            accept=".pub,.txt,*"
+                            onChange={async (e) => {
+                              const file = e.target.files?.[0];
+                              if (file) {
+                                try {
+                                  const content = await file.text();
+                                  field.onChange(content.trim());
+                                } catch {
+                                  toast.error(
+                                    t("credentials.failedToGeneratePublicKey"),
+                                  );
+                                }
+                              }
+                              // reset so the same file can be re-selected
+                              e.target.value = "";
+                            }}
+                            className="absolute inset-0 w-full h-full opacity-0 cursor-pointer"
+                          />
+                          <Button
+                            type="button"
+                            variant="outline"
+                            className="w-full justify-start text-left"
+                          >
+                            <span className="truncate">
+                              {t("credentials.uploadCertFile")}
+                            </span>
+                          </Button>
+                        </div>
+                        {field.value && (
+                          <Button
+                            type="button"
+                            variant="outline"
+                            size="sm"
+                            className="flex-shrink-0"
+                            onClick={() => field.onChange("")}
+                          >
+                            {t("credentials.clearCert")}
+                          </Button>
+                        )}
+                      </div>
+                      <FormControl>
+                        <CodeMirror
+                          value={field.value ?? ""}
+                          onChange={(value) => field.onChange(value)}
+                          placeholder={t("credentials.pasteOrUploadCert")}
+                          theme={editorTheme}
+                          className="border border-input rounded-md overflow-hidden"
+                          minHeight="60px"
+                          basicSetup={{
+                            lineNumbers: false,
+                            foldGutter: false,
+                            dropCursor: false,
+                            allowMultipleSelections: false,
+                            highlightSelectionMatches: false,
+                            searchKeymap: false,
+                            scrollPastEnd: false,
+                          }}
+                          extensions={[
+                            EditorView.theme({
+                              ".cm-scroller": {
+                                overflow: "auto",
+                                scrollbarWidth: "thin",
+                                scrollbarColor:
+                                  "var(--scrollbar-thumb) var(--scrollbar-track)",
+                              },
+                            }),
+                          ]}
+                        />
+                      </FormControl>
+                      {field.value && certTypeName && (
+                        <div className="flex items-center gap-2 text-sm">
+                          <span className="text-muted-foreground">
+                            {t("credentials.certTypeLabel")}:
+                          </span>
+                          <Badge
+                            variant="outline"
+                            className="text-green-600 border-green-600"
+                          >
+                            {certTypeName}
+                          </Badge>
+                        </div>
+                      )}
+                      {field.value && !certTypeName && (
+                        <p className="text-xs text-destructive">
+                          {t("credentials.invalidKey")}
+                        </p>
+                      )}
+                    </FormItem>
+                  );
+                }}
+              />
+            </div>
+
             <div className="grid grid-cols-8 gap-3 mt-3">
               <FormField
                 control={form.control}


### PR DESCRIPTION
# Overview
Support OpenSSH certificate-based authentication (-cert.pub files) in the Credentials manager. When a CA-signed certificate is stored alongside a private key, Termix uses it during SSH connection establishment so that servers relying on certificate-based authorization work out of the box.

# Changes Made
- db/schema.ts: add cert_public_key column to ssh_credentials table
- db/index.ts: auto-migration via addColumnIfNotExists
- routes/credentials.ts: expose certPublicKey in create/update/get endpoints
- ssh/auth-manager.ts: include certPublicKey in ResolvedCredentials
- ssh/host-resolver.ts: propagate certPublicKey when resolving credentials
- ssh/opkssh-cert-auth.ts: refactor shared logic into _applyCertToConnection; export new setupCACertAuth() with optional passphrase support
- ssh/terminal.ts: call setupCACertAuth() when a certificate is present
- utils/ssh-key-utils.ts: detect all OpenSSH cert types in public key parser
- types/index.ts: add certPublicKey to Credential, CredentialBackend, CredentialData interfaces
- CredentialAuthenticationTab.tsx: new CA Certificate section with file upload, paste editor and automatic cert-type badge
- CredentialEditor.tsx: certPublicKey wired into form schema and submit
- CredentialViewer.tsx: show certificate status in security tab
- locales/en.json: add i18n strings for new UI elements

# Screenshots / Demos
<img width="1056" height="819" alt="Screenshot 2026-05-23 at 00 15 32" src="https://github.com/user-attachments/assets/5a11ff94-6981-4e2e-8b6e-6e70178fb0b3" />

# Checklist

- [x] Code follows project style guidelines
- [ ] Supports mobile and desktop UI/app (if applicable)
- [x] I have read [Contributing.md](https://github.com/Termix-SSH/Termix/blob/main/CONTRIBUTING.md)
- [x] This is not a translation request. See [docs](https://docs.termix.site/translations)
