### PR TITLE
persist and use jwt for embedded mode

### DIFF
--- a/src/ui/desktop/apps/features/terminal/Terminal.tsx
+++ b/src/ui/desktop/apps/features/terminal/Terminal.tsx
@@ -851,6 +851,13 @@ const TerminalInner = forwardRef<TerminalHandle, SSHTerminalProps>(
 
         if (isEmbeddedMode()) {
           baseWsUrl = "ws://127.0.0.1:30002";
+///>>> this block of code is cut/pasted from below.  It seems this is needed only for
+///    the embedded mode case.
+          const storedJwt = localStorage.getItem("jwt");
+          if (storedJwt) {
+            baseWsUrl += `?token=${encodeURIComponent(storedJwt)}`;
+          }
+///<<<
         } else if (!configuredUrl) {
           console.error("No configured server URL available for Electron SSH");
           setIsConnected(false);
@@ -866,11 +873,9 @@ const TerminalInner = forwardRef<TerminalHandle, SSHTerminalProps>(
             .replace(/^https?:\/\//, "")
             .replace(/\/$/, "");
           baseWsUrl = `${wsProtocol}${wsHost}/ssh/websocket/`;
-          const storedJwt = localStorage.getItem("jwt");
-          if (storedJwt) {
-            baseWsUrl += `?token=${encodeURIComponent(storedJwt)}`;
-          }
         }
+///>>> alternatively, the moved block of code could be inserted here and it would
+///>>> apply to both the embedded and non-embedded cases.
       } else {
         baseWsUrl = `${getBasePath()}/ssh/websocket/`;
       }

--- a/src/ui/main-axios.ts
+++ b/src/ui/main-axios.ts
@@ -869,7 +869,8 @@ function initializeApp() {
   if (isElectron()) {
     Promise.all([getServerConfig(), getEmbeddedServerStatus()])
       .then(([config, status]) => {
-        if (status?.embedded && status?.running) {
+        /// this is a port of your fix from beta branch
+        if (status?.embedded && status?.running && !config?.serverUrl) {
           embeddedMode = true;
         }
         if (config?.serverUrl) {
@@ -2856,6 +2857,16 @@ export async function loginUser(
       password,
       rememberMe,
     });
+
+    ///>>> from what I could tell, the jwt was not getting persisted to local
+    ///    storage by the existing code (ie. ElectronLoginForm.tsx line 46 was never
+    ///    getting hit).  I assume that there is a more appropriate fix
+    ///    but the flow is too complicated for me, so I stuck this here for testing
+    ///    and it seems to work. 
+    if (response.data.token) {
+      localStorage.setItem("jwt", response.data.token);
+    }
+    ///<<<
 
     const isInIframe =
       typeof window !== "undefined" && window.self !== window.top;


### PR DESCRIPTION
# Overview

_Short summary of what this PR does_

- [ ] Fixed: Local server mode on the main branch is completely broken for me.  I cannot add hosts, or do anything really.  These changes essentially get this mode working by adding the jwt to the requests going to the internal server. 

# Changes Made

The change in main-axios.ts stores the jwt coming from the user/login request to local storage so that it can later be included or appended to the requests.  I don't understand how this code is supposed to work, so the change to this file is only speculative -- I assume there is a better fix.  

Once I was able to create a host in local server mode, I immediately started getting "Authentication failed" errors when trying to connect to the host via SSH.  This is why the fix in Terminal.tsx was required.

I tried porting these changes to the code from the dev-2.3.0 branch.  They improved the behavior by allowing me to login and create hosts.  However, it looks like there may be some other issue in that branch as SSH connections seem to hang and timeout.

# Related Issues

# Screenshots / Demos

# Checklist

- [x] Code follows project style guidelines
- [ ] Supports mobile and desktop UI/app (if applicable)
- [x] I have read [Contributing.md](https://github.com/Termix-SSH/Termix/blob/main/CONTRIBUTING.md)
- [x] This is not a translation request. See [docs](https://docs.termix.site/translations)
