### PR TITLE
docs: add Cloudflare Tunnel guidance

### DIFF
--- a/README.md
+++ b/README.md
@@ -252,6 +252,29 @@ networks:
     driver: bridge
 ```
 
+Cloudflare Tunnel example:
+
+```yaml
+tunnel: <tunnel-id>
+credentials-file: /etc/cloudflared/<tunnel-id>.json
+
+ingress:
+  - hostname: termix.example.com
+    service: http://termix:8080
+    originRequest:
+      httpHostHeader: termix.example.com
+      noTLSVerify: false
+      disableChunkedEncoding: false
+  - service: http_status:404
+```
+
+Point the tunnel at Termix over plain HTTP (`http://termix:8080`) and let
+Cloudflare terminate public HTTPS. If you point Cloudflare Tunnel at Termix's
+self-signed HTTPS origin, Full Strict mode will reject the origin certificate
+unless that certificate matches the public hostname and chains to a trusted CA.
+Keep WebSocket support enabled in Cloudflare because SSH terminals and remote
+desktop sessions use upgrade connections.
+
 <br />
 
 ## Screenshots

--- a/docker/nginx.conf
+++ b/docker/nginx.conf
@@ -49,7 +49,7 @@ http {
 
     server {
         listen ${PORT};
-        server_name localhost;
+        server_name _;
 
         add_header X-Content-Type-Options nosniff always;
         add_header X-XSS-Protection "1; mode=block" always;


### PR DESCRIPTION
## Summary
- accept arbitrary Host names in the HTTP Docker nginx server block instead of only documenting localhost
- add a Cloudflare Tunnel example for exposing Termix through a public HTTPS hostname while using an HTTP origin
- document that Cloudflare Full Strict requires a valid matching origin certificate if users choose an HTTPS origin

Refs https://github.com/Termix-SSH/Support/issues/479

## Validation
- git diff --check
- Static review of docker/nginx.conf and README.md

Note: nginx/envsubst are not installed in this WSL environment, so the nginx template was not executed locally.