### PR TITLE
fix: add SFTP jump-host fallback from host data

### DIFF
--- a/src/backend/ssh/file-manager.ts
+++ b/src/backend/ssh/file-manager.ts
@@ -725,6 +725,7 @@ app.post("/ssh/file_manager/ssh/connect", async (req, res) => {
   let resolvedIp = ip;
   let resolvedPort = port;
   let resolvedUsername = username;
+  let resolvedJumpHosts = jumpHosts;
   if (hostId && userId && !password && !sshKey) {
     try {
       const { resolveHostById } = await import("./host-resolver.js");
@@ -742,6 +743,20 @@ app.post("/ssh/file_manager/ssh/connect", async (req, res) => {
         };
         hostKeepaliveInterval = resolvedHost.terminalConfig?.keepaliveInterval;
         hostKeepaliveCountMax = resolvedHost.terminalConfig?.keepaliveCountMax;
+        if (
+          (!resolvedJumpHosts || resolvedJumpHosts.length === 0) &&
+          resolvedHost.jumpHosts &&
+          resolvedHost.jumpHosts.length > 0
+        ) {
+          resolvedJumpHosts = resolvedHost.jumpHosts;
+          connectionLogs.push(
+            createConnectionLog(
+              "info",
+              "jump",
+              `Loaded ${resolvedHost.jumpHosts.length} jump host(s) from server-side host data`,
+            ),
+          );
+        }
         connectionLogs.push(
           createConnectionLog(
             "info",
@@ -775,6 +790,20 @@ app.post("/ssh/file_manager/ssh/connect", async (req, res) => {
         };
         hostKeepaliveInterval = resolvedHost.terminalConfig?.keepaliveInterval;
         hostKeepaliveCountMax = resolvedHost.terminalConfig?.keepaliveCountMax;
+        if (
+          (!resolvedJumpHosts || resolvedJumpHosts.length === 0) &&
+          resolvedHost.jumpHosts &&
+          resolvedHost.jumpHosts.length > 0
+        ) {
+          resolvedJumpHosts = resolvedHost.jumpHosts;
+          connectionLogs.push(
+            createConnectionLog(
+              "info",
+              "jump",
+              `Loaded ${resolvedHost.jumpHosts.length} jump host(s) from server-side host data`,
+            ),
+          );
+        }
         connectionLogs.push(
           createConnectionLog(
             "info",
@@ -1490,7 +1519,7 @@ app.post("/ssh/file_manager/ssh/connect", async (req, res) => {
         }
       : null;
 
-  const hasJumpHosts = jumpHosts && jumpHosts.length > 0 && userId;
+  const hasJumpHosts = resolvedJumpHosts && resolvedJumpHosts.length > 0 && userId;
 
   if (hasJumpHosts) {
     try {
@@ -1507,11 +1536,11 @@ app.post("/ssh/file_manager/ssh/connect", async (req, res) => {
         createConnectionLog(
           "info",
           "jump",
-          `Connecting via ${jumpHosts.length} jump host(s)`,
+          `Connecting via ${resolvedJumpHosts.length} jump host(s)`,
         ),
       );
       const jumpClient = await createJumpHostChain(
-        jumpHosts,
+        resolvedJumpHosts,
         userId,
         proxyConfig,
       );

--- a/src/ui/features/docker/components/ConsoleTerminal.tsx
+++ b/src/ui/features/docker/components/ConsoleTerminal.tsx
@@ -20,7 +20,6 @@ import type { SSHHost } from "@/types";
 import { isElectron } from "@/main-axios.ts";
 import { SimpleLoader } from "@/lib/SimpleLoader.tsx";
 import { useTranslation } from "react-i18next";
-import { resolveTermixThemeColors } from "@/features/terminal/terminal-theme";
 import {
   TERMINAL_THEMES,
   DEFAULT_TERMINAL_CONFIG,
@@ -50,10 +49,26 @@ export function ConsoleTerminal({
     [hostConfig.terminalConfig],
   );
 
+  const isDarkMode =
+    appTheme === "dark" ||
+    appTheme === "dracula" ||
+    appTheme === "gentlemansChoice" ||
+    appTheme === "midnightEspresso" ||
+    appTheme === "catppuccinMocha" ||
+    (appTheme === "system" &&
+      window.matchMedia("(prefers-color-scheme: dark)").matches);
+
   const themeColors = React.useMemo(() => {
     const activeTheme = terminalConfig.theme;
-    return resolveTermixThemeColors(activeTheme, appTheme);
-  }, [terminalConfig.theme, appTheme]);
+    if (activeTheme === "termix") {
+      return isDarkMode
+        ? TERMINAL_THEMES.termixDark.colors
+        : TERMINAL_THEMES.termixLight.colors;
+    }
+    return (
+      TERMINAL_THEMES[activeTheme]?.colors ?? TERMINAL_THEMES.termixDark.colors
+    );
+  }, [terminalConfig.theme, isDarkMode]);
 
   const [isConnected, setIsConnected] = React.useState(false);
   const [isConnecting, setIsConnecting] = React.useState(false);

--- a/src/ui/features/docker/components/ConsoleTerminal.tsx
+++ b/src/ui/features/docker/components/ConsoleTerminal.tsx
@@ -20,6 +20,7 @@ import type { SSHHost } from "@/types";
 import { isElectron } from "@/main-axios.ts";
 import { SimpleLoader } from "@/lib/SimpleLoader.tsx";
 import { useTranslation } from "react-i18next";
+import { resolveTermixThemeColors } from "@/features/terminal/terminal-theme";
 import {
   TERMINAL_THEMES,
   DEFAULT_TERMINAL_CONFIG,
@@ -49,26 +50,10 @@ export function ConsoleTerminal({
     [hostConfig.terminalConfig],
   );
 
-  const isDarkMode =
-    appTheme === "dark" ||
-    appTheme === "dracula" ||
-    appTheme === "gentlemansChoice" ||
-    appTheme === "midnightEspresso" ||
-    appTheme === "catppuccinMocha" ||
-    (appTheme === "system" &&
-      window.matchMedia("(prefers-color-scheme: dark)").matches);
-
   const themeColors = React.useMemo(() => {
     const activeTheme = terminalConfig.theme;
-    if (activeTheme === "termix") {
-      return isDarkMode
-        ? TERMINAL_THEMES.termixDark.colors
-        : TERMINAL_THEMES.termixLight.colors;
-    }
-    return (
-      TERMINAL_THEMES[activeTheme]?.colors ?? TERMINAL_THEMES.termixDark.colors
-    );
-  }, [terminalConfig.theme, isDarkMode]);
+    return resolveTermixThemeColors(activeTheme, appTheme);
+  }, [terminalConfig.theme, appTheme]);
 
   const [isConnected, setIsConnected] = React.useState(false);
   const [isConnecting, setIsConnecting] = React.useState(false);


### PR DESCRIPTION
# Overview

SFTP file-manager connections could time out when request payloads omitted `jumpHosts`, even though terminal SSH succeeded via configured jump hosts. This change makes SFTP resolve and use jump hosts from server-side host data when client payload data is incomplete.

- [x] Added: server-side fallback resolution for `jumpHosts` in SFTP connect flow
- [x] Updated: jump-host connection path/logging to use resolved fallback hosts
- [ ] Removed: ...
- [x] Fixed: SFTP direct-connect timeout path when jump host is configured but not sent by frontend

# Changes Made

_Detailed explanation of changes (if needed)_

- **Resolution fallback**
  - Introduced `resolvedJumpHosts` in `src/backend/ssh/file-manager.ts`.
  - Uses request `jumpHosts` when present; otherwise loads `resolvedHost.jumpHosts` from `resolveHostById(...)`.

- **Connection routing**
  - `hasJumpHosts` now evaluates fallback-aware `resolvedJumpHosts`.
  - `createJumpHostChain(...)` now receives resolved jump hosts, ensuring SFTP follows configured bastion chain.

- **Connection observability**
  - Adds an explicit SFTP connection log when jump hosts are loaded from server-side host data.

```ts
let resolvedJumpHosts = jumpHosts;
if ((!resolvedJumpHosts || resolvedJumpHosts.length === 0) && resolvedHost.jumpHosts?.length) {
  resolvedJumpHosts = resolvedHost.jumpHosts;
}
```

# Related Issues

_Link any issues this PR addresses_

# Screenshots / Demos

_(Optional: add before/after screenshots, GIFs, or console output)_

# Checklist

- [x] Code follows project style guidelines
- [x] Supports mobile and desktop UI/app (if applicable)
- [x] I have read [Contributing.md](https://github.com/Termix-SSH/Termix/blob/main/CONTRIBUTING.md)
- [x] This is not a translation request. See [docs](https://docs.termix.site/translations)