### PR TITLE
fix: prevent RDP display from snapping back after container resize

### DIFF
--- a/src/ui/features/guacamole/GuacamoleDisplay.tsx
+++ b/src/ui/features/guacamole/GuacamoleDisplay.tsx
@@ -520,7 +520,6 @@ export const GuacamoleDisplay = forwardRef<
           const h = Math.round(rect.height);
           if (w > 0 && h > 0) {
             clientRef.current.sendSize(w, h);
-            rescaleDisplay(true);
           }
         }
       }, 150);


### PR DESCRIPTION
## Summary
- Remove premature `rescaleDisplay()` from ResizeObserver callback
- The `display.onresize` event already handles rescaling when the RDP server responds with the new resolution
- Calling rescale before the server responds uses stale dimensions, truncating the bottom of the screen

## Related Issue
Closes https://github.com/Termix-SSH/Support/issues/725

## Test plan
- [ ] Connect to RDP host (especially Windows 7) — taskbar should be fully visible
- [ ] Resize browser window — display should adapt without snapping back
- [ ] Verify VNC connections still resize correctly