### PR TITLE
fix: add inline quick-action buttons on host name row

### DIFF
--- a/src/ui/sidebar/SidebarTree.tsx
+++ b/src/ui/sidebar/SidebarTree.tsx
@@ -303,6 +303,46 @@ export function HostItem({
           {host.pin && (
             <Pin className="size-2.5 text-accent-brand/50 shrink-0" />
           )}
+          {!selectionMode && (
+            <div className="ml-auto flex items-center gap-0.5 shrink-0 opacity-0 group-hover:opacity-100 transition-opacity">
+              {host.enableSsh && host.enableTerminal && (
+                <button
+                  title="Terminal"
+                  onClick={(e) => { e.stopPropagation(); onOpenTab("terminal"); }}
+                  className="flex items-center justify-center size-5 rounded text-muted-foreground/40 hover:text-foreground hover:bg-muted-foreground/10 transition-colors"
+                >
+                  <Terminal className="size-3" />
+                </button>
+              )}
+              {host.enableSsh && host.enableFileManager && (
+                <button
+                  title="Files"
+                  onClick={(e) => { e.stopPropagation(); onOpenTab("files"); }}
+                  className="flex items-center justify-center size-5 rounded text-muted-foreground/40 hover:text-foreground hover:bg-muted-foreground/10 transition-colors"
+                >
+                  <FolderOpen className="size-3" />
+                </button>
+              )}
+              {host.enableRdp && (
+                <button
+                  title="RDP"
+                  onClick={(e) => { e.stopPropagation(); onOpenTab("rdp"); }}
+                  className="flex items-center justify-center size-5 rounded text-muted-foreground/40 hover:text-foreground hover:bg-muted-foreground/10 transition-colors"
+                >
+                  <Monitor className="size-3" />
+                </button>
+              )}
+              {host.enableVnc && (
+                <button
+                  title="VNC"
+                  onClick={(e) => { e.stopPropagation(); onOpenTab("vnc"); }}
+                  className="flex items-center justify-center size-5 rounded text-muted-foreground/40 hover:text-foreground hover:bg-muted-foreground/10 transition-colors"
+                >
+                  <MousePointerClick className="size-3" />
+                </button>
+              )}
+            </div>
+          )}
         </div>
 
         {/* Address — only visible on hover (or click when trayOnClick) or while menu is open */}


### PR DESCRIPTION
## Summary
- Add Terminal, Files, RDP, VNC shortcut icons directly on the host name row
- Icons appear on hover without requiring the full action tray to expand
- Single-click access to primary connections, matching the pre-2.3.0 UX pattern
- Respects `enableTerminal`, `enableFileManager`, `enableRdp`, `enableVnc` flags

## Related Issue
Closes https://github.com/Termix-SSH/Support/issues/736

## Test plan
- [ ] Hover over a host — quick action icons appear on the right side of the name row
- [ ] Click Terminal icon — opens terminal session without expanding tray
- [ ] Click Files icon — opens file manager without expanding tray
- [ ] Verify full action tray still works (hover/click to expand)
- [ ] Verify icons respect host connection type flags