### PR TITLE
fix(electron): auto-allow SSL certificates for private network hosts

### DIFF
--- a/electron/main.cjs
+++ b/electron/main.cjs
@@ -353,16 +353,83 @@ function isInsecureModeEnabled() {
   );
 }
 
-function getTlsVerificationOptions() {
+function getServerConfigPath() {
+  return path.join(app.getPath("userData"), "server-config.json");
+}
+
+function getServerConfigSync() {
+  try {
+    const configPath = getServerConfigPath();
+    if (!fs.existsSync(configPath)) return null;
+    return JSON.parse(fs.readFileSync(configPath, "utf8"));
+  } catch {
+    return null;
+  }
+}
+
+function getOrigin(url) {
+  try {
+    return new URL(url).origin;
+  } catch {
+    return null;
+  }
+}
+
+function isPrivateNetworkHost(hostname) {
+  if (
+    hostname === "localhost" ||
+    hostname === "127.0.0.1" ||
+    hostname === "::1"
+  ) {
+    return true;
+  }
+
+  const ipv4Match = hostname.match(
+    /^(\d{1,3})\.(\d{1,3})\.(\d{1,3})\.(\d{1,3})$/,
+  );
+  if (ipv4Match) {
+    const [, a, b] = ipv4Match.map(Number);
+    return (
+      a === 10 ||
+      (a === 172 && b >= 16 && b <= 31) ||
+      (a === 192 && b === 168) ||
+      (a === 169 && b === 254)
+    );
+  }
+
+  if (hostname.startsWith("fc") || hostname.startsWith("fd")) {
+    return true;
+  }
+
+  return false;
+}
+
+function isInvalidCertificateAllowedForUrl(url) {
+  if (isInsecureModeEnabled()) return true;
+
+  try {
+    const { hostname } = new URL(url);
+    if (isPrivateNetworkHost(hostname)) return true;
+  } catch {
+    // fall through
+  }
+
+  const config = getServerConfigSync();
+  if (!config?.allowInvalidCertificate || !config?.serverUrl) return false;
+
+  return getOrigin(url) === getOrigin(config.serverUrl);
+}
+
+function getTlsVerificationOptions(url) {
   return {
-    rejectUnauthorized: !isInsecureModeEnabled(),
+    rejectUnauthorized: !isInvalidCertificateAllowedForUrl(url),
   };
 }
 
 function getWebSocketOptions(url, options = {}) {
   return {
     ...options,
-    ...(String(url).startsWith("wss:") ? getTlsVerificationOptions() : {}),
+    ...(String(url).startsWith("wss:") ? getTlsVerificationOptions(url) : {}),
   };
 }
 
@@ -376,7 +443,7 @@ function httpFetch(url, options = {}) {
       method: options.method || "GET",
       headers: options.headers || {},
       timeout: options.timeout || 10000,
-      ...(isHttps ? getTlsVerificationOptions() : {}),
+      ...(isHttps ? getTlsVerificationOptions(url) : {}),
     };
 
     const req = client.request(url, requestOptions, (res) => {
@@ -434,6 +501,25 @@ const electronCacheBuildPath = path.join(
   "client-cache-build.json",
 );
 const termixSessionPartition = "persist:termix";
+
+app.on(
+  "certificate-error",
+  (event, _webContents, url, error, certificate, callback) => {
+    if (isInvalidCertificateAllowedForUrl(url)) {
+      event.preventDefault();
+      logToFile("Allowed invalid certificate for configured server", {
+        url,
+        error,
+        issuer: certificate?.issuerName,
+        subject: certificate?.subjectName,
+      });
+      callback(true);
+      return;
+    }
+
+    callback(false);
+  },
+);
 
 function getElectronBuildTimestamp() {
   try {
@@ -1153,14 +1239,7 @@ ipcMain.handle(
 
 ipcMain.handle("get-server-config", () => {
   try {
-    const userDataPath = app.getPath("userData");
-    const configPath = path.join(userDataPath, "server-config.json");
-
-    if (fs.existsSync(configPath)) {
-      const configData = fs.readFileSync(configPath, "utf8");
-      return JSON.parse(configData);
-    }
-    return null;
+    return getServerConfigSync();
   } catch (error) {
     console.error("Error reading server config:", error);
     return null;
@@ -1170,7 +1249,7 @@ ipcMain.handle("get-server-config", () => {
 ipcMain.handle("save-server-config", (event, config) => {
   try {
     const userDataPath = app.getPath("userData");
-    const configPath = path.join(userDataPath, "server-config.json");
+    const configPath = getServerConfigPath();
 
     if (!fs.existsSync(userDataPath)) {
       fs.mkdirSync(userDataPath, { recursive: true });
@@ -1318,16 +1397,6 @@ const c2sTunnelRuntimes = new Map();
 const C2S_WS_HIGH_WATERMARK = 1024 * 1024;
 const C2S_WS_LOW_WATERMARK = 256 * 1024;
 const C2S_STREAM_WRITE_LIMIT = 8 * 1024 * 1024;
-
-function getServerConfigSync() {
-  try {
-    const configPath = path.join(app.getPath("userData"), "server-config.json");
-    if (!fs.existsSync(configPath)) return null;
-    return JSON.parse(fs.readFileSync(configPath, "utf8"));
-  } catch {
-    return null;
-  }
-}
 
 function getC2SRelayUrl() {
   const config = getServerConfigSync();

--- a/src/types/electron.d.ts
+++ b/src/types/electron.d.ts
@@ -1,5 +1,6 @@
 interface ServerConfig {
   serverUrl?: string;
+  allowInvalidCertificate?: boolean;
   [key: string]: unknown;
 }
 

--- a/src/ui/auth/ElectronServerConfig.tsx
+++ b/src/ui/auth/ElectronServerConfig.tsx
@@ -3,6 +3,7 @@ import { Button } from "@/components/button.tsx";
 import { Input } from "@/components/input.tsx";
 import { Label } from "@/components/label.tsx";
 import { Alert, AlertTitle, AlertDescription } from "@/components/alert.tsx";
+import { Switch } from "@/components/switch.tsx";
 import { useTranslation } from "react-i18next";
 import {
   getServerConfig,
@@ -28,6 +29,7 @@ export function ElectronServerConfig({
 }: ServerConfigProps) {
   const { t } = useTranslation();
   const [serverUrl, setServerUrl] = useState("");
+  const [allowInvalidCertificate, setAllowInvalidCertificate] = useState(false);
   const [loading, setLoading] = useState(false);
   const [embeddedLoading, setEmbeddedLoading] = useState(false);
   const [error, setError] = useState<string | null>(null);
@@ -46,6 +48,7 @@ export function ElectronServerConfig({
       if (config?.serverUrl) {
         setServerUrl(config.serverUrl);
       }
+      setAllowInvalidCertificate(!!config?.allowInvalidCertificate);
     } catch (error) {
       console.error("Server config operation failed:", error);
     }
@@ -141,6 +144,8 @@ export function ElectronServerConfig({
       const config: ServerConfig = {
         serverUrl: normalizedUrl,
         lastUpdated: new Date().toISOString(),
+        allowInvalidCertificate:
+          normalizedUrl.startsWith("https://") && allowInvalidCertificate,
       };
 
       const success = await saveServerConfig(config);
@@ -224,6 +229,25 @@ export function ElectronServerConfig({
               disabled={loading || embeddedLoading}
             />
           </div>
+
+          {serverUrl.trim().startsWith("https://") && (
+            <div className="flex items-start justify-between gap-3 border border-border bg-muted/20 p-3">
+              <div className="flex flex-col gap-1">
+                <Label htmlFor="allow-invalid-certificate">
+                  {t("serverConfig.allowInvalidCertificate")}
+                </Label>
+                <p className="text-xs text-muted-foreground">
+                  {t("serverConfig.allowInvalidCertificateDesc")}
+                </p>
+              </div>
+              <Switch
+                id="allow-invalid-certificate"
+                checked={allowInvalidCertificate}
+                onCheckedChange={setAllowInvalidCertificate}
+                disabled={loading || embeddedLoading}
+              />
+            </div>
+          )}
 
           {error && (
             <Alert variant="destructive">

--- a/src/ui/locales/en.json
+++ b/src/ui/locales/en.json
@@ -38,6 +38,8 @@
     "helpText": "Enter the URL where your Termix server is running (e.g., http://localhost:30001 or https://your-server.com)",
     "changeServer": "Change Server",
     "mustIncludeProtocol": "Server URL must start with http:// or https://",
+    "allowInvalidCertificate": "Allow invalid certificate",
+    "allowInvalidCertificateDesc": "Use only for trusted self-hosted servers with self-signed or IP-address certificates.",
     "useEmbedded": "Use Local Server",
     "embeddedDesc": "Run Termix with the built-in local server (no remote server needed)",
     "embeddedConnecting": "Connecting to local server...",

--- a/src/ui/locales/translated/zh_CN.json
+++ b/src/ui/locales/translated/zh_CN.json
@@ -38,6 +38,8 @@
     "helpText": "输入您的 Termix 服务器运行所对应的 URL（例如，http://localhost:30001 或 https://your-server.com）",
     "changeServer": "变更服务器",
     "mustIncludeProtocol": "服务器 URL 必须以 http:// 或 https:// 开头。",
+    "allowInvalidCertificate": "允许无效证书",
+    "allowInvalidCertificateDesc": "仅用于可信的自托管服务器，例如自签名证书或 IP 地址证书。",
     "useEmbedded": "使用本地服务器",
     "embeddedDesc": "使用内置的本地服务器运行 Termixed (不需要远程服务器)",
     "embeddedConnecting": "正在连接本地服务器...",

--- a/src/ui/main-axios.ts
+++ b/src/ui/main-axios.ts
@@ -562,6 +562,7 @@ let embeddedMode = false;
 export interface ServerConfig {
   serverUrl: string;
   lastUpdated: string;
+  allowInvalidCertificate?: boolean;
 }
 
 interface AxiosRequestConfigExtended extends AxiosRequestConfig {


### PR DESCRIPTION
## Summary
- Add private network IP detection (RFC 1918, link-local, loopback, IPv6 ULA) to the Electron `certificate-error` handler so that connections to local/private servers (e.g. `192.168.x.x`, `10.x.x.x`, `172.16-31.x.x`) bypass SSL validation automatically — matching the Android-side fix in Termix-SSH/Mobile#21
- Add an explicit "Allow invalid certificate" toggle in the server config UI for public HTTPS servers with self-signed or IP-address certificates
- Refactor `getTlsVerificationOptions` and `httpFetch` to use per-URL certificate policy instead of the global `ENABLE_INSECURE_MODE` flag

## Linked issues
Fixes Termix-SSH/Support#748

## Validation
- `npx tsc --noEmit --pretty false`
- `npm run build`

## Checklist
- [x] Code follows project style guidelines
- [x] Supports mobile and desktop UI/app (if applicable) — this PR targets the Electron desktop app only; Android coverage is handled by Termix-SSH/Mobile#21
- [x] I have read [Contributing.md](https://github.com/Termix-SSH/Termix/blob/main/CONTRIBUTING.md)
- [x] This is not a translation request