### PR TITLE
fix: allow navigating away from split-view to non-pane tabs

### DIFF
--- a/src/ui/AppShell.tsx
+++ b/src/ui/AppShell.tsx
@@ -896,7 +896,7 @@ export function AppShell({
           node.style.display = "";
           node.style.visibility = activeInline ? "visible" : "hidden";
           node.style.pointerEvents = activeInline ? "auto" : "none";
-          node.style.zIndex = activeInline && !isSplit ? "1" : "0";
+          node.style.zIndex = activeInline ? "1" : "0";
         } else {
           node.style.visibility = "";
           node.style.pointerEvents = "";
@@ -1189,12 +1189,14 @@ export function AppShell({
               {/* Normal-view container. Tab nodes are appended here (or to pane elements)
                   by the DOM-placement effect above. React portals each tab's content
                   into its stable per-tab node so the component is never remounted.
-                  Hidden when split is active — pane-assigned nodes escape via vanilla DOM
-                  appendChild to paneEl, so hiding this doesn't affect them. */}
+                  When split is active, shown on top only if the active tab is not in a pane. */}
               <div
                 ref={normalViewRef}
                 className="absolute inset-0"
-                style={{ display: isSplit && !isMobile ? "none" : undefined }}
+                style={{
+                  display: isSplit && !isMobile && paneTabIds.includes(activeTabId) ? "none" : undefined,
+                  zIndex: isSplit && !paneTabIds.includes(activeTabId) ? 10 : undefined,
+                }}
               >
                 {tabs.map((tab) => {
                   const tabNode = getTabNode(tab.id, tab.type === "terminal");


### PR DESCRIPTION
## Summary
- Show the normal-view container on top of the split view when the active tab is not assigned to any pane
- Users can now switch to dashboard or other non-pane tabs while split mode is active
- Fix z-index logic so inline tabs render correctly even during split mode

## Related Issue
Closes https://github.com/Termix-SSH/Support/issues/739

## Test plan
- [ ] Open multiple connections in split view
- [ ] Click dashboard tab — should navigate away from split view and show dashboard
- [ ] Click back on a pane tab — should return to split view
- [ ] Verify split view dividers and pane resizing still work correctly