### PR TITLE
fix: recalculate terminal layout after web fonts load

### DIFF
--- a/src/ui/features/terminal/Terminal.tsx
+++ b/src/ui/features/terminal/Terminal.tsx
@@ -1993,6 +1993,10 @@ const TerminalInner = forwardRef<TerminalHandle, SSHTerminalProps>(
       terminal.unicode.activeVersion = "11";
 
       terminal.open(xtermRef.current);
+      document.fonts.ready.then(() => {
+        terminal.refresh(0, terminal.rows - 1);
+        fitAddon.fit();
+      });
 
       terminal.attachCustomWheelEventHandler((ev) => {
         const cfg = {


### PR DESCRIPTION
## Summary
- After `terminal.open()`, wait for `document.fonts.ready` then refresh and re-fit
- Fixes character spacing caused by xterm.js measuring with fallback font before custom font loads
- Applies to all configured fonts (Caskaydia Cove, JetBrains Mono, Fira Code, etc.)

## Related Issue
Closes https://github.com/Termix-SSH/Support/issues/710

## Test plan
- [ ] Open terminal with Caskaydia Cove Nerd Font — spacing should be correct
- [ ] Test with slow network (throttle fonts) — spacing should correct itself once font loads
- [ ] Verify terminal resize still works properly