### PR TITLE
fix: reliable OIDC group syncing for admin roles

### DIFF
--- a/src/backend/database/routes/users.ts
+++ b/src/backend/database/routes/users.ts
@@ -834,7 +834,7 @@ router.get("/oidc/callback", async (req, res) => {
       }
     }
 
-    if (!userInfo && tokenData.access_token) {
+    if (tokenData.access_token) {
       for (const userInfoUrl of userInfoUrls) {
         try {
           const userInfoResponse = await fetch(userInfoUrl, {
@@ -844,10 +844,11 @@ router.get("/oidc/callback", async (req, res) => {
           });
 
           if (userInfoResponse.ok) {
-            userInfo = (await userInfoResponse.json()) as Record<
+            const fetchedUserInfo = (await userInfoResponse.json()) as Record<
               string,
               unknown
             >;
+            userInfo = { ...userInfo, ...fetchedUserInfo };
             break;
           } else {
             authLogger.error(
@@ -1107,9 +1108,29 @@ router.get("/oidc/callback", async (req, res) => {
 
     // Sync admin status based on OIDC group membership
     if (config.admin_group) {
-      const groups = (userInfo.groups || userInfo.roles || []) as string[];
+      const rawGroups = userInfo.groups || userInfo.roles || userInfo.group;
+      const groups = Array.isArray(rawGroups)
+        ? rawGroups.map(String)
+        : typeof rawGroups === "string"
+          ? rawGroups.split(",").map((s) => s.trim())
+          : [];
+
+      authLogger.info(
+        `Evaluating OIDC admin group sync. rawGroups: ${JSON.stringify(rawGroups)}, parsedGroups: ${JSON.stringify(groups)}, configuredAdminGroup: ${config.admin_group}, availableUserInfoKeys: ${Object.keys(userInfo).join(",")}`,
+        {
+          operation: "oidc_admin_group_sync_eval",
+          userId: userRecord.id,
+        }
+      );
+
       const shouldBeAdmin = groups.includes(config.admin_group);
       if (!!userRecord.isAdmin !== shouldBeAdmin) {
+        authLogger.info("Syncing admin status based on OIDC group membership", {
+          operation: "oidc_admin_group_sync",
+          userId: userRecord.id,
+          group: config.admin_group,
+          isAdmin: shouldBeAdmin,
+        });
         await db
           .update(users)
           .set({ isAdmin: shouldBeAdmin })


### PR DESCRIPTION
# Overview

In the current code, syncing user admin status did not work for me using Authelia. This PR is meant to fix it.

# Changes Made

- always fetch from the userinfo endpoint to get extra claims (like `groups` from Authelia) instead of skipping it if the id_token was already parsed
- handle cases where the OIDC provider sends groups as a single string or a comma-separated string
- add debug logging

# Related Issues

- Related to [574](https://github.com/Termix-SSH/Support/issues/574)

# Screenshots / Demos

Log output with it:
```
termix        | [2:00:27 PM] [INFO] [🔐] Evaluating OIDC admin group sync. rawGroups: ["admin","remote-admins"], parsedGroups: ["admin","remote-admins"], configuredAdminGroup: remote-admins, availableUserInfoKeys: amr,at_hash,aud,auth_time,azp,email,email_verified,exp,iat,iss,jti,name,nonce,preferred_username,sub,groups,rat,updated_at [op:oidc_admin_group_sync_eval,user:34kEMJPFRaG2fLyLhaMT1]
termix        | [2:00:27 PM] [INFO] [🔐] Syncing admin status based on OIDC group membership [op:oidc_admin_group_sync,user:34kEMJPFRaG2fLyLhaMT1]
termix        | [2:00:27 PM] [INFO] [🔐] OIDC admin status synced [op:oidc_admin_group_sync,user:34kEMJPFRaG2fLyLhaMT1]
termix        | [2:00:27 PM] [SUCCESS] [🔐] OIDC login successful [op:oidc_login_complete,user:34kEMJPFRaG2fLyLhaMT1]
```

# Checklist

- [x] Code follows project style guidelines (hopefully)
- [x] Supports mobile and desktop UI/app (if applicable)
- [x] I have read [Contributing.md](https://github.com/Termix-SSH/Termix/blob/main/CONTRIBUTING.md)
- [x] This is not a translation request. See [docs](https://docs.termix.site/translations)
