### PR TITLE
feat: support single-host direct tunnels (ssh -L style)

### DIFF
--- a/src/backend/ssh/tunnel.ts
+++ b/src/backend/ssh/tunnel.ts
@@ -1,5 +1,6 @@
 import express, { type Response } from "express";
 import { createServer } from "http";
+import { createServer as createTcpServer, Socket as TcpSocket, type Server as TcpServer } from "net";
 import { createCorsMiddleware } from "../utils/cors-config.js";
 import cookieParser from "cookie-parser";
 import { Client, type ClientChannel } from "ssh2";
@@ -94,6 +95,7 @@ type ActiveTunnelRuntime = {
   bindClient?: Client;
   bindHost?: string;
   bindPort?: number;
+  tcpServer?: TcpServer;
   close: () => void;
 };
 
@@ -523,6 +525,148 @@ function resolveS2SLocalTargetHost(tunnelConfig: TunnelConfig): string {
   }
 
   return targetHost;
+}
+
+function isSingleHostTunnel(tunnelConfig: TunnelConfig): boolean {
+  if (!tunnelConfig.endpointHost && !tunnelConfig.endpointIP) return true;
+  if (
+    tunnelConfig.endpointHost === "127.0.0.1" ||
+    tunnelConfig.endpointHost === "localhost"
+  ) {
+    return true;
+  }
+  if (
+    tunnelConfig.endpointIP &&
+    tunnelConfig.endpointIP === tunnelConfig.sourceIP &&
+    tunnelConfig.endpointSSHPort === tunnelConfig.sourceSSHPort
+  ) {
+    return true;
+  }
+  return false;
+}
+
+async function establishDirectTunnel(
+  sourceClient: Client,
+  tunnelConfig: TunnelConfig,
+): Promise<void> {
+  const tunnelName = tunnelConfig.name;
+  const mode = getTunnelMode(tunnelConfig);
+  const bindHost = getTunnelBindHost(tunnelConfig);
+  const sourcePort = tunnelConfig.sourcePort;
+  const targetHost = tunnelConfig.targetHost || "127.0.0.1";
+  const targetPort = tunnelConfig.endpointPort;
+
+  if (mode === "remote") {
+    const remoteBindPort = await bindForwardIn(
+      sourceClient,
+      targetHost,
+      sourcePort,
+    );
+    const sockets = new Set<TcpSocket>();
+    sourceClient.on("tcp connection", (info, accept, reject) => {
+      if (info.destPort !== remoteBindPort) {
+        reject();
+        return;
+      }
+      const inbound = accept();
+      const local = new TcpSocket();
+      sockets.add(local);
+      local.connect(targetPort, bindHost, () => {
+        pipeTunnelStreams(inbound, Promise.resolve(local), tunnelName);
+      });
+      local.on("error", () => {
+        inbound.destroy();
+        sockets.delete(local);
+      });
+      local.on("close", () => sockets.delete(local));
+    });
+
+    const close = () => {
+      unbindForwardIn(sourceClient, targetHost, remoteBindPort);
+      for (const s of sockets) s.destroy();
+      sockets.clear();
+      try {
+        sourceClient.end();
+      } catch {
+        // expected
+      }
+    };
+
+    activeTunnelRuntimes.set(tunnelName, {
+      sourceClient,
+      bindHost: targetHost,
+      bindPort: remoteBindPort,
+      close,
+    });
+    activeTunnels.set(tunnelName, sourceClient);
+    return;
+  }
+
+  // Local and dynamic modes: listen locally, forward through SSH
+  const sockets = new Set<TcpSocket>();
+  const tcpServer = createTcpServer((socket) => {
+    sockets.add(socket);
+    socket.on("close", () => sockets.delete(socket));
+    socket.on("error", () => {
+      sockets.delete(socket);
+      socket.destroy();
+    });
+
+    if (mode === "dynamic") {
+      handleSocks5Connect(
+        socket,
+        (host, port) => forwardOut(sourceClient, host, port),
+        tunnelName,
+      );
+      return;
+    }
+
+    forwardOut(sourceClient, targetHost, targetPort, tunnelName)
+      .then((outbound) => pipeTunnelStreams(socket, Promise.resolve(outbound), tunnelName))
+      .catch(() => socket.destroy());
+  });
+
+  await new Promise<void>((resolve, reject) => {
+    tcpServer.once("error", reject);
+    tcpServer.listen({ host: bindHost, port: sourcePort }, () => {
+      tcpServer.removeListener("error", reject);
+      resolve();
+    });
+  });
+
+  tunnelLogger.info("Direct tunnel listener started", {
+    operation: "direct_tunnel_listen",
+    tunnelName,
+    mode,
+    bindHost,
+    sourcePort,
+    targetHost,
+    targetPort,
+  });
+
+  const close = () => {
+    for (const s of sockets) s.destroy();
+    sockets.clear();
+    tcpServer.close();
+    try {
+      sourceClient.end();
+    } catch {
+      // expected
+    }
+  };
+
+  sourceClient.on("close", () => {
+    close();
+  });
+
+  activeTunnelRuntimes.set(tunnelName, {
+    sourceClient,
+    tcpServer,
+    bindHost,
+    bindPort: sourcePort,
+    close,
+  });
+  activeTunnels.set(tunnelName, sourceClient);
 }
 
 async function establishManagedS2STunnel(
@@ -1015,11 +1159,15 @@ async function connectSSHTunnel(
         );
       }
 
