### PR TITLE
fix: broaden sudo prompt detection for newer distros

### DIFF
--- a/src/ui/features/terminal/Terminal.tsx
+++ b/src/ui/features/terminal/Terminal.tsx
@@ -1052,7 +1052,7 @@ const TerminalInner = forwardRef<TerminalHandle, SSHTerminalProps>(
 
               terminal.write(outputData);
               const sudoPasswordPattern =
-                /(?:\[sudo\][^\n]*:\s*$|sudo:[^\n]*password[^\n]*required)/i;
+                /(?:\[sudo\][^\n]*:\s*$|sudo:[^\n]*password[^\n]*required|password for [^\n]*:\s*$|Password:\s*$)/i;
               const hasSudoPw =
                 hostConfig.terminalConfig?.sudoPassword ||
                 hostConfig.password ||


### PR DESCRIPTION
## Summary
- Extend sudo prompt regex to match `password for <user>:` and bare `Password:` patterns
- Covers Ubuntu 26.04 and other distros that may use different sudo prompt formats
- Existing `[sudo]` and `sudo:` patterns preserved

## Related Issue
Closes https://github.com/Termix-SSH/Support/issues/718

## Test plan
- [ ] Test sudo auto-fill on Ubuntu 24.04 (existing format) — should still work
- [ ] Test on Ubuntu 26.04 or similar — should now detect the prompt
- [ ] Verify auto-fill doesn't trigger on non-sudo password prompts (SSH login, etc.)