### PR TITLE
feat(tabs): rename tabs via double-click

### DIFF
--- a/src/locales/en.json
+++ b/src/locales/en.json
@@ -568,7 +568,8 @@
     "sudoPasswordCopied": "Sudo password copied to clipboard",
     "noPasswordAvailable": "No password available",
     "failedToCopyPassword": "Failed to copy password",
-    "openFileManager": "Open File Manager"
+    "openFileManager": "Open File Manager",
+    "doubleClickToRename": "Double-click to rename"
   },
   "admin": {
     "title": "Admin Settings",

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -492,6 +492,7 @@ export interface TabContextTab {
     | "vnc"
     | "telnet";
   title: string;
+  customTitle?: string;
   hostConfig?: SSHHost;
   terminalRef?: RefObject<TerminalRefHandle | null>;
   initialTab?: string;

--- a/src/ui/desktop/navigation/TopNavbar.tsx
+++ b/src/ui/desktop/navigation/TopNavbar.tsx
@@ -461,8 +461,13 @@ export function TopNavbar({
                 <Tab
                   tabType={tab.type}
                   title={tab.title}
+                  customTitle={tab.customTitle}
                   isActive={isActive}
                   isSplit={isSplit}
+                  canRename={tab.type !== "home"}
+                  onRename={(newTitle) =>
+                    updateTab(tab.id, { customTitle: newTitle })
+                  }
                   onActivate={() => handleTabActivate(tab.id)}
                   onClose={
                     isTerminal ||
@@ -503,7 +508,7 @@ export function TopNavbar({
                   isDragOver={false}
                   hostConfig={tab.hostConfig}
                   onOpenFileManager={
-                    isTerminal && (tab.hostConfig as any)?.enableFileManager
+                    isTerminal && tab.hostConfig?.enableFileManager
                       ? () => tab.terminalRef?.current?.openFileManager?.()
                       : undefined
                   }

--- a/src/ui/desktop/navigation/tabs/Tab.tsx
+++ b/src/ui/desktop/navigation/tabs/Tab.tsx
@@ -1,4 +1,4 @@
-import React from "react";
+import React, { useEffect, useRef, useState } from "react";
 import { Button } from "@/components/ui/button.tsx";
 import { useTranslation } from "react-i18next";
 import { getHostPassword } from "@/ui/main-axios.ts";
@@ -26,13 +26,16 @@ import type { SSHHost } from "@/types";
 interface TabProps {
   tabType: string;
   title?: string;
+  customTitle?: string;
   isActive?: boolean;
   isSplit?: boolean;
   onActivate?: () => void;
   onClose?: () => void;
   onSplit?: () => void;
+  onRename?: (newTitle: string | undefined) => void;
   canSplit?: boolean;
   canClose?: boolean;
+  canRename?: boolean;
   disableActivate?: boolean;
   disableSplit?: boolean;
   disableClose?: boolean;
@@ -47,13 +50,16 @@ interface TabProps {
 export function Tab({
   tabType,
   title,
+  customTitle,
   isActive,
   isSplit = false,
   onActivate,
   onClose,
   onSplit,
+  onRename,
   canSplit = false,
   canClose = false,
+  canRename = false,
   disableActivate = false,
   disableSplit = false,
   disableClose = false,
@@ -65,6 +71,41 @@ export function Tab({
   onOpenFileManager,
 }: TabProps): React.ReactElement {
   const { t } = useTranslation();
+
+  const [isEditing, setIsEditing] = useState(false);
+  const [draftTitle, setDraftTitle] = useState("");
+  const inputRef = useRef<HTMLInputElement | null>(null);
+  const cancelledRef = useRef(false);
+
+  useEffect(() => {
+    if (isEditing && inputRef.current) {
+      inputRef.current.focus();
+      inputRef.current.select();
+    }
+  }, [isEditing]);
+
+  const beginEdit = (initial: string) => {
+    if (!canRename || !onRename) return;
+    cancelledRef.current = false;
+    setDraftTitle(initial);
+    setIsEditing(true);
+  };
+
+  const commitEdit = () => {
+    if (!isEditing) return;
+    setIsEditing(false);
+    if (cancelledRef.current || !onRename) {
+      cancelledRef.current = false;
+      return;
+    }
+    const trimmed = draftTitle.trim();
+    onRename(trimmed.length === 0 ? undefined : trimmed);
+  };
+
+  const cancelEdit = () => {
+    cancelledRef.current = true;
+    setIsEditing(false);
+  };
 
   const handleCopyPassword = async (e: React.MouseEvent) => {
     e.stopPropagation();
@@ -209,7 +250,7 @@ export function Tab({
     const isTunnel = tabType === "tunnel";
     const isDocker = tabType === "docker";
     const isUserProfile = tabType === "user_profile";
-    const displayTitle =
+    const fallbackTitle =
       title ||
       (isServer
         ? t("nav.serverStats")
@@ -224,6 +265,7 @@ export function Tab({
                 : tabType === "rdp" || tabType === "vnc" || tabType === "telnet"
                   ? tabType.toUpperCase()
                   : t("nav.terminal"));
+    const displayTitle = customTitle?.trim() || fallbackTitle;
 
     const { base, suffix } = splitTitle(displayTitle);
 
@@ -257,8 +299,43 @@ export function Tab({
           ) : (
             <TerminalIcon className="h-4 w-4 flex-shrink-0" />
           )}
-          <span className="truncate text-sm flex-1 min-w-0">{base}</span>
-          {suffix && <span className="text-sm flex-shrink-0">{suffix}</span>}
+          {isEditing ? (
+            <input
+              ref={inputRef}
+              type="text"
+              value={draftTitle}
+              onChange={(e) => setDraftTitle(e.target.value)}
+              onClick={(e) => e.stopPropagation()}
+              onMouseDown={(e) => e.stopPropagation()}
+              onDoubleClick={(e) => e.stopPropagation()}
+              onBlur={commitEdit}
+              onKeyDown={(e) => {
+                if (e.key === "Enter") {
+                  e.preventDefault();
+                  commitEdit();
+                } else if (e.key === "Escape") {
+                  e.preventDefault();
+                  cancelEdit();
+                }
+              }}
+              className="flex-1 min-w-0 bg-transparent border-b border-border outline-none text-sm px-0 py-0 h-5"
+            />
+          ) : (
+            <>
+              <span
+                className="truncate text-sm flex-1 min-w-0 select-none"
+                onDoubleClick={(e) => {
+                  if (!canRename || !onRename) return;
+                  e.stopPropagation();
+                  beginEdit(customTitle ?? displayTitle);
+                }}
+                title={canRename ? t("nav.doubleClickToRename") : undefined}
+              >
+                {base}
+              </span>
+              {suffix && <span className="text-sm flex-shrink-0">{suffix}</span>}
+            </>
+          )}
         </div>
 
         {hasPassword && (


### PR DESCRIPTION
## Summary

Adds inline tab rename on double-click, requested as a Tabby-style ergonomic
addition where each session can carry its own label distinct from the host name.

- Double-click a tab label → input with current title selected
- Enter or blur → save
- Esc → cancel
- Empty input → clear custom title (falls back to host/default name)

A new `customTitle?: string` field on `TabContextTab` holds the user override.
Display logic prefers `customTitle` over the existing `title` (host name or
default). `updateHostConfig` is unchanged so renaming the host no longer
overwrites a custom tab title.

Persistence rides on the existing `termix_tabs` localStorage flow, so renames
survive reloads when terminal session persistence is enabled (default).

## Scope

- Desktop only this iteration. Mobile UI tab rendering lives in
  `BottomNavbar.tsx` and double-click is awkward on touch; happy to add a
  long-press variant in a follow-up if maintainers prefer.
- Currently wired for the terminal/server_stats/file_manager/rdp/vnc/telnet/
  tunnel/docker/user_profile render block. ssh_manager/admin/network_graph
  are practically singletons and were left out to keep this PR small; trivial
  to extend if desired.
- `nav.doubleClickToRename` added to `en.json` only — other locales fall
  through Crowdin as usual.

## Drive-by

While touching `TopNavbar.tsx` I removed a stray `(tab.hostConfig as any)?.enableFileManager`
cast — `SSHHost` already declares `enableFileManager: boolean` so the cast was
unnecessary and was tripping the `check-any-changed` lint rule.

## Test plan

- [x] Double-click terminal tab → edit, Enter saves, Esc cancels, blur saves
- [x] Empty input clears custom title and reverts to host name
- [x] Updating host config (rename in Host Manager) preserves custom title
- [x] Reload with persistence enabled keeps custom title
- [x] Built and ran via `docker/Dockerfile`, exercised against a live SSH host

🤖 Generated with [Claude Code](https://claude.com/claude-code)