### PR TITLE
fix: support native OIDC callbacks

### DIFF
--- a/src/backend/database/routes/users.ts
+++ b/src/backend/database/routes/users.ts
@@ -563,7 +563,7 @@ router.get("/oidc-config/admin", requireAdmin, async (req, res) => {
  */
 router.get("/oidc/authorize", async (req, res) => {
   try {
-    const { rememberMe, desktopCallbackPort } = req.query;
+    const { rememberMe, desktopCallbackPort, appCallbackUrl } = req.query;
     const origin = getRequestOriginWithForceHTTPS(req);
     const backendCallbackUri = `${origin}/users/oidc/callback`;
 
@@ -588,6 +588,17 @@ router.get("/oidc/authorize", async (req, res) => {
     let frontendOrigin;
     if (desktopCallbackPort) {
       frontendOrigin = `http://127.0.0.1:${desktopCallbackPort}/oidc-callback`;
+    } else if (typeof appCallbackUrl === "string" && appCallbackUrl) {
+      let callbackUrl: URL;
+      try {
+        callbackUrl = new URL(appCallbackUrl);
+      } catch {
+        return res.status(400).json({ error: "Invalid app callback URL" });
+      }
+      if (callbackUrl.protocol !== "termix-mobile:") {
+        return res.status(400).json({ error: "Unsupported app callback URL" });
+      }
+      frontendOrigin = callbackUrl.toString();
     } else if (referer) {
       const refererUrl = new URL(referer);
       frontendOrigin = `${refererUrl.protocol}//${refererUrl.host}`;
@@ -1129,7 +1140,9 @@ router.get("/oidc/callback", async (req, res) => {
     const redirectUrl = new URL(frontendOrigin);
     redirectUrl.searchParams.set("success", "true");
 
-    const isDesktopCallback = frontendOrigin.startsWith("http://127.0.0.1:");
+    const isTokenCallback =
+      frontendOrigin.startsWith("http://127.0.0.1:") ||
+      frontendOrigin.startsWith("termix-mobile:");
 
     const maxAge =
       deviceInfo.type === "desktop" || deviceInfo.type === "mobile"
@@ -1140,7 +1153,7 @@ router.get("/oidc/callback", async (req, res) => {
 
     res.clearCookie("jwt", authManager.getClearCookieOptions(req));
 
-    if (isDesktopCallback) {
+    if (isTokenCallback) {
       redirectUrl.searchParams.set("token", token);
       return res.redirect(redirectUrl.toString());
     }

--- a/src/ui/auth/Auth.tsx
+++ b/src/ui/auth/Auth.tsx
@@ -687,7 +687,7 @@ export function Auth({ onLogin }: AuthProps) {
             callbackPort,
           );
           if (result.success && result.token) {
-            localStorage.setItem("jwt_token", result.token);
+            localStorage.setItem("jwt", result.token);
             window.location.reload();
             return;
           }


### PR DESCRIPTION
## Summary
- allow restricted termix-mobile:// OIDC callback URLs for native app sign-in
- return the JWT token on native callbacks like the Electron localhost callback
- store Electron system-browser OIDC tokens under the key used by the app

Refs https://github.com/Termix-SSH/Support/issues/402

## Validation
- npm run type-check
- npx eslint src/backend/database/routes/users.ts src/ui/auth/Auth.tsx
- npm run build