### PR TITLE
Feat/docker release tag

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -52,7 +52,7 @@ jobs:
           ALL_TAGS=()
 
           if [ "$BUILD_TYPE" = "Production" ]; then
-            TAGS+=("release-$VERSION" "latest")
+            TAGS+=("release-$VERSION" "$VERSION" "latest")
             for tag in "${TAGS[@]}"; do
               ALL_TAGS+=("ghcr.io/lukegus/termix:$tag")
               ALL_TAGS+=("docker.io/bugattiguy527/termix:$tag")

--- a/src/ui/features/docker/components/ConsoleTerminal.tsx
+++ b/src/ui/features/docker/components/ConsoleTerminal.tsx
@@ -20,7 +20,6 @@ import type { SSHHost } from "@/types";
 import { isElectron } from "@/main-axios.ts";
 import { SimpleLoader } from "@/lib/SimpleLoader.tsx";
 import { useTranslation } from "react-i18next";
-import { resolveTermixThemeColors } from "@/features/terminal/terminal-theme";
 import {
   TERMINAL_THEMES,
   DEFAULT_TERMINAL_CONFIG,
@@ -50,10 +49,26 @@ export function ConsoleTerminal({
     [hostConfig.terminalConfig],
   );
 
+  const isDarkMode =
+    appTheme === "dark" ||
+    appTheme === "dracula" ||
+    appTheme === "gentlemansChoice" ||
+    appTheme === "midnightEspresso" ||
+    appTheme === "catppuccinMocha" ||
+    (appTheme === "system" &&
+      window.matchMedia("(prefers-color-scheme: dark)").matches);
+
   const themeColors = React.useMemo(() => {
     const activeTheme = terminalConfig.theme;
-    return resolveTermixThemeColors(activeTheme, appTheme);
-  }, [terminalConfig.theme, appTheme]);
+    if (activeTheme === "termix") {
+      return isDarkMode
+        ? TERMINAL_THEMES.termixDark.colors
+        : TERMINAL_THEMES.termixLight.colors;
+    }
+    return (
+      TERMINAL_THEMES[activeTheme]?.colors ?? TERMINAL_THEMES.termixDark.colors
+    );
+  }, [terminalConfig.theme, isDarkMode]);
 
   const [isConnected, setIsConnected] = React.useState(false);
   const [isConnecting, setIsConnecting] = React.useState(false);

--- a/src/ui/features/docker/components/ConsoleTerminal.tsx
+++ b/src/ui/features/docker/components/ConsoleTerminal.tsx
@@ -20,6 +20,7 @@ import type { SSHHost } from "@/types";
 import { isElectron } from "@/main-axios.ts";
 import { SimpleLoader } from "@/lib/SimpleLoader.tsx";
 import { useTranslation } from "react-i18next";
+import { resolveTermixThemeColors } from "@/features/terminal/terminal-theme";
 import {
   TERMINAL_THEMES,
   DEFAULT_TERMINAL_CONFIG,
@@ -49,26 +50,10 @@ export function ConsoleTerminal({
     [hostConfig.terminalConfig],
   );
 
-  const isDarkMode =
-    appTheme === "dark" ||
-    appTheme === "dracula" ||
-    appTheme === "gentlemansChoice" ||
-    appTheme === "midnightEspresso" ||
-    appTheme === "catppuccinMocha" ||
-    (appTheme === "system" &&
-      window.matchMedia("(prefers-color-scheme: dark)").matches);
-
   const themeColors = React.useMemo(() => {
     const activeTheme = terminalConfig.theme;
-    if (activeTheme === "termix") {
-      return isDarkMode
-        ? TERMINAL_THEMES.termixDark.colors
-        : TERMINAL_THEMES.termixLight.colors;
-    }
-    return (
-      TERMINAL_THEMES[activeTheme]?.colors ?? TERMINAL_THEMES.termixDark.colors
-    );
-  }, [terminalConfig.theme, isDarkMode]);
+    return resolveTermixThemeColors(activeTheme, appTheme);
+  }, [terminalConfig.theme, appTheme]);
 
   const [isConnected, setIsConnected] = React.useState(false);
   const [isConnecting, setIsConnecting] = React.useState(false);


### PR DESCRIPTION
# Overview

This PR add the support of x.y.z docker tag alongside the existing tag when a release is created.

- [x] Added: Add x.y.z Docker tag alongside release-x.y.z for Renovate/Dependabot compatibility 

# Related Issues

- Closes https://github.com/Termix-SSH/Support/issues/705

# Checklist

- [x] Code follows project style guidelines
- [x] Supports mobile and desktop UI/app (if applicable)
- [x] I have read [Contributing.md](https://github.com/Termix-SSH/Termix/blob/main/CONTRIBUTING.md)
- [x] This is not a translation request. See [docs](https://docs.termix.site/translations)
