### PR TITLE
fix: apply guacamole-lite protocol patch in Docker builds

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -8,7 +8,10 @@ COPY package*.json ./
 COPY .npmrc ./
 COPY vendor ./vendor
 
+COPY scripts/patch-guacamole-lite.cjs ./scripts/
+
 RUN npm ci --ignore-scripts && \
+    node scripts/patch-guacamole-lite.cjs && \
     npm cache clean --force
 
 # Stage 2: Build frontend
@@ -42,7 +45,10 @@ COPY package*.json ./
 COPY .npmrc ./
 COPY vendor ./vendor
 
+COPY scripts/patch-guacamole-lite.cjs ./scripts/
+
 RUN npm ci --omit=dev --ignore-scripts && \
+    node scripts/patch-guacamole-lite.cjs && \
     npm rebuild better-sqlite3 bcryptjs && \
     npm cache clean --force
 


### PR DESCRIPTION
## Summary
- Dockerfile uses `--ignore-scripts` which skips the `postinstall` hook
- The guacamole-lite patch for guacd 1.6.0 protocol VERSION_1_5_0 was never applied in Docker builds
- Without the patch, timezone handshake instruction is missing for protocol versions > 1.1.0
- VNC connections fail immediately because guacd 1.6.0 expects the timezone instruction

## Related Issue
Closes https://github.com/Termix-SSH/Support/issues/734

## Test plan
- [ ] Build Docker image — verify patch output in build log
- [ ] Connect to VNC host via guacd 1.6.0 — connection should succeed
- [ ] Verify RDP connections still work through guacamole
- [ ] Check guacd logs for successful protocol negotiation