### PR TITLE
fix: support PuTTY PPK ssh keys

### DIFF
--- a/src/backend/database/routes/credential-deploy-routes.ts
+++ b/src/backend/database/routes/credential-deploy-routes.ts
@@ -7,6 +7,7 @@ import { eq } from "drizzle-orm";
 import ssh2Pkg from "ssh2";
 import { db } from "../db/index.js";
 import { hosts, sshCredentials } from "../db/schema.js";
+import { preparePrivateKeyForSSH2 } from "../../utils/ssh-key-utils.js";
 
 const { Client } = ssh2Pkg;
 
@@ -312,19 +313,10 @@ async function deploySSHKeyToHost(
       } else if (hostConfig.authType === "key" && hostConfig.privateKey) {
         try {
           const privateKey = hostConfig.privateKey as string;
-          if (
-            !privateKey.includes("-----BEGIN") ||
-            !privateKey.includes("-----END")
-          ) {
-            throw new Error("Invalid private key format");
-          }
-
-          const cleanKey = privateKey
-            .trim()
-            .replace(/\r\n/g, "\n")
-            .replace(/\r/g, "\n");
-
-          connectionConfig.privateKey = Buffer.from(cleanKey, "utf8");
+          connectionConfig.privateKey = preparePrivateKeyForSSH2(
+            privateKey,
+            hostConfig.keyPassword as string | undefined,
+          );
 
           if (hostConfig.keyPassword) {
             connectionConfig.passphrase = hostConfig.keyPassword;

--- a/src/backend/database/routes/credentials.ts
+++ b/src/backend/database/routes/credentials.ts
@@ -156,7 +156,7 @@ router.post(
           return res.status(400).json({
             error: keyInfo.error
               ? `Invalid SSH key: ${keyInfo.error}`
-              : "Unrecognized SSH key format. Only OpenSSH and PEM formats are supported (not PuTTY .ppk).",
+              : "Unrecognized SSH key format. Use an OpenSSH, PEM, or PuTTY PPK v2 RSA/DSA private key.",
           });
         }
       }
@@ -529,7 +529,7 @@ router.put(
             return res.status(400).json({
               error: keyInfo.error
                 ? `Invalid SSH key: ${keyInfo.error}`
-                : "Unrecognized SSH key format. Only OpenSSH and PEM formats are supported (not PuTTY .ppk).",
+                : "Unrecognized SSH key format. Use an OpenSSH, PEM, or PuTTY PPK v2 RSA/DSA private key.",
             });
           }
           updateFields.privateKey = keyInfo.privateKey;

--- a/src/backend/database/routes/host.ts
+++ b/src/backend/database/routes/host.ts
@@ -341,19 +341,6 @@ router.post(
       sshDataObj.keyType = null;
     } else if (effectiveAuthType === "key") {
       if (key && typeof key === "string") {
-        if (!key.includes("-----BEGIN") || !key.includes("-----END")) {
-          sshLogger.warn("Invalid SSH key format provided", {
-            operation: "host_create",
-            userId,
-            name,
-            ip,
-            port,
-          });
-          return res.status(400).json({
-            error: "Invalid SSH key format. Key must be in PEM format.",
-          });
-        }
-
         const keyValidation = parseSSHKey(
           key,
           typeof keyPassword === "string" ? keyPassword : undefined,
@@ -919,20 +906,6 @@ router.put(
       sshDataObj.keyType = null;
     } else if (effectiveAuthType === "key") {
       if (key && typeof key === "string") {
-        if (!key.includes("-----BEGIN") || !key.includes("-----END")) {
-          sshLogger.warn("Invalid SSH key format provided", {
-            operation: "host_update",
-            hostId: parseInt(hostId),
-            userId,
-            name,
-            ip,
-            port,
-          });
-          return res.status(400).json({
-            error: "Invalid SSH key format. Key must be in PEM format.",
-          });
-        }
-
         const keyValidation = parseSSHKey(
           key,
           typeof keyPassword === "string" ? keyPassword : undefined,

--- a/src/backend/ssh/docker.ts
+++ b/src/backend/ssh/docker.ts
@@ -19,6 +19,7 @@ import type { SSHHost, ProxyNode } from "../../types/index.js";
 import type { LogEntry, ConnectionStage } from "../../types/connection-log.js";
 import { SSHHostKeyVerifier } from "./host-key-verifier.js";
 import { registerDockerContainerRoutes } from "./docker-container-routes.js";
+import { preparePrivateKeyForSSH2 } from "../utils/ssh-key-utils.js";
 
 const sshLogger = logger;
 
@@ -923,37 +924,16 @@ app.post("/docker/ssh/connect", async (req, res) => {
       resolvedCredentials.sshKey
     ) {
       try {
-        if (
-          !resolvedCredentials.sshKey.includes("-----BEGIN") ||
-          !resolvedCredentials.sshKey.includes("-----END")
-        ) {
-          sshLogger.error("Invalid SSH key format", {
-            operation: "docker_connect",
-            sessionId,
-            hostId,
-          });
-          connectionLogs.push(
-            createConnectionLog(
-              "error",
-              "docker_auth",
-              "Invalid SSH private key format",
-            ),
-          );
-          return res.status(400).json({
-            error: "Invalid private key format",
-            connectionLogs,
-          });
-        }
-
-        const cleanKey = resolvedCredentials.sshKey
-          .trim()
-          .replace(/\r\n/g, "\n")
-          .replace(/\r/g, "\n");
-        config.privateKey = Buffer.from(cleanKey, "utf8");
+        config.privateKey = preparePrivateKeyForSSH2(
+          resolvedCredentials.sshKey,
+          resolvedCredentials.keyPassword,
+        );
         if (resolvedCredentials.keyPassword) {
           config.passphrase = resolvedCredentials.keyPassword;
         }
       } catch (error) {
+        const message =
+          error instanceof Error ? error.message : "Invalid private key format";
         sshLogger.error("SSH key processing error", error, {
           operation: "docker_connect",
           sessionId,
@@ -963,11 +943,11 @@ app.post("/docker/ssh/connect", async (req, res) => {
           createConnectionLog(
             "error",
             "docker_auth",
-            "SSH key processing error",
+            `SSH key processing error: ${message}`,
           ),
         );
         return res.status(400).json({
-          error: "SSH key format error: Invalid private key format",
+          error: `SSH key format error: ${message}`,
           connectionLogs,
         });
       }

--- a/src/backend/ssh/file-manager.ts
+++ b/src/backend/ssh/file-manager.ts
@@ -33,6 +33,7 @@ import {
 import { registerFileContentRoutes } from "./file-manager-content-routes.js";
 import { createConnectionLog } from "./file-manager-log.js";
 import { createJumpHostChain } from "./jump-host-chain.js";
+import { preparePrivateKeyForSSH2 } from "../utils/ssh-key-utils.js";
 import {
   ChannelOpenSerializer,
   execChannel,
@@ -929,19 +930,10 @@ app.post("/ssh/file_manager/ssh/connect", async (req, res) => {
     resolvedCredentials.sshKey.trim()
   ) {
     try {
-      if (
-        !resolvedCredentials.sshKey.includes("-----BEGIN") ||
-        !resolvedCredentials.sshKey.includes("-----END")
-      ) {
-        throw new Error("Invalid private key format");
-      }
-
-      const cleanKey = resolvedCredentials.sshKey
-        .trim()
-        .replace(/\r\n/g, "\n")
-        .replace(/\r/g, "\n");
-
-      config.privateKey = Buffer.from(cleanKey, "utf8");
+      config.privateKey = preparePrivateKeyForSSH2(
+        resolvedCredentials.sshKey,
+        resolvedCredentials.keyPassword,
+      );
 
       if (resolvedCredentials.keyPassword)
         config.passphrase = resolvedCredentials.keyPassword;

--- a/src/backend/ssh/host-metrics.ts
+++ b/src/backend/ssh/host-metrics.ts
@@ -28,6 +28,7 @@ import {
   createSocks5Connection,
   type SOCKS5Config,
 } from "../utils/socks5-helper.js";
+import { preparePrivateKeyForSSH2 } from "../utils/ssh-key-utils.js";
 import { SSHHostKeyVerifier } from "./host-key-verifier.js";
 import { connectionPool, withConnection } from "./ssh-connection-pool.js";
 import { registerHostMetricsSettingsRoutes } from "./host-metrics-settings-routes.js";
@@ -1017,18 +1018,9 @@ async function buildSshConfig(
     }
 
     try {
-      if (!host.key.includes("-----BEGIN") || !host.key.includes("-----END")) {
-        throw new Error("Invalid private key format");
-      }
-
-      const cleanKey = host.key
-        .trim()
-        .replace(/\r\n/g, "\n")
-        .replace(/\r/g, "\n");
-
-      (base as Record<string, unknown>).privateKey = Buffer.from(
-        cleanKey,
-        "utf8",
+      (base as Record<string, unknown>).privateKey = preparePrivateKeyForSSH2(
+        host.key,
+        host.keyPassword,
       );
 
       if (host.keyPassword) {

--- a/src/backend/ssh/terminal.ts
+++ b/src/backend/ssh/terminal.ts
@@ -31,6 +31,7 @@ import {
 } from "./tmux-helper.js";
 import { MemoryAgent, performPortKnocking } from "./terminal-auth-helpers.js";
 import { isWindowsSftpPath, sftpPathToLocalPath } from "./transfer-paths.js";
+import { preparePrivateKeyForSSH2 } from "../utils/ssh-key-utils.js";
 
 interface ConnectToHostData {
   cols: number;
@@ -2285,19 +2286,10 @@ wss.on("connection", async (ws: WebSocket, req) => {
     ) {
       sendLog("auth", "info", "Using SSH key authentication");
       try {
-        if (
-          !resolvedCredentials.key.includes("-----BEGIN") ||
-          !resolvedCredentials.key.includes("-----END")
-        ) {
-          throw new Error("Invalid private key format");
-        }
-
-        const cleanKey = resolvedCredentials.key
-          .trim()
-          .replace(/\r\n/g, "\n")
-          .replace(/\r/g, "\n");
-
-        connectConfig.privateKey = Buffer.from(cleanKey, "utf8");
+        connectConfig.privateKey = preparePrivateKeyForSSH2(
+          resolvedCredentials.key,
+          resolvedCredentials.keyPassword,
+        );
 
         if (resolvedCredentials.keyPassword) {
           connectConfig.passphrase = resolvedCredentials.keyPassword;
@@ -2346,11 +2338,15 @@ wss.on("connection", async (ws: WebSocket, req) => {
           }
         }
       } catch (keyError) {
-        sshLogger.error("SSH key format error: " + keyError.message);
+        const message =
+          keyError instanceof Error
+            ? keyError.message
+            : "Invalid private key format";
+        sshLogger.error("SSH key format error: " + message);
         ws.send(
           JSON.stringify({
             type: "error",
-            message: "SSH key format error: Invalid private key format",
+            message: `SSH key format error: ${message}`,
           }),
         );
         return;

--- a/src/backend/ssh/tmux-monitor.ts
+++ b/src/backend/ssh/tmux-monitor.ts
@@ -10,6 +10,7 @@ import { tmuxSessionTags, users } from "../database/db/schema.js";
 import { logAudit, getRequestMeta } from "../utils/audit-logger.js";
 import { sshLogger } from "../utils/logger.js";
 import { SSH_ALGORITHMS } from "../utils/ssh-algorithms.js";
+import { preparePrivateKeyForSSH2 } from "../utils/ssh-key-utils.js";
 import { SSHHostKeyVerifier } from "./host-key-verifier.js";
 import { resolveHostById, checkHostAccess } from "./host-resolver.js";
 import { createJumpHostChain } from "./jump-host-chain.js";
@@ -81,16 +82,12 @@ async function buildSshConfig(host: SSHHost): Promise<ConnectConfig> {
     }
     base.password = host.password;
   } else if (host.authType === "key") {
-    if (!host.key || !host.key.includes("-----BEGIN")) {
+    if (!host.key) {
       throw new Error(`No valid SSH key available for host ${host.ip}`);
     }
-    const cleanKey = host.key
-      .trim()
-      .replace(/\r\n/g, "\n")
-      .replace(/\r/g, "\n");
-    (base as Record<string, unknown>).privateKey = Buffer.from(
-      cleanKey,
-      "utf8",
+    (base as Record<string, unknown>).privateKey = preparePrivateKeyForSSH2(
+      host.key,
+      host.keyPassword,
     );
     if (host.keyPassword) {
       (base as Record<string, unknown>).passphrase = host.keyPassword;

--- a/src/backend/ssh/tunnel.ts
+++ b/src/backend/ssh/tunnel.ts
@@ -32,6 +32,7 @@ import { createSocks5Connection } from "../utils/socks5-helper.js";
 import { AuthManager } from "../utils/auth-manager.js";
 import { PermissionManager } from "../utils/permission-manager.js";
 import { withConnection } from "./ssh-connection-pool.js";
+import { preparePrivateKeyForSSH2 } from "../utils/ssh-key-utils.js";
 import {
   applyAuthOptions,
   bindForwardIn,
@@ -1300,37 +1301,33 @@ async function connectSSHTunnel(
     resolvedSourceCredentials.authMethod === "key" &&
     resolvedSourceCredentials.sshKey
   ) {
-    if (
-      !resolvedSourceCredentials.sshKey.includes("-----BEGIN") ||
-      !resolvedSourceCredentials.sshKey.includes("-----END")
-    ) {
+    try {
+      connOptions.privateKey = preparePrivateKeyForSSH2(
+        resolvedSourceCredentials.sshKey,
+        resolvedSourceCredentials.keyPassword,
+      );
+    } catch (error) {
+      const message =
+        error instanceof Error ? error.message : "Invalid SSH key format";
       tunnelLogger.error(
-        `Invalid SSH key format for tunnel '${tunnelName}'. Key should contain both BEGIN and END markers`,
+        `Invalid SSH key format for tunnel '${tunnelName}': ${message}`,
         undefined,
         {
           operation: "tunnel_invalid_ssh_key_format",
           tunnelName,
           sourceHost: `${tunnelConfig.sourceUsername}@${tunnelConfig.sourceIP}:${tunnelConfig.sourceSSHPort}`,
           keyType: resolvedSourceCredentials.keyType,
-          hasBeginMarker:
-            resolvedSourceCredentials.sshKey.includes("-----BEGIN"),
-          hasEndMarker: resolvedSourceCredentials.sshKey.includes("-----END"),
         },
       );
       broadcastTunnelStatus(tunnelName, {
         connected: false,
         status: CONNECTION_STATES.FAILED,
-        reason: "Invalid SSH key format",
+        reason: message,
       });
       tunnelConnecting.delete(tunnelName);
       return;
     }
 
-    const cleanKey = resolvedSourceCredentials.sshKey
-      .trim()
-      .replace(/\r\n/g, "\n")
-      .replace(/\r/g, "\n");
-    connOptions.privateKey = Buffer.from(cleanKey, "utf8");
     if (resolvedSourceCredentials.keyPassword) {
       connOptions.passphrase = resolvedSourceCredentials.keyPassword;
     }
@@ -1482,11 +1479,15 @@ async function killRemoteTunnelByMarker(
     resolvedSourceCredentials.authMethod === "key" &&
     resolvedSourceCredentials.sshKey
   ) {
-    if (
-      !resolvedSourceCredentials.sshKey.includes("-----BEGIN") ||
-      !resolvedSourceCredentials.sshKey.includes("-----END")
-    ) {
-      callback(new Error("Invalid SSH key format"));
+    try {
+      preparePrivateKeyForSSH2(
+        resolvedSourceCredentials.sshKey,
+        resolvedSourceCredentials.keyPassword,
+      );
+    } catch (error) {
+      callback(
+        error instanceof Error ? error : new Error("Invalid SSH key format"),
+      );
       return;
     }
   }
@@ -1542,11 +1543,10 @@ async function killRemoteTunnelByMarker(
       resolvedSourceCredentials.authMethod === "key" &&
       resolvedSourceCredentials.sshKey
     ) {
-      const cleanKey = resolvedSourceCredentials.sshKey
-        .trim()
-        .replace(/\r\n/g, "\n")
-        .replace(/\r/g, "\n");
-      connOptions.privateKey = Buffer.from(cleanKey, "utf8");
+      connOptions.privateKey = preparePrivateKeyForSSH2(
+        resolvedSourceCredentials.sshKey,
+        resolvedSourceCredentials.keyPassword,
+      );
       if (resolvedSourceCredentials.keyPassword) {
         connOptions.passphrase = resolvedSourceCredentials.keyPassword;
       }

--- a/src/backend/utils/ssh-key-utils.test.ts
+++ b/src/backend/utils/ssh-key-utils.test.ts
@@ -1,7 +1,9 @@
 import { describe, it, expect } from "vitest";
+import { readFileSync } from "node:fs";
 import {
   parseSSHKey,
   parsePublicKey,
+  preparePrivateKeyForSSH2,
   getFriendlyKeyTypeName,
   validateKeyPair,
 } from "./ssh-key-utils.js";
@@ -19,6 +21,11 @@ AAAEDLo85Twyg0v6V1zsJaeRaxq9KPQXkqGY0HiJtVMzCXEFH+Ektft4yKdLjAkx8baBZK
 
 const ED25519_PUBLIC =
   "ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAIFH+Ektft4yKdLjAkx8baBZK21SK5Iu+oPBVhPnfHSp7 test@termix.test";
+
+const PPK_RSA_PRIVATE = readFileSync(
+  "node_modules/ssh2/test/fixtures/keyParser/ppk_rsa",
+  "utf8",
+);
 
 describe("parsePublicKey", () => {
   it("detects ssh-ed25519 public keys", () => {
@@ -67,6 +74,26 @@ describe("parseSSHKey", () => {
     const info = parseSSHKey("definitely not a key");
     expect(info.success).toBe(false);
     expect(info.keyType).toBe("unknown");
+  });
+
+  it("accepts PuTTY PPK v2 private keys supported by ssh2", () => {
+    const info = parseSSHKey(PPK_RSA_PRIVATE);
+    expect(info.success).toBe(true);
+    expect(info.keyType).toBe("ssh-rsa");
+    expect(info.publicKey).toContain("ssh-rsa");
+  });
+
+  it("prepares PuTTY PPK v2 private keys for ssh2 connections", () => {
+    const prepared = preparePrivateKeyForSSH2(PPK_RSA_PRIVATE);
+    expect(prepared.toString("utf8")).toContain("PuTTY-User-Key-File-2");
+  });
+
+  it("reports unsupported PuTTY PPK versions clearly", () => {
+    const info = parseSSHKey(
+      "PuTTY-User-Key-File-3: ssh-ed25519\nEncryption: none\n",
+    );
+    expect(info.success).toBe(false);
+    expect(info.error).toMatch(/Unsupported PuTTY PPK v3/);
   });
 });
 

--- a/src/backend/utils/ssh-key-utils.ts
+++ b/src/backend/utils/ssh-key-utils.ts
@@ -225,20 +225,53 @@ export interface KeyPairValidationResult {
   error?: string;
 }
 
+const PUTTY_PRIVATE_KEY_RE = /^PuTTY-User-Key-File-(\d+):\s*(.+)$/m;
+
+export function normalizePrivateKeyText(privateKeyData: string): string {
+  return privateKeyData.trim().replace(/\r\n/g, "\n").replace(/\r/g, "\n");
+}
+
+function getUnsupportedPrivateKeyError(privateKeyData: string): string {
+  const puttyMatch = PUTTY_PRIVATE_KEY_RE.exec(privateKeyData.trim());
+  if (puttyMatch) {
+    const [, version, type] = puttyMatch;
+    return `Unsupported PuTTY PPK v${version} private key format (${type}). Convert the key to OpenSSH format with PuTTYgen, or use a PuTTY PPK v2 RSA/DSA key.`;
+  }
+
+  return "Unsupported private key format. Use an OpenSSH, PEM, or PuTTY PPK v2 RSA/DSA private key.";
+}
+
+export function preparePrivateKeyForSSH2(
+  privateKeyData: string,
+  passphrase?: string,
+): Buffer {
+  const cleanKey = normalizePrivateKeyText(privateKeyData);
+  const keyInfo = parseSSHKey(cleanKey, passphrase);
+
+  if (!keyInfo.success) {
+    throw new Error(keyInfo.error || getUnsupportedPrivateKeyError(cleanKey));
+  }
+
+  return Buffer.from(cleanKey, "utf8");
+}
+
 export function parseSSHKey(
   privateKeyData: string,
   passphrase?: string,
 ): KeyInfo {
   try {
+    const cleanKey = normalizePrivateKeyText(privateKeyData);
     let keyType = "unknown";
     let publicKey = "";
     let useSSH2 = false;
 
     if (ssh2Utils && typeof ssh2Utils.parseKey === "function") {
       try {
-        const parsedKey = ssh2Utils.parseKey(privateKeyData, passphrase);
+        const parsedKey = ssh2Utils.parseKey(cleanKey, passphrase);
 
-        if (!(parsedKey instanceof Error)) {
+        if (parsedKey instanceof Error) {
+          throw parsedKey;
+        } else {
           if (parsedKey.type) {
             keyType = parsedKey.type;
           }
@@ -273,23 +306,26 @@ export function parseSSHKey(
     }
 
     if (!useSSH2) {
-      keyType = detectKeyTypeFromContent(privateKeyData);
+      keyType = detectKeyTypeFromContent(cleanKey);
 
       publicKey = "";
     }
 
     return {
-      privateKey: privateKeyData,
+      privateKey: cleanKey,
       publicKey,
       keyType,
       success: keyType !== "unknown",
+      error:
+        keyType === "unknown" ? getUnsupportedPrivateKeyError(cleanKey) : undefined,
     };
   } catch (error) {
     try {
-      const fallbackKeyType = detectKeyTypeFromContent(privateKeyData);
+      const cleanKey = normalizePrivateKeyText(privateKeyData);
+      const fallbackKeyType = detectKeyTypeFromContent(cleanKey);
       if (fallbackKeyType !== "unknown") {
         return {
-          privateKey: privateKeyData,
+          privateKey: cleanKey,
           publicKey: "",
           keyType: fallbackKeyType,
           success: true,
@@ -299,13 +335,18 @@ export function parseSSHKey(
       // expected - fallback key type detection may fail
     }
 
+    const parserError = error instanceof Error ? error.message : "";
+    const isPuttyKey = PUTTY_PRIVATE_KEY_RE.test(privateKeyData.trim());
+
     return {
       privateKey: privateKeyData,
       publicKey: "",
       keyType: "unknown",
       success: false,
       error:
-        error instanceof Error ? error.message : "Unknown error parsing key",
+        isPuttyKey && /unsupported|parse|format/i.test(parserError)
+          ? getUnsupportedPrivateKeyError(privateKeyData)
+          : parserError || getUnsupportedPrivateKeyError(privateKeyData),
     };
   }
 }

--- a/src/ui/sidebar/CredentialEditorView.tsx
+++ b/src/ui/sidebar/CredentialEditorView.tsx
@@ -332,7 +332,7 @@ export function CredentialEditorView({
                   <input
                     ref={credFileInputRef}
                     type="file"
-                    accept=".pem,.key,.txt"
+                    accept=".pem,.key,.ppk,.txt"
                     className="hidden"
                     onChange={async (e) => {
                       const file = e.target.files?.[0];

--- a/src/ui/sidebar/HostEditor.tsx
+++ b/src/ui/sidebar/HostEditor.tsx
@@ -375,7 +375,7 @@ export function HostEditor({
                               </span>
                               <input
                                 type="file"
-                                accept=".pem,.key,.txt"
+                                accept=".pem,.key,.ppk,.txt"
                                 className="hidden"
                                 onChange={async (e) => {
                                   const file = e.target.files?.[0];

--- a/src/ui/ssh/dialogs/SSHAuthDialog.tsx
+++ b/src/ui/ssh/dialogs/SSHAuthDialog.tsx
@@ -210,7 +210,7 @@ export function SSHAuthDialog({
                     <input
                       id="key-upload"
                       type="file"
-                      accept="*,.pem,.key,.txt"
+                      accept="*,.pem,.key,.ppk,.txt"
                       onChange={handleKeyFileUpload}
                       className="absolute inset-0 w-full h-full opacity-0 cursor-pointer"
                     />


### PR DESCRIPTION
## Summary
- allow uploaded PuTTY `.ppk` private keys through host and credential editors
- replace PEM-marker checks with shared SSH key parsing before terminal, SFTP, Docker, tunnel, tmux, and host metrics connections
- add coverage for ssh2-supported PuTTY PPK v2 keys and clearer errors for unsupported PPK formats

Refs https://github.com/Termix-SSH/Support/issues/172

## Validation
- npm run type-check
- npx eslint src/backend/utils/ssh-key-utils.ts src/backend/utils/ssh-key-utils.test.ts src/backend/database/routes/host.ts src/backend/database/routes/credentials.ts src/backend/database/routes/credential-deploy-routes.ts src/backend/ssh/terminal.ts src/backend/ssh/file-manager.ts src/backend/ssh/docker.ts src/backend/ssh/tunnel.ts src/backend/ssh/tmux-monitor.ts src/backend/ssh/host-metrics.ts src/ui/sidebar/HostEditor.tsx src/ui/sidebar/CredentialEditorView.tsx src/ui/ssh/dialogs/SSHAuthDialog.tsx
- git diff --check

Note: `npm test -- src/backend/utils/ssh-key-utils.test.ts` could not run in this checkout because the local install does not include the `vitest` binary.
