### PR TITLE
fix: adjust RDP desktop height and implement CJK font fallbacks

### DIFF
--- a/src/ui/features/docker/components/ConsoleTerminal.tsx
+++ b/src/ui/features/docker/components/ConsoleTerminal.tsx
@@ -20,7 +20,6 @@ import type { SSHHost } from "@/types";
 import { isElectron } from "@/main-axios.ts";
 import { SimpleLoader } from "@/lib/SimpleLoader.tsx";
 import { useTranslation } from "react-i18next";
-import { resolveTermixThemeColors } from "@/features/terminal/terminal-theme";
 import {
   TERMINAL_THEMES,
   DEFAULT_TERMINAL_CONFIG,
@@ -50,10 +49,26 @@ export function ConsoleTerminal({
     [hostConfig.terminalConfig],
   );
 
+  const isDarkMode =
+    appTheme === "dark" ||
+    appTheme === "dracula" ||
+    appTheme === "gentlemansChoice" ||
+    appTheme === "midnightEspresso" ||
+    appTheme === "catppuccinMocha" ||
+    (appTheme === "system" &&
+      window.matchMedia("(prefers-color-scheme: dark)").matches);
+
   const themeColors = React.useMemo(() => {
     const activeTheme = terminalConfig.theme;
-    return resolveTermixThemeColors(activeTheme, appTheme);
-  }, [terminalConfig.theme, appTheme]);
+    if (activeTheme === "termix") {
+      return isDarkMode
+        ? TERMINAL_THEMES.termixDark.colors
+        : TERMINAL_THEMES.termixLight.colors;
+    }
+    return (
+      TERMINAL_THEMES[activeTheme]?.colors ?? TERMINAL_THEMES.termixDark.colors
+    );
+  }, [terminalConfig.theme, isDarkMode]);
 
   const [isConnected, setIsConnected] = React.useState(false);
   const [isConnecting, setIsConnecting] = React.useState(false);

--- a/src/ui/features/docker/components/ConsoleTerminal.tsx
+++ b/src/ui/features/docker/components/ConsoleTerminal.tsx
@@ -20,6 +20,7 @@ import type { SSHHost } from "@/types";
 import { isElectron } from "@/main-axios.ts";
 import { SimpleLoader } from "@/lib/SimpleLoader.tsx";
 import { useTranslation } from "react-i18next";
+import { resolveTermixThemeColors } from "@/features/terminal/terminal-theme";
 import {
   TERMINAL_THEMES,
   DEFAULT_TERMINAL_CONFIG,
@@ -49,26 +50,10 @@ export function ConsoleTerminal({
     [hostConfig.terminalConfig],
   );
 
-  const isDarkMode =
-    appTheme === "dark" ||
-    appTheme === "dracula" ||
-    appTheme === "gentlemansChoice" ||
-    appTheme === "midnightEspresso" ||
-    appTheme === "catppuccinMocha" ||
-    (appTheme === "system" &&
-      window.matchMedia("(prefers-color-scheme: dark)").matches);
-
   const themeColors = React.useMemo(() => {
     const activeTheme = terminalConfig.theme;
-    if (activeTheme === "termix") {
-      return isDarkMode
-        ? TERMINAL_THEMES.termixDark.colors
-        : TERMINAL_THEMES.termixLight.colors;
-    }
-    return (
-      TERMINAL_THEMES[activeTheme]?.colors ?? TERMINAL_THEMES.termixDark.colors
-    );
-  }, [terminalConfig.theme, isDarkMode]);
+    return resolveTermixThemeColors(activeTheme, appTheme);
+  }, [terminalConfig.theme, appTheme]);
 
   const [isConnected, setIsConnected] = React.useState(false);
   const [isConnecting, setIsConnecting] = React.useState(false);

--- a/src/ui/features/docker/components/ConsoleTerminal.tsx
+++ b/src/ui/features/docker/components/ConsoleTerminal.tsx
@@ -25,6 +25,8 @@ import {
   DEFAULT_TERMINAL_CONFIG,
   TERMINAL_FONTS,
 } from "@/lib/terminal-themes";
