### PR TITLE
fix: pass through terminal tab completion

### DIFF
--- a/src/ui/features/terminal/Terminal.tsx
+++ b/src/ui/features/terminal/Terminal.tsx
@@ -2303,20 +2303,29 @@ const TerminalInner = forwardRef<TerminalHandle, SSHTerminalProps>(
           e.preventDefault();
           e.stopPropagation();
 
-          const autocompleteEnabled =
-            localStorage.getItem("commandAutocomplete") === "true";
-
-          if (!autocompleteEnabled) {
+          const sendTabToShell = () => {
             if (webSocketRef.current?.readyState === 1) {
               webSocketRef.current.send(
                 JSON.stringify({ type: "input", data: "\t" }),
               );
             }
+          };
+
+          const autocompleteEnabled =
+            localStorage.getItem("commandAutocomplete") === "true";
+
+          if (!autocompleteEnabled) {
+            sendTabToShell();
             return false;
           }
 
           const currentCmd = getCurrentCommandRef.current().trim();
-          if (currentCmd.length > 0 && webSocketRef.current?.readyState === 1) {
+          if (currentCmd.length === 0) {
+            sendTabToShell();
+            return false;
+          }
+
+          if (webSocketRef.current?.readyState === 1) {
             const matches = autocompleteHistory.current
               .filter(
                 (cmd) =>
@@ -2376,6 +2385,8 @@ const TerminalInner = forwardRef<TerminalHandle, SSHTerminalProps>(
               }
 
               setShowAutocomplete(true);
+            } else {
+              sendTabToShell();
             }
           }
           return false;


### PR DESCRIPTION
Refs https://github.com/Termix-SSH/Support/issues/525

## Summary
- keep app command autocomplete behavior when history suggestions match
- pass Tab through to the remote shell when command autocomplete is disabled, empty, or has no match
- avoids swallowing shell completion in the Electron terminal

## Validation
- npx eslint src/ui/features/terminal/Terminal.tsx
- git diff --check
- npm run type-check