-      await establishManagedS2STunnel(
-        conn,
-        tunnelConfig,
-        resolvedEndpointCredentials,
-      );
+      if (isSingleHostTunnel(tunnelConfig)) {
+        await establishDirectTunnel(conn, tunnelConfig);
+      } else {
+        await establishManagedS2STunnel(
+          conn,
+          tunnelConfig,
+          resolvedEndpointCredentials,
+        );
+      }
 
       tunnelConnecting.delete(tunnelName);
       tunnelLogger.success("Managed tunnel creation complete", {
@@ -1743,7 +1891,10 @@ app.post(
           }
         }
 
-        if (!tunnelConfig.endpointIP || !tunnelConfig.endpointUsername) {
+        if (
+          !isSingleHostTunnel(tunnelConfig) &&
+          (!tunnelConfig.endpointIP || !tunnelConfig.endpointUsername)
+        ) {
           try {
             const systemCrypto = SystemCrypto.getInstance();
             const internalAuthToken = await systemCrypto.getInternalAuthToken();

--- a/src/ui/features/tunnel/TunnelTab.tsx
+++ b/src/ui/features/tunnel/TunnelTab.tsx
@@ -296,24 +296,31 @@ export function TunnelTab({ host }: { label: string; host?: DemoHost }) {
     setTunnelActions((prev) => ({ ...prev, [name]: true }));
     try {
       if (action === "connect") {
-        const allHosts = await getSSHHosts();
-        const endpointSsh = allHosts.find(
-          (h) =>
-            h.name === tunnel.endpointHost ||
-            `${h.username}@${h.ip}` === tunnel.endpointHost,
-        );
+        const isDirect =
+          !tunnel.endpointHost ||
+          tunnel.endpointHost === "127.0.0.1" ||
+          tunnel.endpointHost === "localhost";
+        let endpointSsh: SSHHost | undefined;
+        if (!isDirect) {
+          const allHosts = await getSSHHosts();
+          endpointSsh = allHosts.find(
+            (h) =>
+              h.name === tunnel.endpointHost ||
+              `${h.username}@${h.ip}` === tunnel.endpointHost,
+          );
+        }
         await connectTunnel({
           name,
           scope: tunnel.scope ?? "s2s",
           mode:
             tunnel.mode ??
             (tunnel.tunnelType as "local" | "remote" | "dynamic") ??
-            "remote",
+            "local",
           tunnelType:
             tunnel.tunnelType ??
             (tunnel.mode === "local" || tunnel.mode === "remote"
               ? tunnel.mode
-              : "remote"),
+              : "local"),
           bindHost: tunnel.bindHost,
           targetHost: tunnel.targetHost,
           sourceHostId: sshHost.id,
@@ -332,9 +339,15 @@ export function TunnelTab({ host }: { label: string; host?: DemoHost }) {
             sshHost.authType === "key" ? sshHost.keyType : undefined,
           sourceCredentialId: sshHost.credentialId,
           endpointHost: tunnel.endpointHost ?? "",
-          endpointIP: endpointSsh?.ip ?? tunnel.endpointHost ?? "",
-          endpointSSHPort: endpointSsh?.port ?? 22,
-          endpointUsername: endpointSsh?.username ?? "",
+          endpointIP: isDirect
+            ? sshHost.ip
+            : (endpointSsh?.ip ?? tunnel.endpointHost ?? ""),
+          endpointSSHPort: isDirect
+            ? sshHost.port
+            : (endpointSsh?.port ?? 22),
+          endpointUsername: isDirect
+            ? sshHost.username
+            : (endpointSsh?.username ?? ""),
           endpointPassword:
             endpointSsh?.authType === "password"
               ? endpointSsh.password

--- a/src/ui/locales/en.json
+++ b/src/ui/locales/en.json
@@ -356,6 +356,7 @@
     "tunnelModeLocalDesc": "Forward a local port to a port on the remote server (or a host reachable from it).",
     "tunnelModeRemoteDesc": "Forward a port on the remote server back to a local port on your machine.",
     "tunnelModeDynamicDesc": "Create a SOCKS5 proxy on a local port for dynamic port forwarding.",
+    "sameHost": "This host (direct tunnel)",
     "endpointHost": "Endpoint Host",
     "endpointPort": "Endpoint Port",
     "bindHost": "Bind Host",

--- a/src/ui/locales/translated/zh_CN.json
+++ b/src/ui/locales/translated/zh_CN.json
@@ -356,6 +356,7 @@
     "tunnelModeLocalDesc": "将本地端口转发到远程服务器上的端口(或其主机可访问)。",
     "tunnelModeRemoteDesc": "将远程服务器上的端口转回您机器上的本地端口。",
     "tunnelModeDynamicDesc": "在本地端口上创建一个 SOCKS5 代理, 用于动态端口转发.",
+    "sameHost": "本机（直接隧道）",
     "endpointHost": "端点主机",
     "endpointPort": "端点端口",
     "bindHost": "绑定主机",

--- a/src/ui/sidebar/HostEditor.tsx
+++ b/src/ui/sidebar/HostEditor.tsx
@@ -1090,10 +1090,7 @@ export function HostEditor({
                               }}
                             >
                               <option value="">
-                                {t("hosts.selectAServer")}
-                              </option>
-                              <option value="127.0.0.1">
-                                127.0.0.1 (localhost)
+                                {t("hosts.sameHost")}
                               </option>
                               {hosts
                                 .filter((h) => h.enableSsh)


### PR DESCRIPTION
## Summary
- Add direct tunnel mode for single-host port forwarding (`ssh -L` / `ssh -R` / `ssh -D` equivalent) — no second endpoint host required in the Termix database
- For **local** mode: the Termix server creates a local TCP listener on `bindHost:sourcePort` and forwards each connection through the SSH channel via `forwardOut` to `targetHost:endpointPort` on the remote host
- For **remote** mode: uses `bindForwardIn` to listen on the remote host, forwards back to a local port on the Termix server
- For **dynamic** mode: creates a local SOCKS5 proxy, forwards arbitrary destinations through the SSH channel
- `isSingleHostTunnel()` detects when endpoint is absent, `127.0.0.1`, `localhost`, or identical to the source — automatically routes to the direct tunnel path
- Frontend: endpoint host dropdown defaults to "This host (direct tunnel)" instead of requiring a server selection, making the common `ssh -L` use case the default
- Default tunnel mode changed from `remote` to `local` to match PuTTY/Termius behavior

## Context
Users coming from PuTTY, Termius, and MobaXterm expect to create simple local port forwards (e.g., `ssh -L 8006:localhost:8006 remote-host` for Proxmox GUI access). The existing S2S tunnel architecture requires two Termix-managed SSH hosts (source + endpoint), which confused users and made basic forwarding impossible without registering the same host twice.

This was raised in Discord by multiple users (Antiager, NyvenZA, frenzykiwi) and was the root cause of the `"Endpoint host not found in database"` error.

## Linked issues
Related discussion in Termix-SSH/Support (Discord thread, no GitHub issue)

## Validation
- `npx tsc --noEmit --pretty false`
- `npm run build`

## Checklist
- [x] Code follows project style guidelines
- [x] Supports mobile and desktop UI/app (if applicable) — this affects the web tunnel UI and the backend; desktop C2S tunnels are unchanged
- [x] I have read [Contributing.md](https://github.com/Termix-SSH/Termix/blob/main/CONTRIBUTING.md)
- [x] This is not a translation request