### PR TITLE
fix: sync appearance preferences

### DIFF
--- a/src/backend/database/db/index.ts
+++ b/src/backend/database/db/index.ts
@@ -467,6 +467,10 @@ async function initializeCompleteDatabase(): Promise<void> {
     CREATE TABLE IF NOT EXISTS user_preferences (
         user_id TEXT PRIMARY KEY,
         reopen_tabs_on_login INTEGER NOT NULL DEFAULT 0,
+        theme TEXT,
+        font_size TEXT,
+        accent_color TEXT,
+        language TEXT,
         updated_at TEXT NOT NULL DEFAULT CURRENT_TIMESTAMP,
         FOREIGN KEY (user_id) REFERENCES users (id) ON DELETE CASCADE
     );
@@ -606,6 +610,11 @@ const addColumnIfNotExists = (
 };
 
 const migrateSchema = () => {
+  addColumnIfNotExists("user_preferences", "theme", "TEXT");
+  addColumnIfNotExists("user_preferences", "font_size", "TEXT");
+  addColumnIfNotExists("user_preferences", "accent_color", "TEXT");
+  addColumnIfNotExists("user_preferences", "language", "TEXT");
+
   addColumnIfNotExists("users", "is_admin", "INTEGER NOT NULL DEFAULT 0");
 
   addColumnIfNotExists("users", "is_oidc", "INTEGER NOT NULL DEFAULT 0");

--- a/src/backend/database/db/schema.ts
+++ b/src/backend/database/db/schema.ts
@@ -658,6 +658,10 @@ export const userPreferences = sqliteTable("user_preferences", {
   reopenTabsOnLogin: integer("reopen_tabs_on_login", { mode: "boolean" })
     .notNull()
     .default(false),
+  theme: text("theme"),
+  fontSize: text("font_size"),
+  accentColor: text("accent_color"),
+  language: text("language"),
   updatedAt: text("updated_at")
     .notNull()
     .default(sql`CURRENT_TIMESTAMP`),

--- a/src/backend/database/routes/user-preferences.ts
+++ b/src/backend/database/routes/user-preferences.ts
@@ -11,6 +11,14 @@ const router = express.Router();
 const authManager = AuthManager.getInstance();
 const authenticateJWT = authManager.createAuthMiddleware();
 
+const pickPreferences = (row?: typeof userPreferences.$inferSelect) => ({
+  reopenTabsOnLogin: row?.reopenTabsOnLogin ?? false,
+  theme: row?.theme ?? null,
+  fontSize: row?.fontSize ?? null,
+  accentColor: row?.accentColor ?? null,
+  language: row?.language ?? null,
+});
+
 /**
  * @openapi
  * /user-preferences:
@@ -38,10 +46,7 @@ router.get("/", authenticateJWT, (req: Request, res: Response) => {
       .where(eq(userPreferences.userId, userId))
       .all();
 
-    if (rows.length === 0) {
-      return res.json({ reopenTabsOnLogin: false });
-    }
-    return res.json({ reopenTabsOnLogin: rows[0].reopenTabsOnLogin });
+    return res.json(pickPreferences(rows[0]));
   } catch (e) {
     databaseLogger.error("Failed to get user preferences", e, {
       operation: "get_user_preferences",
@@ -73,12 +78,46 @@ router.get("/", authenticateJWT, (req: Request, res: Response) => {
  */
 router.put("/", authenticateJWT, (req: Request, res: Response) => {
   const userId = (req as AuthenticatedRequest).userId;
-  const { reopenTabsOnLogin } = req.body as { reopenTabsOnLogin?: boolean };
+  const { reopenTabsOnLogin, theme, fontSize, accentColor, language } =
+    req.body as {
+      reopenTabsOnLogin?: boolean;
+      theme?: string | null;
+      fontSize?: string | null;
+      accentColor?: string | null;
+      language?: string | null;
+    };
 
-  if (typeof reopenTabsOnLogin !== "boolean") {
-    return res
-      .status(400)
-      .json({ error: "reopenTabsOnLogin must be a boolean" });
+  const updates: Partial<typeof userPreferences.$inferInsert> = {
+    updatedAt: new Date().toISOString(),
+  };
+
+  if (reopenTabsOnLogin !== undefined) {
+    if (typeof reopenTabsOnLogin !== "boolean") {
+      return res
+        .status(400)
+        .json({ error: "reopenTabsOnLogin must be a boolean" });
+    }
+    updates.reopenTabsOnLogin = reopenTabsOnLogin;
+  }
+
+  for (const [key, value] of Object.entries({
+    theme,
+    fontSize,
+    accentColor,
+    language,
+  })) {
+    if (value !== undefined && value !== null && typeof value !== "string") {
+      return res.status(400).json({ error: `${key} must be a string` });
+    }
+  }
+
+  if (theme !== undefined) updates.theme = theme;
+  if (fontSize !== undefined) updates.fontSize = fontSize;
+  if (accentColor !== undefined) updates.accentColor = accentColor;
+  if (language !== undefined) updates.language = language;
+
+  if (Object.keys(updates).length === 1) {
+    return res.status(400).json({ error: "No preferences provided" });
   }
 
   try {
@@ -92,18 +131,17 @@ router.put("/", authenticateJWT, (req: Request, res: Response) => {
       db.insert(userPreferences)
         .values({
           userId,
-          reopenTabsOnLogin,
-          updatedAt: new Date().toISOString(),
+          ...updates,
         })
         .run();
     } else {
       db.update(userPreferences)
-        .set({ reopenTabsOnLogin, updatedAt: new Date().toISOString() })
+        .set(updates)
         .where(eq(userPreferences.userId, userId))
         .run();
     }
 
-    return res.json({ success: true, reopenTabsOnLogin });
+    return res.json({ success: true, ...updates });
   } catch (e) {
     databaseLogger.error("Failed to update user preferences", e, {
       operation: "update_user_preferences",

--- a/src/ui/AppShell.tsx
+++ b/src/ui/AppShell.tsx
@@ -31,8 +31,11 @@ import type {
   Host,
   SplitMode,
   HostFolder,
+  ThemeId,
+  FontSizeId,
 } from "@/types/ui-types";
-import { PANE_COUNTS } from "@/lib/theme";
+import { applyAccentColor, applyFontSize, PANE_COUNTS } from "@/lib/theme";
+import { useTheme } from "@/components/theme-provider";
 import {
   getSSHHosts,
   getUserInfo,
@@ -142,7 +145,8 @@ export function AppShell({
   username: string;
   onLogout: () => void;
 }) {
-  const { t } = useTranslation();
+  const { t, i18n } = useTranslation();
+  const { setTheme } = useTheme();
   const [tabs, setTabs] = useState<Tab[]>([
     {
       id: "dashboard",
@@ -364,7 +368,19 @@ export function AppShell({
 
   useEffect(() => {
     getUserPreferences()
-      .then((prefs) => setUserPrefs(prefs))
+      .then((prefs) => {
+        setUserPrefs(prefs);
+        if (prefs.theme) setTheme(prefs.theme as ThemeId);
+        if (prefs.fontSize) applyFontSize(prefs.fontSize as FontSizeId);
+        if (prefs.accentColor) {
+          localStorage.setItem("termix-accent", prefs.accentColor);
+          applyAccentColor(prefs.accentColor);
+        }
+        if (prefs.language && prefs.language !== i18n.language) {
+          localStorage.setItem("i18nextLng", prefs.language);
+          void i18n.changeLanguage(prefs.language);
+        }
+      })
       .catch(() => {})
       .finally(() => setUserPrefsLoaded(true));
   }, []);

--- a/src/ui/api/open-tabs-api.ts
+++ b/src/ui/api/open-tabs-api.ts
@@ -79,6 +79,10 @@ export async function getActiveSessions(): Promise<ActiveSessionInfo[]> {
 
 export interface UserPreferences {
   reopenTabsOnLogin: boolean;
+  theme?: string | null;
+  fontSize?: string | null;
+  accentColor?: string | null;
+  language?: string | null;
 }
 
 export async function getUserPreferences(): Promise<UserPreferences> {

--- a/src/ui/sidebar/UserProfilePanel.tsx
+++ b/src/ui/sidebar/UserProfilePanel.tsx
@@ -13,6 +13,7 @@ import {
   disableTOTP,
   getVersionInfo,
   getUserRoles,
+  saveUserPreferences,
 } from "@/main-axios";
 import type { UserRole } from "@/main-axios";
 import type React from "react";
@@ -553,22 +554,39 @@ export function UserProfilePanel({
       .catch(() => {});
   }, [t]);
 
+  function saveAppearancePreference(prefs: {
+    theme?: ThemeId;
+    fontSize?: FontSizeId;
+    accentColor?: string;
+    language?: string;
+  }) {
+    void saveUserPreferences(prefs).catch(() => {});
+  }
+
+  function handleThemeChange(id: ThemeId) {
+    setTheme(id);
+    saveAppearancePreference({ theme: id });
+  }
+
   function handleAccentChange(value: string) {
     setAccentColor(value);
     setCustomColorInput(value);
     localStorage.setItem("termix-accent", value);
     applyAccentColor(value);
+    saveAppearancePreference({ accentColor: value });
   }
 
   function handleFontSizeChange(id: FontSizeId) {
     setFontSize(id);
     applyFontSize(id);
+    saveAppearancePreference({ fontSize: id });
   }
 
   function handleLanguageChange(code: string) {
     setLanguage(code);
     localStorage.setItem("i18nextLng", code);
     i18n.changeLanguage(code);
+    saveAppearancePreference({ language: code });
   }
 
   function toggle(id: UserProfileSection) {
@@ -818,7 +836,7 @@ export function UserProfilePanel({
             <div className="relative">
               <select
                 value={theme}
-                onChange={(e) => setTheme(e.target.value as ThemeId)}
+                onChange={(e) => handleThemeChange(e.target.value as ThemeId)}
                 className="w-full px-2.5 py-1.5 text-xs bg-background border border-border text-foreground outline-none focus:ring-1 focus:ring-ring appearance-none pr-7"
               >
                 {THEMES.map((th) => (
@@ -834,7 +852,7 @@ export function UserProfilePanel({
                 <button
                   key={th.id}
                   title={themeLabel[th.id]}
-                  onClick={() => setTheme(th.id)}
+                  onClick={() => handleThemeChange(th.id)}
                   className={`h-4 flex-1 border transition-all ${theme === th.id ? "border-accent-brand ring-1 ring-accent-brand" : "border-border/50"}`}
                   style={{ background: th.preview }}
                 />


### PR DESCRIPTION
Refs https://github.com/Termix-SSH/Support/issues/539

## Summary
- persist appearance preferences in user_preferences
- apply saved theme, font size, accent color, and language at login
- save appearance panel changes through the existing preferences API

## Validation
- npm run type-check
- npx eslint src/backend/database/db/schema.ts src/backend/database/db/index.ts src/backend/database/routes/user-preferences.ts src/ui/api/open-tabs-api.ts src/ui/AppShell.tsx src/ui/sidebar/UserProfilePanel.tsx
- git diff --check
- npm run build