### PR TITLE
fix: normalize lazy import default exports for iOS compatibility

### DIFF
--- a/src/main.tsx
+++ b/src/main.tsx
@@ -19,16 +19,24 @@ const AppShell = lazy(() =>
 );
 
 // Full-screen apps opened via query params (e.g. from external links or Electron)
-const TerminalApp = lazy(() => import("@/features/terminal/TerminalApp"));
-const FileManagerApp = lazy(
-  () => import("@/features/file-manager/FileManagerApp"),
+const TerminalApp = lazy(() =>
+  import("@/features/terminal/TerminalApp").then((m) => ({ default: m.default })),
 );
-const TunnelApp = lazy(() => import("@/features/tunnel/TunnelApp"));
-const ServerStatsApp = lazy(
-  () => import("@/features/server-stats/ServerStatsApp"),
+const FileManagerApp = lazy(() =>
+  import("@/features/file-manager/FileManagerApp").then((m) => ({ default: m.default })),
 );
-const DockerApp = lazy(() => import("@/features/docker/DockerApp"));
-const GuacamoleApp = lazy(() => import("@/features/guacamole/GuacamoleApp"));
+const TunnelApp = lazy(() =>
+  import("@/features/tunnel/TunnelApp").then((m) => ({ default: m.default })),
+);
+const ServerStatsApp = lazy(() =>
+  import("@/features/server-stats/ServerStatsApp").then((m) => ({ default: m.default })),
+);
+const DockerApp = lazy(() =>
+  import("@/features/docker/DockerApp").then((m) => ({ default: m.default })),
+);
+const GuacamoleApp = lazy(() =>
+  import("@/features/guacamole/GuacamoleApp").then((m) => ({ default: m.default })),
+);
 
 const ElectronVersionCheck = lazy(() =>
   import("@/user/ElectronVersionCheck").then((module) => ({


### PR DESCRIPTION
## Summary
- Wrap all `lazy()` imports with explicit `.then(m => ({ default: m.default }))` 
- iOS Safari/WebView may handle bare `lazy(() => import(...))` differently, returning the full module object instead of extracting the default export
- This causes React error #130: "Element type is invalid: expected a string or class/function but got: object"

## Related Issue
Closes https://github.com/Termix-SSH/Support/issues/721

## Test plan
- [ ] Open terminal on iOS Safari — should no longer crash with React error #130
- [ ] Open terminal on iOS app — should render correctly
- [ ] Verify all fullscreen app modes still work on desktop (terminal, file-manager, rdp, vnc, etc.)