### PR TITLE
fix: improve terminal cwd detection and initial directory command

### DIFF
--- a/src/backend/ssh/terminal.ts
+++ b/src/backend/ssh/terminal.ts
@@ -848,9 +848,7 @@ wss.on("connection", async (ws: WebSocket, req) => {
         }
         cwdPending = true;
         cwdBuffer = "";
-        // Split the sentinel across shell variables so the echoed command
-        // itself never contains "TERMIX_CWD:" — only the output line does.
-        activeStream.write('a=TERMIX_CWD; echo "$a:$(pwd)"\r');
+        activeStream.write('\x15a=TERMIX_CWD; echo "$a:$(pwd)"\r');
         break;
       }
 
@@ -1787,7 +1785,7 @@ wss.on("connection", async (ws: WebSocket, req) => {
           const runPostShellCommands = (delay: number) => {
             setTimeout(() => {
               if (initialPath && initialPath.trim() !== "") {
-                const cdCommand = `cd "${initialPath.replace(/"/g, '\\"')}" && pwd\r`;
+                const cdCommand = `cd "${initialPath.replace(/"/g, '\\"')}"\r`;
                 stream.write(cdCommand);
               }
               if (executeCommand && executeCommand.trim() !== "") {


### PR DESCRIPTION
## Summary
- Remove `&& pwd` from initial directory command — fixes PowerShell 5.1 which doesn't support `&&`
- Prepend `Ctrl+U` to get_cwd probe to clear pending input line before injecting the command

## Related Issue
Closes https://github.com/Termix-SSH/Support/issues/713
Closes https://github.com/Termix-SSH/Support/issues/714

## Test plan
- [ ] Open terminal with initial directory on POSIX shell — should cd correctly
- [ ] Open terminal with initial directory on Windows PowerShell 5.1 host — should no longer error
- [ ] Click File Manager while terminal is at a shell prompt — get_cwd should work
- [ ] Click File Manager while an interactive program (vim/nano) is running — Ctrl+U reduces interference