### PR TITLE
fix: disable hardware acceleration on Windows to prevent startup crash

### DIFF
--- a/electron/main.cjs
+++ b/electron/main.cjs
@@ -478,6 +478,10 @@ if (process.platform === "linux") {
   app.commandLine.appendSwitch("--enable-features=VaapiVideoDecoder");
 }
 
+if (process.platform === "win32") {
+  app.disableHardwareAcceleration();
+}
+
 if (isInsecureModeEnabled()) {
   logToFile(
     "[security] ENABLE_INSECURE_MODE is enabled; TLS certificate validation is disabled.",

--- a/src/ui/features/docker/components/ConsoleTerminal.tsx
+++ b/src/ui/features/docker/components/ConsoleTerminal.tsx
@@ -20,7 +20,6 @@ import type { SSHHost } from "@/types";
 import { isElectron } from "@/main-axios.ts";
 import { SimpleLoader } from "@/lib/SimpleLoader.tsx";
 import { useTranslation } from "react-i18next";
-import { resolveTermixThemeColors } from "@/features/terminal/terminal-theme";
 import {
   TERMINAL_THEMES,
   DEFAULT_TERMINAL_CONFIG,
@@ -50,10 +49,26 @@ export function ConsoleTerminal({
     [hostConfig.terminalConfig],
   );
 
+  const isDarkMode =
+    appTheme === "dark" ||
+    appTheme === "dracula" ||
+    appTheme === "gentlemansChoice" ||
+    appTheme === "midnightEspresso" ||
+    appTheme === "catppuccinMocha" ||
+    (appTheme === "system" &&
+      window.matchMedia("(prefers-color-scheme: dark)").matches);
+
   const themeColors = React.useMemo(() => {
     const activeTheme = terminalConfig.theme;
-    return resolveTermixThemeColors(activeTheme, appTheme);
-  }, [terminalConfig.theme, appTheme]);
+    if (activeTheme === "termix") {
+      return isDarkMode
+        ? TERMINAL_THEMES.termixDark.colors
+        : TERMINAL_THEMES.termixLight.colors;
+    }
+    return (
+      TERMINAL_THEMES[activeTheme]?.colors ?? TERMINAL_THEMES.termixDark.colors
+    );
+  }, [terminalConfig.theme, isDarkMode]);
 
   const [isConnected, setIsConnected] = React.useState(false);
   const [isConnecting, setIsConnecting] = React.useState(false);

--- a/src/ui/features/docker/components/ConsoleTerminal.tsx
+++ b/src/ui/features/docker/components/ConsoleTerminal.tsx
@@ -20,6 +20,7 @@ import type { SSHHost } from "@/types";
 import { isElectron } from "@/main-axios.ts";
 import { SimpleLoader } from "@/lib/SimpleLoader.tsx";
 import { useTranslation } from "react-i18next";
+import { resolveTermixThemeColors } from "@/features/terminal/terminal-theme";
 import {
   TERMINAL_THEMES,
   DEFAULT_TERMINAL_CONFIG,
@@ -49,26 +50,10 @@ export function ConsoleTerminal({
     [hostConfig.terminalConfig],
   );
 
-  const isDarkMode =
-    appTheme === "dark" ||
-    appTheme === "dracula" ||
-    appTheme === "gentlemansChoice" ||
-    appTheme === "midnightEspresso" ||
-    appTheme === "catppuccinMocha" ||
-    (appTheme === "system" &&
-      window.matchMedia("(prefers-color-scheme: dark)").matches);
-
   const themeColors = React.useMemo(() => {
     const activeTheme = terminalConfig.theme;
-    if (activeTheme === "termix") {
-      return isDarkMode
-        ? TERMINAL_THEMES.termixDark.colors
-        : TERMINAL_THEMES.termixLight.colors;
-    }
-    return (
-      TERMINAL_THEMES[activeTheme]?.colors ?? TERMINAL_THEMES.termixDark.colors
-    );
-  }, [terminalConfig.theme, isDarkMode]);
+    return resolveTermixThemeColors(activeTheme, appTheme);
+  }, [terminalConfig.theme, appTheme]);
 
   const [isConnected, setIsConnected] = React.useState(false);
   const [isConnecting, setIsConnecting] = React.useState(false);


### PR DESCRIPTION
Closes [#795](https://github.com/Termix-SSH/Support/issues/795)

## Description

This PR fixes a Windows startup issue where Electron's GPU process fails during initialization, preventing the application window from loading.

### Change

```js
if (process.platform === "win32") {
  app.disableHardwareAcceleration();
}
```

### Tested

Environment:
* Windows 11
* Electron 42.2.0
* NVIDIA RTX 3050 Laptop GPU
* Termix v2.3.2

### Result

Before:
* Application crashed during startup
* Renderer never loaded
* GPU process exited unexpectedly

After:
* Application launches successfully
* Backend initializes successfully
* Frontend loads successfully
* Login works correctly

### Scope

This PR only contains the Windows GPU startup fix.
