### PR TITLE
fix(guacamole-lite): send name instruction for protocol >= 1.3.0 (fixes VNC on guacd 1.6.0)

### DIFF
--- a/scripts/patch-guacamole-lite.cjs
+++ b/scripts/patch-guacamole-lite.cjs
@@ -26,6 +26,21 @@ const newVersionCheck =
 const oldTimezone = "if (protocolVersion === '1_1_0') {";
 const newTimezone = "if (protocolVersion !== '1_0_0') {";
 
+// Patch 3: send the `name` handshake instruction for protocol >= 1.3.0.
+// The Guacamole protocol added the `name` instruction in 1.3.0 (an optional
+// human-readable identifier for the joining user). guacd 1.6.0 began requiring
+// it during the VNC handshake even when negotiating older protocol versions,
+// causing connections to silently drop right after "User joined". See
+// Termix-SSH/Support#567 and #734.
+const oldConnect =
+  "        this.sendInstruction(['connect'].concat(connectArgs));";
+const newConnect =
+  "        if (protocolVersion === '1_3_0' || protocolVersion === '1_5_0') {\n" +
+  "            this.sendInstruction(['name', this.connectionSettings.name || 'guacamole-lite']);\n" +
+  "        }\n" +
+  "\n" +
+  "        this.sendInstruction(['connect'].concat(connectArgs));";
+
 let patched = false;
 
 if (!content.includes(newVersionCheck)) {
@@ -48,6 +63,17 @@ if (!content.includes(newTimezone)) {
   patched = true;
 }
 
+if (!content.includes(newConnect)) {
+  if (!content.includes(oldConnect)) {
+    console.log(
+      "[patch-guacamole-lite] Connect target not found, skipping name patch",
+    );
+    process.exit(0);
+  }
+  content = content.replace(oldConnect, newConnect);
+  patched = true;
+}
+
 if (!patched) {
   console.log("[patch-guacamole-lite] Already patched");
   process.exit(0);
@@ -55,5 +81,5 @@ if (!patched) {
 
 fs.writeFileSync(filePath, content);
 console.log(
-  "[patch-guacamole-lite] Patched to support protocol VERSION_1_3_0 and VERSION_1_5_0 with correct timezone handshake",
+  "[patch-guacamole-lite] Patched to support protocol VERSION_1_3_0 and VERSION_1_5_0 with name handshake instruction",
 );


### PR DESCRIPTION
# Overview

_Fixes silent VNC connection drops when running against guacd 1.6.0._

- [ ] Added: ...
- [ ] Updated: ...
- [ ] Removed: ...
- [x] Fixed: `scripts/patch-guacamole-lite.cjs` now also patches `guacamole-lite` to send the `name` handshake instruction when the negotiated Guacamole protocol version is 1.3.0 or 1.5.0.

# Changes Made

The Guacamole protocol added the `name` handshake instruction in 1.3.0 (an optional human-readable identifier for the joining user). guacd 1.6.0 began requiring it during the VNC handshake even when negotiating older protocol versions, causing connections to silently drop right after the `User joined` log line with no client-visible error — exactly the failure mode reported in Termix-SSH/Support#567 / Termix-SSH/Support#734.

Patches 1 and 2 in `patch-guacamole-lite.cjs` already taught the bundled `guacamole-lite@1.2.0` to *negotiate* `VERSION_1_5_0`, but the library still didn't *send* the new mandatory instruction. This PR adds a third idempotent string-replacement to inject the `name` send into `GuacdClient.prototype.sendHandshakeReply` immediately before the `connect` instruction, gated to protocol versions 1.3.0 / 1.5.0.

The patched handshake reply for a `VERSION_1_5_0` negotiation now sends, in order: `size` → `audio` → `video` → `image` → `timezone` → **`name`** (new) → `connect`.

The injected `name` value falls back to `'guacamole-lite'` if `connectionSettings.name` is not provided, matching the spirit of the Apache Guacamole reference implementation. Callers that want a per-user/per-host identity can still override via the existing `connectionSettings` mechanism without further changes.

# Related Issues

- Closes Termix-SSH/Support#734
- Closes Termix-SSH/Support#567

# Screenshots / Demos

**Before (Termix dev-2.3.2 + guacd 1.6.0):**

```
guacd[10]: DEBUG:   Processing instruction: size
guacd[10]: DEBUG:   Processing instruction: audio
guacd[10]: DEBUG:   Processing instruction: video
guacd[10]: DEBUG:   Processing instruction: image
guacd[10]: DEBUG:   Processing instruction: timezone
guacd[10]: INFO:    Cursor rendering: remote
guacd[10]: INFO:    User "@..." joined connection "$..." (1 users now present)
guacd[10]: DEBUG:   Client is using protocol version "VERSION_1_1_0"
guacd[1]:  INFO:    Connection "$..." removed.
```

**After this PR (Termix patched + guacd 1.6.0):**

```
guacd[10]: DEBUG:   Processing instruction: size
guacd[10]: DEBUG:   Processing instruction: audio
guacd[10]: DEBUG:   Processing instruction: video
guacd[10]: DEBUG:   Processing instruction: image
guacd[10]: DEBUG:   Processing instruction: timezone
guacd[10]: DEBUG:   Processing instruction: name           ← NEW
guacd[10]: INFO:    Cursor rendering: remote
guacd[10]: INFO:    User "@..." joined connection "$..." (1 users now present)
guacd[10]: DEBUG:   Client is using protocol version "VERSION_1_5_0"   ← was VERSION_1_1_0
```

End-to-end verified against a real VNC target (macOS Tahoe Apple VNC) using a freshly-built Docker image from this branch; full VNC session establishes successfully when paired with guacd 1.5.5.

> **Note on guacd 1.6.0 + Apple VNC**: a separate Apple-VNC regression in guacd 1.6.0 (unrelated to `guacamole-lite`) still prevents VNC against Apple Screen Sharing targets specifically — see porkmagus's comment on Termix-SSH/Support#734. That belongs upstream in `apache/guacamole-server`. This PR resolves the Termix-side failure, which is independently needed for non-Apple VNC targets and for any future guacd release that fixes the Apple regression.

# Checklist

- [x] Code follows project style guidelines
- [x] Supports mobile and desktop UI/app (if applicable) — backend-only patch script, no UI surface
- [x] I have read [Contributing.md](https://github.com/Termix-SSH/Termix/blob/main/CONTRIBUTING.md)
- [x] This is not a translation request. See [docs](https://docs.termix.site/translations)
