### PR TITLE
fix: resolve sudo password for shared host users

### DIFF
--- a/src/backend/database/routes/host.ts
+++ b/src/backend/database/routes/host.ts
@@ -1807,16 +1807,36 @@ router.get(
 
     try {
       const data = await SimpleDBOps.select(
-        db
-          .select()
-          .from(hosts)
-          .where(and(eq(hosts.id, hostId), eq(hosts.userId, userId))),
+        db.select().from(hosts).where(eq(hosts.id, hostId)),
         "ssh_data",
         userId,
       );
 
       if (data.length === 0) {
-        return res.status(404).json({ error: "Host not found" });
+        const ownerData = await db
+          .select({ userId: hosts.userId })
+          .from(hosts)
+          .where(eq(hosts.id, hostId));
+        if (ownerData.length === 0) {
+          return res.status(404).json({ error: "Host not found" });
+        }
+        const ownerId = ownerData[0].userId as string;
+        const ownerDecrypted = await SimpleDBOps.select(
+          db.select().from(hosts).where(eq(hosts.id, hostId)),
+          "ssh_data",
+          ownerId,
+        );
+        if (ownerDecrypted.length === 0) {
+          return res.status(404).json({ error: "Host not found" });
+        }
+        const host = ownerDecrypted[0];
+        const resolved =
+          (await resolveHostCredentials(host, ownerId)) || host;
+        const value = resolved[field];
+        if (!value) {
+          return res.status(404).json({ error: "No password set" });
+        }
+        return res.json({ value });
       }
 
       const host = data[0];


### PR DESCRIPTION
## Summary
- The `/db/host/:id/password` endpoint filtered by `hosts.userId === requestingUserId`
- Shared host users couldn't fetch sudo passwords because they don't own the host
- Now falls back to decrypting with the owner's data key when the requesting user is not the owner

## Related Issue
Closes https://github.com/Termix-SSH/Support/issues/717

## Test plan
- [ ] Create host with sudo password as user A
- [ ] Share host to user B
- [ ] User B opens terminal, triggers sudo — auto-fill should work
- [ ] Verify host owner still gets auto-fill normally