### PR TITLE
feat(oidc): expose admin_group via OIDC_ADMIN_GROUP env var

### DIFF
--- a/src/backend/database/routes/users.ts
+++ b/src/backend/database/routes/users.ts
@@ -64,6 +64,7 @@ function getOIDCConfigFromEnv(): {
   name_path: string;
   scopes: string;
   allowed_users: string;
+  admin_group: string;
 } | null {
   const client_id = process.env.OIDC_CLIENT_ID;
   const client_secret = process.env.OIDC_CLIENT_SECRET;
@@ -92,6 +93,7 @@ function getOIDCConfigFromEnv(): {
     name_path: process.env.OIDC_NAME_PATH || "name",
     scopes: process.env.OIDC_SCOPES || "openid email profile",
     allowed_users: process.env.OIDC_ALLOWED_USERS || "",
+    admin_group: process.env.OIDC_ADMIN_GROUP || "",
   };
 }
 


### PR DESCRIPTION
## Summary

- Adds an `OIDC_ADMIN_GROUP` environment variable, populated into the env-config object returned by [`getOIDCConfigFromEnv()`](src/backend/database/routes/users.ts#L54-L94).
- Lets deployments using the env-var config path (Helm, Docker Compose, declarative IaC) enable the admin-group sync introduced in #782 without abandoning env-var config in favor of the in-app admin UI.
- Two-line change, backward compatible: when `OIDC_ADMIN_GROUP` is unset, the field is `""` (falsy), and the existing guard `if (config.admin_group)` at [users.ts:1336](src/backend/database/routes/users.ts#L1336) keeps the sync block skipped — same behavior as today.

## Why

#782 (v2.3.0) added admin-status sync from OIDC group membership, but only via the DB-stored OIDC config (the `admin_group` field on `POST /users/oidc-config`, line [524](src/backend/database/routes/users.ts#L524)). The env-var path was not extended.

That means deployments that configure OIDC declaratively from environment — Helm values, Compose `environment:`, Kubernetes Secrets / ConfigMaps, Puppet/Ansible templates — cannot enable the feature without:

- migrating the OIDC config (including `client_secret`) into the in-app SQLite DB through the admin UI, and
- accepting that the secret-bearing config now lives outside their declarative source of truth.

Concrete fallout in my own infra: I had to drop 5 `OIDC_*` env vars from the container and paste the `client_secret` into the admin UI manually to unlock admin-group sync. This PR closes that gap so the env-var path stays viable.

## Behavior

| `OIDC_ADMIN_GROUP` (env) | `admin_group` from `getOIDCConfigFromEnv()` | Sync block at [users.ts:1336](src/backend/database/routes/users.ts#L1336) |
| --- | --- | --- |
| unset | `\"\"` | skipped (current behavior) |
| `\"admins\"` | `\"admins\"` | runs: `isAdmin` is set to `userInfo.groups.includes(\"admins\")` on each OIDC login |

The DB-stored config path is unchanged. When both `getOIDCConfigFromEnv()` returns non-null (all 5 required env vars are set) **and** an `oidc_config` row exists in `settings`, the env config wins — same precedence as today (lines [826-830](src/backend/database/routes/users.ts#L826-L830) and [941-945](src/backend/database/routes/users.ts#L941-L945)).

## Surface

`GET /users/oidc-config/admin` (admin-only endpoint, line [749-751](src/backend/database/routes/users.ts#L749-L751)) returns `getOIDCConfigFromEnv()` verbatim when no DB row exists. With this PR, that response now includes `admin_group`. The value is non-secret (an IdP group name), and the endpoint is gated by `requireAdmin`, so this is intentional and consistent with how the endpoint already exposes the other env-config fields.

## Out of scope (noted for upstream awareness)

These are pre-existing observations spotted while reviewing the surrounding code, **not** changed by this PR:

- The sync block at [users.ts:1340](src/backend/database/routes/users.ts#L1340) does `(userInfo.groups || userInfo.roles || []).includes(...)`. If an IdP returns the claim as a non-array (some return a single string when the user is in exactly one group), `includes()` returns `false` and the user silently loses admin status. A defensive normalization like `([] as string[]).concat(userInfo.groups ?? userInfo.roles ?? [])` would harden this — happy to follow up in a separate PR if you'd like.
- No OIDC env var is documented in `README.md` or `docker/docker-compose.yml` today (`OIDC_CLIENT_ID`, `OIDC_USERINFO_URL`, `OIDC_ALLOWED_USERS`, `OIDC_ALLOW_REGISTRATION`, and now `OIDC_ADMIN_GROUP` are all source-only). Not changed here to keep the PR minimal, but a follow-up "document all OIDC env vars" PR would help downstream operators.

## Test plan

- [x] Manual code-path read-through: with `OIDC_ADMIN_GROUP` unset, `getOIDCConfigFromEnv()` returns `admin_group: ""`, the `if (config.admin_group)` guard short-circuits, no behavior change.
- [x] With `OIDC_ADMIN_GROUP=admins` set and `OIDC_SCOPES` including `groups`: the OIDC token from the IdP carries the `groups` claim, the callback reads `userInfo.groups`, the sync block runs and updates `isAdmin` from membership.
- [ ] `npm run build` / `npm run lint` on CI — not run locally (no `npm install` performed for a two-line type-and-object addition; happy to run if you want the diff verified locally).