+import { resolveTerminalFontFamily } from "@/lib/fonts";
+import i18n from "@/i18n/i18n";
 import { useTheme } from "@/components/theme-provider";
 
 interface ConsoleTerminalProps {
@@ -91,10 +93,10 @@ export function ConsoleTerminal({
     terminal.loadAddon(clipboardAddon);
     terminal.loadAddon(webLinksAddon);
 
-    const fontConfig = TERMINAL_FONTS.find(
-      (f) => f.value === terminalConfig.fontFamily,
+    const fontFamily = resolveTerminalFontFamily(
+      terminalConfig.fontFamily || TERMINAL_FONTS[0].value,
+      i18n.language,
     );
-    const fontFamily = fontConfig?.fallback ?? TERMINAL_FONTS[0].fallback;
 
     terminal.options.cursorBlink = terminalConfig.cursorBlink;
     terminal.options.cursorStyle = terminalConfig.cursorStyle;

--- a/src/ui/features/guacamole/GuacamoleApp.tsx
+++ b/src/ui/features/guacamole/GuacamoleApp.tsx
@@ -16,12 +16,14 @@ interface GuacamoleAppProps {
   hostId?: string;
   tabId?: string;
   protocol?: "rdp" | "vnc" | "telnet";
+  isVisible?: boolean;
 }
 
 const GuacamoleApp: React.FC<GuacamoleAppProps> = ({
   hostId,
   tabId,
   protocol,
+  isVisible = true,
 }) => {
   const { t } = useTranslation();
 
@@ -82,6 +84,7 @@ const GuacamoleApp: React.FC<GuacamoleAppProps> = ({
             hostConfig={hostConfig}
             tabId={tabId}
             protocol={protocol}
+            isVisible={isVisible}
           />
         );
       }}
@@ -94,6 +97,7 @@ interface GuacamoleAppInnerProps {
   hostConfig: Pick<SSHHost, "connectionType">;
   tabId?: string;
   protocol?: "rdp" | "vnc" | "telnet";
+  isVisible?: boolean;
 }
 
 const GuacamoleAppInner: React.FC<GuacamoleAppInnerProps> = ({
@@ -101,6 +105,7 @@ const GuacamoleAppInner: React.FC<GuacamoleAppInnerProps> = ({
   hostConfig,
   tabId,
   protocol,
+  isVisible = true,
 }) => {
   const { t } = useTranslation();
   const [token, setToken] = useState<string | null>(null);
@@ -233,7 +238,7 @@ const GuacamoleAppInner: React.FC<GuacamoleAppInnerProps> = ({
           protocol: resolvedProtocol,
           type: resolvedProtocol,
         }}
-        isVisible={true}
+        isVisible={isVisible}
         onError={(err) => setConnectionError(err)}
       />
       <GuacamoleToolbar displayRef={displayRef} protocol={resolvedProtocol} />

--- a/src/ui/features/guacamole/GuacamoleDisplay.tsx
+++ b/src/ui/features/guacamole/GuacamoleDisplay.tsx
@@ -10,6 +10,10 @@ import Guacamole from "guacamole-common-js";
 import { useTranslation } from "react-i18next";
 import { getGuacamoleToken, isElectron, isEmbeddedMode } from "@/main-axios.ts";
 import { SimpleLoader } from "@/lib/SimpleLoader.tsx";
+import {
+  getGuacamoleDisplaySize,
+  waitForGuacamoleDisplaySize,
+} from "@/features/guacamole/guacamole-display-size.ts";
 
 export type GuacamoleConnectionType = "rdp" | "vnc" | "telnet";
 
@@ -44,6 +48,7 @@ interface GuacamoleDisplayProps {
 }
 
 const isDev = import.meta.env.DEV;
+const SIZE_SYNC_DEBOUNCE_MS = 100;
 
 export const GuacamoleDisplay = forwardRef<
   GuacamoleDisplayHandle,
@@ -235,34 +240,41 @@ export const GuacamoleDisplay = forwardRef<
     };
   }, [isVisible]);
 
-  const rescaleDisplay = useCallback((immediate: boolean = false) => {
+  const rescaleDisplay = useCallback(() => {
     if (!clientRef.current || !containerRef.current) return;
 
-    const performRescale = () => {
-      if (!clientRef.current || !containerRef.current) return;
+    const display = clientRef.current.getDisplay();
+    const { width: cWidth, height: cHeight } = getGuacamoleDisplaySize(
+      containerRef.current,
+    );
+    const displayWidth = display.getWidth();
+    const displayHeight = display.getHeight();
 
-      const display = clientRef.current.getDisplay();
-      const cWidth = containerRef.current.clientWidth;
-      const cHeight = containerRef.current.clientHeight;
-      const displayWidth = display.getWidth();
-      const displayHeight = display.getHeight();
-
-      if (displayWidth > 0 && displayHeight > 0 && cWidth > 0 && cHeight > 0) {
-        const scale = Math.min(cWidth / displayWidth, cHeight / displayHeight);
-        scaleRef.current = scale;
-        display.scale(scale);
-      }
-    };
-
-    if (immediate) {
-      performRescale();
-    } else {
-      if (resizeTimeoutRef.current) {
-        clearTimeout(resizeTimeoutRef.current);
-      }
-      resizeTimeoutRef.current = setTimeout(performRescale, 200);
+    if (displayWidth > 0 && displayHeight > 0 && cWidth > 0 && cHeight > 0) {
+      const scale = Math.min(cWidth / displayWidth, cHeight / displayHeight);
+      scaleRef.current = scale;
+      display.scale(scale);
     }
   }, []);
+
+  const syncRemoteDisplaySize = useCallback(() => {
+    if (!isVisible || !clientRef.current || !containerRef.current) return;
+
+    const { width, height } = getGuacamoleDisplaySize(containerRef.current);
+    if (width > 0 && height > 0) {
+      clientRef.current.sendSize(width, height);
+    }
+    rescaleDisplay();
+  }, [isVisible, rescaleDisplay]);
+
+  const scheduleRemoteDisplaySizeSync = useCallback(() => {
+    if (resizeTimeoutRef.current) {
+      clearTimeout(resizeTimeoutRef.current);
+    }
+    resizeTimeoutRef.current = setTimeout(() => {
+      syncRemoteDisplaySize();
+    }, SIZE_SYNC_DEBOUNCE_MS);
+  }, [syncRemoteDisplaySize]);
 
   const connect = useCallback(async () => {
     if (isConnectingRef.current) return;
@@ -270,19 +282,8 @@ export const GuacamoleDisplay = forwardRef<
     setIsReady(false);
     setHasError(false);
 
-    // Wait two frames so the container is fully laid out before measuring.
-    await new Promise<void>((resolve) =>
-      requestAnimationFrame(() => requestAnimationFrame(() => resolve())),
-    );
-
-    const rect = containerRef.current?.getBoundingClientRect();
-    let containerWidth = rect?.width || 0;
-    let containerHeight = rect?.height || 0;
-
-    if (containerWidth < 100 || containerHeight < 100) {
-      containerWidth = window.innerWidth || 1280;
-      containerHeight = window.innerHeight || 720;
-    }
+    const { width: containerWidth, height: containerHeight } =
+      await waitForGuacamoleDisplaySize(containerRef.current);
 
     const wsUrl = await getWebSocketUrl(containerWidth, containerHeight);
     if (!wsUrl) {
@@ -307,7 +308,7 @@ export const GuacamoleDisplay = forwardRef<
     displayElement.style.outline = "none";
 
     display.onresize = () => {
-      rescaleDisplay(true);
+      rescaleDisplay();
       setIsReady(true);
     };
 
@@ -367,13 +368,8 @@ export const GuacamoleDisplay = forwardRef<
           isConnectingRef.current = false;
           setIsReady(true);
           onConnect?.();
-          if (containerRef.current) {
-            const rect = containerRef.current.getBoundingClientRect();
-            const w = Math.round(rect.width);
-            const h = Math.round(rect.height);
-            if (w > 0 && h > 0) client.sendSize(w, h);
-          }
-          rescaleDisplay(false);
+          syncRemoteDisplaySize();
+          requestAnimationFrame(() => syncRemoteDisplaySize());
           break;
         case 4:
           break;
@@ -436,7 +432,7 @@ export const GuacamoleDisplay = forwardRef<
     onDisconnect,
     onError,
     refreshKeyboardHandlers,
-    rescaleDisplay,
+    syncRemoteDisplaySize,
     connectionConfig.protocol,
     connectionConfig.type,
     t,
@@ -458,10 +454,12 @@ export const GuacamoleDisplay = forwardRef<
   useEffect(() => {
     if (!isVisible) {
       hasKeyboardFocusRef.current = false;
+    } else if (isReady) {
+      syncRemoteDisplaySize();
     }
 
     refreshKeyboardHandlers();
-  }, [isVisible, refreshKeyboardHandlers]);
+  }, [isVisible, isReady, refreshKeyboardHandlers, syncRemoteDisplaySize]);
 
   useEffect(() => {
     const handleWindowFocus = () => {
@@ -512,28 +510,31 @@ export const GuacamoleDisplay = forwardRef<
   }, []);
 
   useEffect(() => {
-    if (!containerRef.current) return;
+    const container = containerRef.current;
+    if (!container) return;
 
     const resizeObserver = new ResizeObserver(() => {
-      if (resizeTimeoutRef.current) clearTimeout(resizeTimeoutRef.current);
-      resizeTimeoutRef.current = setTimeout(() => {
-        if (clientRef.current && containerRef.current) {
-          const rect = containerRef.current.getBoundingClientRect();
-          const w = Math.round(rect.width);
-          const h = Math.round(rect.height);
-          if (w > 0 && h > 0) {
-            clientRef.current.sendSize(w, h);
-          }
-        }
-      }, 150);
+      scheduleRemoteDisplaySizeSync();
     });
+    resizeObserver.observe(container);
 
-    resizeObserver.observe(containerRef.current);
+    const tabBar = document.querySelector("[data-termix-tab-bar]");
+    const mobileBar = document.querySelector("[data-termix-mobile-bottom-bar]");
+    if (tabBar) resizeObserver.observe(tabBar);
+    if (mobileBar) resizeObserver.observe(mobileBar);
+
+    const onViewportChange = () => scheduleRemoteDisplaySizeSync();
+    window.addEventListener("resize", onViewportChange);
+    window.visualViewport?.addEventListener("resize", onViewportChange);
+    window.visualViewport?.addEventListener("scroll", onViewportChange);
 
     return () => {
       resizeObserver.disconnect();
+      window.removeEventListener("resize", onViewportChange);
+      window.visualViewport?.removeEventListener("resize", onViewportChange);
+      window.visualViewport?.removeEventListener("scroll", onViewportChange);
     };
-  }, [rescaleDisplay]);
+  }, [scheduleRemoteDisplaySizeSync]);
 
   const syncClipboard = useCallback(() => {
     const client = clientRef.current;
@@ -585,7 +586,7 @@ export const GuacamoleDisplay = forwardRef<
     >
       <div
         ref={displayRef}
-        className="relative w-full h-full flex items-center justify-center"
+        className="relative w-full h-full flex items-start justify-center"
         style={{
           cursor: isReady ? "none" : "default",
           visibility: isReady ? "visible" : "hidden",

--- a/src/ui/features/guacamole/guacamole-display-size.ts
+++ b/src/ui/features/guacamole/guacamole-display-size.ts
@@ -1,0 +1,85 @@
+const MIN_DISPLAY_DIMENSION = 1;
+
+/**
+ * Size for Guacamole sendSize — uses the container's own box, capped only when
+ * it extends past the visible viewport bottom (no tab-bar double subtraction).
+ */
+export function getGuacamoleDisplaySize(container: HTMLElement): {
+  width: number;
+  height: number;
+} {
+  const width = Math.round(container.clientWidth);
+  let height = Math.round(container.clientHeight);
+
+  const rect = container.getBoundingClientRect();
+  const vv = window.visualViewport;
+  const viewportBottom =
+    (vv?.offsetTop ?? 0) + (vv?.height ?? window.innerHeight);
+  const maxHeight = Math.round(Math.max(0, viewportBottom - rect.top));
+  if (maxHeight > 0 && height > maxHeight) {
+    height = maxHeight;
+  }
+
+  const mobileBar = document.querySelector<HTMLElement>(
+    "[data-termix-mobile-bottom-bar]",
+  );
+  const mobileBarRect = mobileBar?.getBoundingClientRect();
+  if (mobileBarRect && mobileBarRect.height > 0) {
+    const mobileMaxHeight = Math.round(
+      Math.max(0, mobileBarRect.top - rect.top),
+    );
+    if (mobileMaxHeight > 0 && height > mobileMaxHeight) {
+      height = mobileMaxHeight;
+    }
+  }
+
+  return {
+    width: Math.max(width, MIN_DISPLAY_DIMENSION),
+    height: Math.max(height, MIN_DISPLAY_DIMENSION),
+  };
+}
+
+const MIN_CONTAINER_DIMENSION = 100;
+const MAX_MEASURE_FRAMES = 60;
+
+export async function waitForGuacamoleDisplaySize(
+  container: HTMLDivElement | null | undefined,
+): Promise<{ width: number; height: number }> {
+  for (let i = 0; i < MAX_MEASURE_FRAMES; i++) {
+    if (container) {
+      const size = getGuacamoleDisplaySize(container);
+      if (
+        size.width >= MIN_CONTAINER_DIMENSION &&
+        size.height >= MIN_CONTAINER_DIMENSION
+      ) {
+        return size;
+      }
+    }
+    await new Promise<void>((resolve) =>
+      requestAnimationFrame(() => resolve()),
+    );
+  }
+
+  if (container) {
+    return getGuacamoleDisplaySize(container);
+  }
+
+  const tabBar = document.querySelector<HTMLElement>("[data-termix-tab-bar]");
+  const tabBarRect = tabBar?.getBoundingClientRect();
+  const vv = window.visualViewport;
+  const viewportBottom =
+    (vv?.offsetTop ?? 0) + (vv?.height ?? window.innerHeight);
+  const top =
+    tabBarRect && tabBarRect.height > 0 ? tabBarRect.bottom : (vv?.offsetTop ?? 0);
+
+  return {
+    width: Math.max(
+      MIN_CONTAINER_DIMENSION,
+      Math.round(vv?.width ?? window.innerWidth),
+    ),
+    height: Math.max(
+      MIN_CONTAINER_DIMENSION,
+      Math.round(Math.max(0, viewportBottom - top)),
+    ),
+  };
+}

--- a/src/ui/features/terminal/Terminal.tsx
+++ b/src/ui/features/terminal/Terminal.tsx
@@ -37,6 +37,7 @@ import {
   DEFAULT_TERMINAL_CONFIG,
   TERMINAL_FONTS,
 } from "@/lib/terminal-themes.ts";
+import { resolveTerminalFontFamily } from "@/lib/fonts.ts";
 import "./terminal-global-styles.ts";
 import { useTheme } from "@/components/theme-provider.tsx";
 import { useCommandTracker } from "@/features/terminal/command-history/useCommandTracker.ts";
@@ -89,7 +90,7 @@ const TerminalInner = forwardRef<TerminalHandle, SSHTerminalProps>(
     },
     ref,
   ) {
-    const { t } = useTranslation();
+    const { t, i18n } = useTranslation();
     const { instance: terminal, ref: xtermRef } = useXTerm();
     const commandHistoryContext = useCommandHistory();
     const { confirmWithToast } = useConfirmation();
@@ -1798,10 +1799,10 @@ const TerminalInner = forwardRef<TerminalHandle, SSHTerminalProps>(
       const activeTheme = previewTheme || config.theme;
       const themeColors = resolveTermixThemeColors(activeTheme, appTheme);
 
-      const fontConfig = TERMINAL_FONTS.find(
-        (f) => f.value === config.fontFamily,
+      const fontFamily = resolveTerminalFontFamily(
+        config.fontFamily || TERMINAL_FONTS[0].value,
+        i18n.language,
       );
-      const fontFamily = fontConfig?.fallback || TERMINAL_FONTS[0].fallback;
 
       // Update terminal options individually to avoid re-initialization flashes
       terminal.options.cursorBlink = config.cursorBlink;
@@ -1852,7 +1853,14 @@ const TerminalInner = forwardRef<TerminalHandle, SSHTerminalProps>(
 
       // Refresh terminal to apply new theme colors to existing buffer content
       hardRefresh();
-    }, [terminal, hostConfig.terminalConfig, previewTheme, appTheme, isFitted]);
+    }, [
+      terminal,
+      hostConfig.terminalConfig,
+      previewTheme,
+      appTheme,
+      isFitted,
+      i18n.language,
+    ]);
 
     useEffect(() => {
       if (!terminal || !xtermRef.current) return;
@@ -1862,10 +1870,10 @@ const TerminalInner = forwardRef<TerminalHandle, SSHTerminalProps>(
         ...hostConfig.terminalConfig,
       };
 
-      const fontConfig = TERMINAL_FONTS.find(
-        (f) => f.value === config.fontFamily,
+      const fontFamily = resolveTerminalFontFamily(
+        config.fontFamily || TERMINAL_FONTS[0].value,
+        i18n.language,
       );
-      const fontFamily = fontConfig?.fallback || TERMINAL_FONTS[0].fallback;
 
       const activeTheme = previewTheme || config.theme;
       const themeColors = resolveTermixThemeColors(activeTheme, appTheme);

--- a/src/ui/features/terminal/TerminalPreview.tsx
+++ b/src/ui/features/terminal/TerminalPreview.tsx
@@ -1,5 +1,7 @@
 import { useTheme } from "@/components/theme-provider";
 import { TERMINAL_THEMES, TERMINAL_FONTS } from "@/lib/terminal-themes";
+import { resolveTerminalFontFamily } from "@/lib/fonts";
+import { useTranslation } from "react-i18next";
 
 interface TerminalPreviewProps {
   theme: string;
@@ -20,6 +22,7 @@ export function TerminalPreview({
   letterSpacing = 0,
   lineHeight = 1.0,
 }: TerminalPreviewProps) {
+  const { i18n } = useTranslation();
   const { theme: appTheme } = useTheme();
 
   const resolvedTheme =
@@ -32,9 +35,10 @@ export function TerminalPreview({
       : theme;
 
   const colors = TERMINAL_THEMES[resolvedTheme]?.colors;
-  const fontFallback =
-    TERMINAL_FONTS.find((f) => f.value === fontFamily)?.fallback ||
-    TERMINAL_FONTS[0].fallback;
+  const fontFallback = resolveTerminalFontFamily(
+    fontFamily || TERMINAL_FONTS[0].value,
+    i18n.language,
+  );
 
   return (
     <div className="border border-input overflow-hidden">

--- a/src/ui/features/terminal/terminal-global-styles.ts
+++ b/src/ui/features/terminal/terminal-global-styles.ts
@@ -70,7 +70,7 @@ style.innerHTML = `
 }
 
 .xterm .xterm-screen {
-  font-family: 'Caskaydia Cove Nerd Font Mono', 'SF Mono', Monaco, Consolas, 'Liberation Mono', 'Courier New', monospace !important;
+  font-family: var(--font-mono) !important;
   font-variant-ligatures: none;
 }
 

--- a/src/ui/i18n/i18n.ts
+++ b/src/ui/i18n/i18n.ts
@@ -3,6 +3,7 @@ import { initReactI18next } from "react-i18next";
 import LanguageDetector from "i18next-browser-languagedetector";
 
 import enTranslation from "../locales/en.json";
+import { applyLocaleFonts } from "@/lib/fonts";
 
 type LocaleModule = { default: ResourceKey };
 
@@ -103,5 +104,13 @@ i18n
       useSuspense: false,
     },
   });
+
+i18n.on("initialized", () => {
+  applyLocaleFonts(i18n.language);
+});
+
+i18n.on("languageChanged", (lng) => {
+  applyLocaleFonts(lng);
+});
 
 export default i18n;

--- a/src/ui/index.css
+++ b/src/ui/index.css
@@ -45,7 +45,12 @@
 
 @theme inline {
   --font-heading: var(--font-mono);
-  --font-mono: "JetBrains Mono Variable", monospace;
+  --font-cjk: "PingFang SC", "PingFang TC", "Hiragino Sans", "Yu Gothic UI",
+    "Apple SD Gothic Neo", "Malgun Gothic", "Microsoft YaHei",
+    "Microsoft JhengHei";
+  --font-mono: "JetBrains Mono Variable", "Caskaydia Cove Nerd Font Mono",
+    ui-monospace, SFMono-Regular, Menlo, Consolas, "Liberation Mono",
+    var(--font-cjk), monospace;
   --color-accent-brand: var(--accent-brand);
   --color-sidebar-ring: var(--sidebar-ring);
   --color-sidebar-border: var(--sidebar-border);

--- a/src/ui/lib/fonts.test.ts
+++ b/src/ui/lib/fonts.test.ts
@@ -1,0 +1,41 @@
+import { describe, expect, it } from "vitest";
+import { getCjkFontFallback, resolveTerminalFontFamily } from "./fonts";
+
+describe("getCjkFontFallback", () => {
+  it("prioritizes Simplified Chinese fonts for zh-CN", () => {
+    const stack = getCjkFontFallback("zh-CN");
+    expect(stack.indexOf("PingFang SC")).toBeLessThan(
+      stack.indexOf("Hiragino Sans"),
+    );
+    expect(stack.indexOf("Microsoft YaHei")).toBeLessThan(
+      stack.indexOf("Malgun Gothic"),
+    );
+  });
+
+  it("prioritizes Traditional Chinese fonts for zh-TW", () => {
+    const stack = getCjkFontFallback("zh-TW");
+    expect(stack.startsWith('"PingFang TC"')).toBe(true);
+    expect(stack).toContain("Microsoft JhengHei");
+  });
+
+  it("prioritizes Japanese fonts for ja", () => {
+    const stack = getCjkFontFallback("ja");
+    expect(stack.startsWith('"Hiragino Sans"')).toBe(true);
+    expect(stack).toContain("Yu Gothic UI");
+  });
+
+  it("prioritizes Korean fonts for ko", () => {
+    const stack = getCjkFontFallback("ko");
+    expect(stack.startsWith('"Apple SD Gothic Neo"')).toBe(true);
+    expect(stack).toContain("Malgun Gothic");
+  });
+});
+
+describe("resolveTerminalFontFamily", () => {
+  it("places the primary font before CJK fallbacks", () => {
+    const stack = resolveTerminalFontFamily("JetBrains Mono", "zh-CN");
+    expect(stack.startsWith('"JetBrains Mono"')).toBe(true);
+    expect(stack).toContain("PingFang SC");
+    expect(stack.endsWith("monospace")).toBe(true);
+  });
+});

--- a/src/ui/lib/fonts.ts
+++ b/src/ui/lib/fonts.ts
@@ -1,0 +1,53 @@
+/** Latin monospace fallbacks when the primary font lacks a glyph. */
+export const LATIN_MONO_FALLBACK =
+  'ui-monospace, SFMono-Regular, "SF Mono", Menlo, Consolas, "Liberation Mono"';
+
+/** Balanced CJK fallbacks before locale is resolved. */
+export const DEFAULT_CJK_FALLBACK =
+  '"PingFang SC", "PingFang TC", "Hiragino Sans", "Yu Gothic UI", "Apple SD Gothic Neo", "Malgun Gothic", "Microsoft YaHei", "Microsoft JhengHei"';
+
+function normalizeLocale(locale: string): string {
+  return locale.trim().toLowerCase().replace(/_/g, "-");
+}
+
+/**
+ * Locale-aware CJK font fallbacks. Primary script fonts are listed first so
+ * mixed UI text renders with the correct regional typeface.
+ */
+export function getCjkFontFallback(locale?: string | null): string {
+  const lang = normalizeLocale(locale ?? "en");
+
+  if (lang.startsWith("zh-cn") || lang === "zh") {
+    return '"PingFang SC", "Microsoft YaHei", "Noto Sans SC", "Source Han Sans SC", "Hiragino Sans GB", "Yu Gothic UI", "Malgun Gothic"';
+  }
+  if (
+    lang.startsWith("zh-tw") ||
+    lang.startsWith("zh-hk") ||
+    lang.startsWith("zh-hant")
+  ) {
+    return '"PingFang TC", "Microsoft JhengHei", "Noto Sans TC", "Source Han Sans TC", "Hiragino Sans", "Yu Gothic UI", "Malgun Gothic"';
+  }
+  if (lang.startsWith("ja")) {
+    return '"Hiragino Sans", "Hiragino Kaku Gothic ProN", "Yu Gothic UI", "Yu Gothic", "Meiryo", "Noto Sans JP", "Source Han Sans JP"';
+  }
+  if (lang.startsWith("ko")) {
+    return '"Apple SD Gothic Neo", "Malgun Gothic", "Noto Sans KR", "Source Han Sans KR"';
+  }
+
+  return DEFAULT_CJK_FALLBACK;
+}
+
+export function resolveTerminalFontFamily(
+  primaryFont: string,
+  locale?: string | null,
+): string {
+  return `"${primaryFont}", ${LATIN_MONO_FALLBACK}, ${getCjkFontFallback(locale)}, monospace`;
+}
+
+export function applyLocaleFonts(locale?: string | null): void {
+  if (typeof document === "undefined") return;
+  document.documentElement.style.setProperty(
+    "--font-cjk",
+    getCjkFontFallback(locale),
+  );
+}

--- a/src/ui/lib/terminal-themes.ts
+++ b/src/ui/lib/terminal-themes.ts
@@ -733,47 +733,14 @@ export const TERMINAL_FONTS = [
   {
     value: "Caskaydia Cove Nerd Font Mono",
     label: "Caskaydia Cove Nerd Font Mono",
-    fallback:
-      '"Caskaydia Cove Nerd Font Mono", "SF Mono", Consolas, "Liberation Mono", monospace',
   },
-  {
-    value: "JetBrains Mono",
-    label: "JetBrains Mono",
-    fallback:
-      '"JetBrains Mono", "SF Mono", Consolas, "Liberation Mono", monospace',
-  },
-  {
-    value: "Fira Code",
-    label: "Fira Code",
-    fallback: '"Fira Code", "SF Mono", Consolas, "Liberation Mono", monospace',
-  },
-  {
-    value: "Cascadia Code",
-    label: "Cascadia Code",
-    fallback:
-      '"Cascadia Code", "SF Mono", Consolas, "Liberation Mono", monospace',
-  },
-  {
-    value: "Source Code Pro",
-    label: "Source Code Pro",
-    fallback:
-      '"Source Code Pro", "SF Mono", Consolas, "Liberation Mono", monospace',
-  },
-  {
-    value: "SF Mono",
-    label: "SF Mono",
-    fallback: '"SF Mono", Consolas, "Liberation Mono", monospace',
-  },
-  {
-    value: "Consolas",
-    label: "Consolas",
-    fallback: 'Consolas, "Liberation Mono", monospace',
-  },
-  {
-    value: "Monaco",
-    label: "Monaco",
-    fallback: 'Monaco, "Liberation Mono", monospace',
-  },
+  { value: "JetBrains Mono", label: "JetBrains Mono" },
+  { value: "Fira Code", label: "Fira Code" },
+  { value: "Cascadia Code", label: "Cascadia Code" },
+  { value: "Source Code Pro", label: "Source Code Pro" },
+  { value: "SF Mono", label: "SF Mono" },
+  { value: "Consolas", label: "Consolas" },
+  { value: "Monaco", label: "Monaco" },
 ];
 
 export const CURSOR_STYLES = [

--- a/src/ui/shell/MobileBottomBar.tsx
+++ b/src/ui/shell/MobileBottomBar.tsx
@@ -71,7 +71,10 @@ export function MobileBottomBar({
   const moreActive = MORE_ITEMS.some((i) => i.view === railView) && sidebarOpen;
 
   return (
-    <div className="md:hidden flex items-stretch shrink-0 bg-sidebar border-t border-border safe-bottom">
+    <div
+      className="md:hidden flex items-stretch shrink-0 bg-sidebar border-t border-border safe-bottom"
+      data-termix-mobile-bottom-bar
+    >
       {PRIMARY_ITEMS.map((item) => {
         const active = sidebarOpen && railView === item.view;
         const hasDot = item.view === "split-screen" && splitMode !== "none";

--- a/src/ui/shell/TabBar.tsx
+++ b/src/ui/shell/TabBar.tsx
@@ -169,7 +169,7 @@ export function TabBar({
   const target = dragTargetIndex ?? dragIdx;
 
   return (
-    <div className="flex flex-col shrink-0 min-w-0">
+    <div className="flex flex-col shrink-0 min-w-0" data-termix-tab-bar>
       <div
         className={`flex items-end bg-sidebar min-w-0 transition-all duration-200 ${open ? "h-12.5 border-b border-border" : "h-0 overflow-hidden"}`}
       >

--- a/src/ui/shell/tabUtils.tsx
+++ b/src/ui/shell/tabUtils.tsx
@@ -241,6 +241,7 @@ export function renderTabContent(
           hostId={host.id}
           tabId={tab.id}
           protocol={tab.type as "rdp" | "vnc" | "telnet"}
+          isVisible={isVisible}
         />
       );
 


### PR DESCRIPTION
# Overview

Two quality-of-life improvements: locale-aware CJK font rendering for terminals and the UI, plus a fix for RDP desktop height calculations that account for the tab bar and mobile bottom bar.

- [x] Added: Locale-aware CJK font fallback system (src/ui/lib/fonts.ts) with per-locale font stacks (zh-CN, zh-TW, ja, ko)
- [x] Added: Unit tests for CJK font fallback and terminal font resolution
- [x] Added: getGuacamoleDisplaySize() and waitForGuacamoleDisplaySize() helpers for accurate RDP viewport sizing
- [x] Updated: Terminal, TerminalPreview, and ConsoleTerminal components to use resolveTerminalFontFamily() based on current i18n locale
- [x] Updated: --font-mono CSS custom property to include CJK fallbacks via var(--font-cjk)
- [x] Updated: GuacamoleDisplay to observe tab bar and mobile bottom bar for correct desktop height
- [x] Removed: Redundant fallback fields from TERMINAL_FONTS entries (now centralized in fonts.ts)
- [x] Fixed: RDP desktop being clipped or misaligned when the tab bar or mobile bottom bar is visible

# Changes Made

### CJK Font Fallbacks (9bf2bb1)

Previously, terminal font stacks only listed Latin monospace fonts. CJK characters rendered with whatever the OS default was, often using the wrong regional typeface (e.g. simplified Chinese glyphs in a ja-JP terminal).

The new fonts.ts module provides getCjkFontFallback(locale) which returns a prioritized font stack per locale:
- zh-CN / zh — PingFang SC, Microsoft YaHei, Noto Sans SC
- zh-TW / zh-HK — PingFang TC, Microsoft JhengHei, Noto Sans TC
- ja — Hiragino Sans, Yu Gothic UI, Meiryo, Noto Sans JP
- ko — Apple SD Gothic Neo, Malgun Gothic, Noto Sans KR
- fallback — balanced stack of all CJK families

resolveTerminalFontFamily(primaryFont, locale) wraps the primary font with Latin and CJK fallbacks. The font stack is applied reactively via i18n hooks — when the language changes, --font-cjk is updated on :root and all terminals pick up the new fallbacks.

TERMINAL_FONTS entries no longer carry their own fallback strings, removing duplication.

### RDP Desktop Height Fix (2daf851)

The Guacamole RDP display used to measure container.clientHeight directly for sendSize, which didn't account for the tab bar (above) or mobile bottom bar (below). On mobile or with the tab bar open, the remote desktop would appear clipped at the bottom.

New logic in guacamole-display-size.ts:
- getGuacamoleDisplaySize() clamps the container height to the visual viewport bottom and to the mobile bottom bar top, ensuring the remote desktop fits within the actual visible area
- waitForGuacamoleDisplaySize() polls up to 60 frames (replacing a fixed 2-frame requestAnimationFrame wait) for a stable measurement ≥100px² — handles slow layouts more robustly
- ResizeObservers are attached to the tab bar ([data-termix-tab-bar]) and mobile bottom bar ([data-termix-mobile-bottom-bar]) so the display recalculates when either bar appears/disappears
- visualViewport resize and scroll events also trigger resync, critical for mobile keyboards pushing the viewport up

Alignment fix: The display wrapper changed from items-center to items-start so the remote desktop stays top-aligned rather than floating mid-container when the container is taller than the scaled display.

# Related Issues

None

# Screenshots / Demos

### Before:
<img width="1058" height="394" alt="屏幕截图_20260610_170559" src="https://github.com/user-attachments/assets/2e4c81cd-5100-4cb8-84a9-c43922fa1f3d" />
<img width="1235" height="268" alt="屏幕截图_20260610_171148" src="https://github.com/user-attachments/assets/9b220dbb-d1fd-46e8-8c63-b62309670d88" />

### After:
<img width="1527" height="439" alt="屏幕截图_20260610_171532" src="https://github.com/user-attachments/assets/1f5f764b-cdcd-4c8a-9214-f00ca4cb3b4f" />
<img width="1314" height="356" alt="屏幕截图_20260610_170140" src="https://github.com/user-attachments/assets/5eb3e796-5301-4686-9477-bc46c5d5a439" />

# Checklist

- [x] Code follows project style guidelines
- [x] Supports mobile and desktop UI/app (RDP fix specifically tested on mobile viewport; CJK fonts tested across all four locales)
- [x] I have read Contributing.md (https://github.com/Termix-SSH/Termix/blob/main/CONTRIBUTING.md)
- [x] This is not a translation request
