### PR TITLE
fix: patch TOTP bypass and password hash disclosure

### DIFF
--- a/src/backend/database/routes/users.ts
+++ b/src/backend/database/routes/users.ts
@@ -3209,8 +3209,10 @@ router.post("/totp/disable", authenticateJWT, async (req, res) => {
   const userId = (req as AuthenticatedRequest).userId;
   const { password, totp_code } = req.body;
 
-  if (!password && !totp_code) {
-    return res.status(400).json({ error: "Password or TOTP code is required" });
+  if (!password || !totp_code) {
+    return res
+      .status(400)
+      .json({ error: "Both password and TOTP code are required" });
   }
 
   try {
@@ -3225,24 +3227,22 @@ router.post("/totp/disable", authenticateJWT, async (req, res) => {
       return res.status(400).json({ error: "TOTP is not enabled" });
     }
 
-    if (password && !userRecord.isOidc) {
+    if (!userRecord.isOidc) {
       const isMatch = await bcrypt.compare(password, userRecord.passwordHash);
       if (!isMatch) {
         return res.status(401).json({ error: "Incorrect password" });
       }
-    } else if (totp_code) {
-      const verified = speakeasy.totp.verify({
-        secret: userRecord.totpSecret!,
-        encoding: "base32",
-        token: totp_code,
-        window: 2,
-      });
+    }
 
-      if (!verified) {
-        return res.status(401).json({ error: "Invalid TOTP code" });
-      }
-    } else {
-      return res.status(400).json({ error: "Authentication required" });
+    const verified = speakeasy.totp.verify({
+      secret: userRecord.totpSecret!,
+      encoding: "base32",
+      token: totp_code,
+      window: 2,
+    });
+
+    if (!verified) {
+      return res.status(401).json({ error: "Invalid TOTP code" });
     }
 
     await db
@@ -3300,8 +3300,10 @@ router.post("/totp/backup-codes", authenticateJWT, async (req, res) => {
   const userId = (req as AuthenticatedRequest).userId;
   const { password, totp_code } = req.body;
 
-  if (!password && !totp_code) {
-    return res.status(400).json({ error: "Password or TOTP code is required" });
+  if (!password || !totp_code) {
+    return res
+      .status(400)
+      .json({ error: "Both password and TOTP code are required" });
   }
 
   try {
@@ -3316,24 +3318,22 @@ router.post("/totp/backup-codes", authenticateJWT, async (req, res) => {
       return res.status(400).json({ error: "TOTP is not enabled" });
     }
 
-    if (password && !userRecord.isOidc) {
+    if (!userRecord.isOidc) {
       const isMatch = await bcrypt.compare(password, userRecord.passwordHash);
       if (!isMatch) {
         return res.status(401).json({ error: "Incorrect password" });
       }
-    } else if (totp_code) {
-      const verified = speakeasy.totp.verify({
-        secret: userRecord.totpSecret!,
-        encoding: "base32",
-        token: totp_code,
-        window: 2,
-      });
+    }
 
-      if (!verified) {
-        return res.status(401).json({ error: "Invalid TOTP code" });
-      }
-    } else {
-      return res.status(400).json({ error: "Authentication required" });
+    const verified = speakeasy.totp.verify({
+      secret: userRecord.totpSecret!,
+      encoding: "base32",
+      token: totp_code,
+      window: 2,
+    });
+
+    if (!verified) {
+      return res.status(401).json({ error: "Invalid TOTP code" });
     }
 
     const backupCodes = Array.from({ length: 8 }, () =>

--- a/src/backend/database/routes/users.ts
+++ b/src/backend/database/routes/users.ts
@@ -2797,7 +2797,6 @@ router.get("/list", authenticateJWT, async (req, res) => {
         username: users.username,
         isAdmin: users.isAdmin,
         isOidc: users.isOidc,
-        passwordHash: users.passwordHash,
       })
       .from(users);
 


### PR DESCRIPTION
## Summary
- Remove `passwordHash` from `/users/list` API response — hashes should never leave the server
- Require **both** password and TOTP code for `/totp/disable` and `/totp/backup-codes` — previously either alone was sufficient, defeating MFA

## Security Advisories Addressed
- GHSA-ccm8-q457-6vjj (password hash disclosure)
- GHSA-wqfw-rqj7-fv9m (TOTP bypass via password-only)

## Test plan
- [ ] Verify `/users/list` no longer returns `passwordHash` field
- [ ] Verify `/totp/disable` rejects requests with password only (no TOTP code)
- [ ] Verify `/totp/backup-codes` rejects requests with password only
- [ ] Verify both endpoints still work when both password + valid TOTP code are provided