### PR TITLE
fix: add portal Desktop DBus permission for Flatpak URL opening

### DIFF
--- a/flatpak/com.karmaa.termix.yml
+++ b/flatpak/com.karmaa.termix.yml
@@ -18,6 +18,7 @@ finish-args:
   - --socket=ssh-auth
   - --socket=session-bus
   - --talk-name=org.freedesktop.secrets
+  - --talk-name=org.freedesktop.portal.Desktop
   - --env=ELECTRON_TRASH=gio
   - --env=XCURSOR_PATH=/run/host/user-share/icons:/run/host/share/icons
   - --env=ELECTRON_OZONE_PLATFORM_HINT=auto


### PR DESCRIPTION
## Summary
- Add `--talk-name=org.freedesktop.portal.Desktop` to Flatpak finish-args
- Required for `window.open()` to work through xdg-desktop-portal in sandboxed Flatpak environment
- Without this permission, clicking terminal URLs opens `about:blank` instead of the actual URL

## Related Issue
Closes https://github.com/Termix-SSH/Support/issues/704

## Test plan
- [ ] Build Flatpak package — verify manifest includes new permission
- [ ] Click a URL in terminal within Flatpak app — should open in default browser
- [ ] Verify web version still opens URLs correctly