### PR TITLE
fix: decode base64 file content as UTF-8 in file manager

### DIFF
--- a/src/ui/features/file-manager/components/FileWindow.tsx
+++ b/src/ui/features/file-manager/components/FileWindow.tsx
@@ -126,7 +126,8 @@ export function FileWindow({
 
         if (response.encoding === "base64") {
           try {
-            const decoded = atob(fileContent);
+            const bytes = Uint8Array.from(atob(fileContent), (c) => c.charCodeAt(0));
+            const decoded = new TextDecoder("utf-8").decode(bytes);
             if (isDisplayableText(decoded)) {
               fileContent = decoded;
             }


### PR DESCRIPTION
## Summary
- Replace `atob()` with `TextDecoder('utf-8')` for base64 file content decoding
- `atob()` only handles Latin-1, corrupting multi-byte UTF-8 characters (e.g. `é` → `Ã©`)

## Related Issue
Closes https://github.com/Termix-SSH/Support/issues/719

## Test plan
- [ ] Open a file containing UTF-8 characters (accented letters, CJK, emoji) in file manager
- [ ] Verify characters display correctly
- [ ] Edit and save — verify UTF-8 content is preserved
- [ ] Verify ASCII-only files still work correctly