### PR TITLE
fix: file upload fails with 400 and missing schema migrations on v2.4.1 upgrade

### DIFF
--- a/src/backend/database/db/index.ts
+++ b/src/backend/database/db/index.ts
@@ -695,6 +695,18 @@ const migrateSchema = () => {
   addColumnIfNotExists("user_preferences", "confirm_tab_close", "INTEGER");
   addColumnIfNotExists("user_preferences", "hidden_rail_tabs", "TEXT");
   addColumnIfNotExists("user_preferences", "compact_host_view", "INTEGER");
+  addColumnIfNotExists("user_preferences", "status_color_scheme", "TEXT");
+
+  sqlite.exec(`
+    CREATE TABLE IF NOT EXISTS dashboard_service_links (
+      id INTEGER PRIMARY KEY AUTOINCREMENT,
+      user_id TEXT NOT NULL REFERENCES users(id) ON DELETE CASCADE,
+      label TEXT NOT NULL,
+      url TEXT NOT NULL,
+      "order" INTEGER NOT NULL DEFAULT 0,
+      created_at TEXT NOT NULL DEFAULT CURRENT_TIMESTAMP
+    )
+  `);
 
   addColumnIfNotExists("users", "is_admin", "INTEGER NOT NULL DEFAULT 0");
 

--- a/src/ui/api/ssh-file-operations-api.ts
+++ b/src/ui/api/ssh-file-operations-api.ts
@@ -357,7 +357,7 @@ export async function uploadSSHFile(
     if (userId !== undefined) form.append("userId", userId);
     form.append("file", file, fileName);
 
-    const response = await fileManagerApi.post("/ssh/uploadFileStream", form, {
+    const response = await fileManagerApi.postForm("/ssh/uploadFileStream", form, {
       timeout: 0,
     });
     return response.data;


### PR DESCRIPTION
## Summary

Fixes two bugs introduced in v2.4.1 (closes #928).

### Bug 1 — File upload returns 400 `Expected multipart/form-data request`

**Root cause:** `uploadSSHFileStream` in `ssh-file-operations-api.ts` was refactored in v2.4.1 from a JSON-based upload to a `FormData` streaming upload (to support the new 100MB limit). However, all axios instances in Termix are created with `Content-Type: application/json` as the default header. When axios sees `FormData` + `Content-Type: application/json`, its `transformRequest` JSON-serializes the FormData instead of sending it as multipart — the `File` object becomes `{}` in the body and the binary is lost.

**Fix:** Change `fileManagerApi.post()` to `fileManagerApi.postForm()`. The `postForm` method sets `Content-Type: multipart/form-data` so `transformRequest` returns the `FormData` as-is, and the browser XHR automatically assigns the correct `multipart/form-data; boundary=...` header.

```diff
- const response = await fileManagerApi.post("/ssh/uploadFileStream", form, {
+ const response = await fileManagerApi.postForm("/ssh/uploadFileStream", form, {
    timeout: 0,
  });
```

Note: other functions in the same file that use `FormData` (e.g. SSH key upload) correctly pass explicit `Content-Type: multipart/form-data` — this one was missed during the v2.4.1 refactor.

### Bug 2 — 500 errors on `/service-links` and `/user-preferences` after upgrade

**Root cause:** Two new schema items were added to `schema.ts` in v2.4.1 but not to the `migrateSchema()` function in `db/index.ts`. Existing installations upgrading from v2.4.0 hit:
- `SqliteError: no such table: dashboard_service_links`
- `SqliteError: no such column: "status_color_scheme"`

**Fix:** Add the missing entries to `migrateSchema()`:

```diff
  addColumnIfNotExists("user_preferences", "compact_host_view", "INTEGER");
+ addColumnIfNotExists("user_preferences", "status_color_scheme", "TEXT");
+
+ sqlite.exec(`
+   CREATE TABLE IF NOT EXISTS dashboard_service_links (
+     id INTEGER PRIMARY KEY AUTOINCREMENT,
+     user_id TEXT NOT NULL REFERENCES users(id) ON DELETE CASCADE,
+     label TEXT NOT NULL,
+     url TEXT NOT NULL,
+     "order" INTEGER NOT NULL DEFAULT 0,
+     created_at TEXT NOT NULL DEFAULT CURRENT_TIMESTAMP
+   )
+ `);
```

## Test plan

- [ ] Upgrade a v2.4.0 install to v2.4.1 — `/service-links` and `/user-preferences` should no longer return 500
- [ ] Upload a file via the file manager — should succeed instead of returning 400
- [ ] Fresh v2.4.1 install — both endpoints and upload work normally