### PR TITLE
fix: resolve recent support bugs

### DIFF
--- a/src/backend/database/db/index.ts
+++ b/src/backend/database/db/index.ts
@@ -563,11 +563,12 @@ async function initializeCompleteDatabase(): Promise<void> {
       .prepare("SELECT value FROM settings WHERE key = 'guac_url'")
       .get();
     if (!row) {
+      const defaultGuacUrl = `${process.env.GUACD_HOST || "localhost"}:${process.env.GUACD_PORT || "4822"}`;
       sqlite
         .prepare(
-          "INSERT INTO settings (key, value) VALUES ('guac_url', 'guacd:4822')",
+          "INSERT INTO settings (key, value) VALUES ('guac_url', ?)",
         )
-        .run();
+        .run(defaultGuacUrl);
     }
   } catch (e) {
     databaseLogger.warn("Could not initialize guac_url setting", {

--- a/src/backend/database/routes/host.ts
+++ b/src/backend/database/routes/host.ts
@@ -1901,7 +1901,10 @@ async function resolveHostCredentials(
               keyType: sharedCred.keyType,
             };
 
-            if (!host.overrideCredentialUsername) {
+            if (
+              !host.overrideCredentialUsername &&
+              isNonEmptyString(sharedCred.username)
+            ) {
               resolvedHost.username = sharedCred.username;
             }
 
@@ -1947,7 +1950,10 @@ async function resolveHostCredentials(
           keyType: credential.keyType,
         };
 
-        if (!host.overrideCredentialUsername) {
+        if (
+          !host.overrideCredentialUsername &&
+          isNonEmptyString(credential.username)
+        ) {
           resolvedHost.username = credential.username;
         }
 

--- a/src/backend/database/routes/user-settings-routes.ts
+++ b/src/backend/database/routes/user-settings-routes.ts
@@ -10,6 +10,10 @@ import {
 import { db } from "../db/index.js";
 import { users } from "../db/schema.js";
 
+function getDefaultGuacUrl(): string {
+  return `${process.env.GUACD_HOST || "localhost"}:${process.env.GUACD_PORT || "4822"}`;
+}
+
 export function registerUserSettingsRoutes(
   router: Router,
   authenticateJWT: RequestHandler,
@@ -47,7 +51,7 @@ export function registerUserSettingsRoutes(
         .get() as { value: string } | undefined;
       res.json({
         enabled: enabledRow ? enabledRow.value !== "false" : true,
-        url: urlRow ? urlRow.value : "guacd:4822",
+        url: urlRow ? urlRow.value : getDefaultGuacUrl(),
       });
     } catch (err) {
       authLogger.error("Failed to get guacamole settings", err);
@@ -120,7 +124,7 @@ export function registerUserSettingsRoutes(
         .get() as { value: string } | undefined;
       res.json({
         enabled: enabledRow ? enabledRow.value !== "false" : true,
-        url: urlRow ? urlRow.value : "guacd:4822",
+        url: urlRow ? urlRow.value : getDefaultGuacUrl(),
       });
     } catch (err) {
       authLogger.error("Failed to update guacamole settings", err);

--- a/src/ui/sidebar/SidebarTree.tsx
+++ b/src/ui/sidebar/SidebarTree.tsx
@@ -223,6 +223,9 @@ export function HostItem({
     const v = localStorage.getItem("showHostTags");
     return v !== null ? v === "true" : true;
   });
+  const isTouchOnly =
+    typeof window !== "undefined" && window.matchMedia("(hover: none)").matches;
+  const shouldUseClickTray = trayOnClick || isTouchOnly;
 
   useEffect(() => {
     const handler = () =>
@@ -265,7 +268,7 @@ export function HostItem({
           return;
         }
         // On touch devices open the action tray instead of immediately launching a tab
-        if (window.matchMedia("(hover: none)").matches) {
+        if (isTouchOnly) {
           e.stopPropagation();
           onTrayOpenChange?.(!isTrayOpen);
           return;
@@ -361,7 +364,7 @@ export function HostItem({
 
         {/* Address — only visible on hover (or click when trayOnClick) or while menu is open */}
         <span
-          className={`text-[11px] text-muted-foreground/55 truncate leading-none pl-3 transition-opacity duration-100 ${!trayOnClick ? "group-hover:opacity-100 group-hover:h-auto" : ""} ${isMenuOpen || (trayOnClick && isTrayOpen) ? "opacity-100 h-auto" : "opacity-0 h-0 overflow-hidden"}`}
+          className={`text-[11px] text-muted-foreground/55 truncate leading-none pl-3 transition-opacity duration-100 ${!shouldUseClickTray ? "group-hover:opacity-100 group-hover:h-auto" : ""} ${isMenuOpen || (shouldUseClickTray && isTrayOpen) ? "opacity-100 h-auto" : "opacity-0 h-0 overflow-hidden"}`}
         >
           {host.username}@{host.ip}
         </span>
@@ -387,7 +390,7 @@ export function HostItem({
 
         {/* Action tray — slides open on CSS hover, on click (when trayOnClick), or while menu is open */}
         <div
-          className={`overflow-hidden transition-all duration-150 ease-out max-h-0 opacity-0 ${!trayOnClick ? "group-hover:max-h-[300px] group-hover:opacity-100" : ""} ${selectionMode ? "!max-h-0 !opacity-0" : ""} ${(isMenuOpen || (trayOnClick && isTrayOpen)) && !selectionMode ? "!max-h-[300px] !opacity-100" : ""}`}
+          className={`overflow-hidden transition-all duration-150 ease-out max-h-0 opacity-0 ${!shouldUseClickTray ? "group-hover:max-h-[300px] group-hover:opacity-100" : ""} ${selectionMode ? "!max-h-0 !opacity-0" : ""} ${(isMenuOpen || (shouldUseClickTray && isTrayOpen)) && !selectionMode ? "!max-h-[300px] !opacity-100" : ""}`}
         >
           {host.online &&
             ((host.cpu != null && host.cpu > 0) ||


### PR DESCRIPTION
## Summary
- initialize Guacamole URL from GUACD_HOST/GUACD_PORT instead of a hardcoded guacd default
- preserve host usernames when linked credentials do not define a username
- allow touch-only host rows to open the action tray without the click-to-expand preference

## Linked issues
Fixes Termix-SSH/Support#744
Fixes Termix-SSH/Support#745
Fixes Termix-SSH/Support#746

## Validation
- npx prettier --check src/backend/database/db/index.ts src/backend/database/routes/user-settings-routes.ts src/backend/database/routes/host.ts src/ui/sidebar/SidebarTree.tsx
- npx eslint src/backend/database/db/index.ts src/backend/database/routes/user-settings-routes.ts src/backend/database/routes/host.ts src/ui/sidebar/SidebarTree.tsx
- npx tsc --noEmit --pretty false
- npm run build