### PR TITLE
fix(docker): use resolveTermixThemeColors for Docker console terminal background

### DIFF
--- a/src/ui/features/docker/components/ConsoleTerminal.tsx
+++ b/src/ui/features/docker/components/ConsoleTerminal.tsx
@@ -20,6 +20,7 @@ import type { SSHHost } from "@/types";
 import { isElectron } from "@/main-axios.ts";
 import { SimpleLoader } from "@/lib/SimpleLoader.tsx";
 import { useTranslation } from "react-i18next";
+import { resolveTermixThemeColors } from "@/features/terminal/terminal-theme";
 import {
   TERMINAL_THEMES,
   DEFAULT_TERMINAL_CONFIG,
@@ -49,26 +50,10 @@ export function ConsoleTerminal({
     [hostConfig.terminalConfig],
   );
 
-  const isDarkMode =
-    appTheme === "dark" ||
-    appTheme === "dracula" ||
-    appTheme === "gentlemansChoice" ||
-    appTheme === "midnightEspresso" ||
-    appTheme === "catppuccinMocha" ||
-    (appTheme === "system" &&
-      window.matchMedia("(prefers-color-scheme: dark)").matches);
-
   const themeColors = React.useMemo(() => {
     const activeTheme = terminalConfig.theme;
-    if (activeTheme === "termix") {
-      return isDarkMode
-        ? TERMINAL_THEMES.termixDark.colors
-        : TERMINAL_THEMES.termixLight.colors;
-    }
-    return (
-      TERMINAL_THEMES[activeTheme]?.colors ?? TERMINAL_THEMES.termixDark.colors
-    );
-  }, [terminalConfig.theme, isDarkMode]);
+    return resolveTermixThemeColors(activeTheme, appTheme);
+  }, [terminalConfig.theme, appTheme]);
 
   const [isConnected, setIsConnected] = React.useState(false);
   const [isConnecting, setIsConnecting] = React.useState(false);


### PR DESCRIPTION
## Summary

Fixes the Docker container console terminal having a white background (`#ffffff`) for many app themes, by replacing a manually-maintained `isDarkMode` boolean check with the shared `resolveTermixThemeColors()` function that the regular SSH terminal already uses.

## Issue

Closes #780 — https://github.com/Termix-SSH/Support/issues/780

## Root Cause

`src/ui/features/docker/components/ConsoleTerminal.tsx` had its own incomplete theme resolution logic (lines 52–71) that checked only a hardcoded list of dark app themes. For any app theme not in that list — or for the `"termix"` theme on any non-explicitly-dark theme — it fell through to `TERMINAL_THEMES.termixLight` with a white background.

The SSH terminal (`src/ui/features/terminal/Terminal.tsx`) already handles this correctly via `resolveTermixThemeColors()`, which maps the app theme through a rich lookup table covering all themes (dark, light, dracula, catppuccin, nord, solarized, tokyo-night, one-dark, gruvbox).

## Changes

**`src/ui/features/docker/components/ConsoleTerminal.tsx`** — 3 insertions, 18 deletions

- Added import of `resolveTermixThemeColors` from the shared terminal-theme module
- Replaced the `isDarkMode` boolean (10 lines) and manual theme switch (7 lines) with a single call to `resolveTermixThemeColors(activeTheme, appTheme)`
- Updated the memo dependency array from `[terminalConfig.theme, isDarkMode]` to `[terminalConfig.theme, appTheme]`

## Testing

- [X] Docker console with various themes