### PR TITLE
fix: chunk large file manager uploads

### DIFF
--- a/src/backend/ssh/file-manager-content-routes.ts
+++ b/src/backend/ssh/file-manager-content-routes.ts
@@ -16,6 +16,20 @@ type FileContentRoutesDeps = {
   verifySessionOwnership: (session: SSHSession, userId: string) => boolean;
 };
 
+const getRequiredQueryParam = (
+  value: string | string[] | undefined,
+): string | undefined => {
+  if (Array.isArray(value)) return value[0];
+  return value;
+};
+
+const parseByteOffset = (value: string | undefined): number | null => {
+  if (!value) return null;
+  const parsed = Number(value);
+  if (!Number.isSafeInteger(parsed) || parsed < 0) return null;
+  return parsed;
+};
+
 export function registerFileContentRoutes(
   app: Express,
   { sshSessions, verifySessionOwnership }: FileContentRoutesDeps,
@@ -1505,6 +1519,127 @@ export function registerFileContentRoutes(
       });
 
       req.pipe(bb);
+    },
+  );
+
+  /**
+   * @openapi
+   * /ssh/file_manager/ssh/uploadFileChunk:
+   *   post:
+   *     summary: Upload one raw file chunk
+   *     description: Writes a raw request body to the remote file at the supplied byte offset, allowing browser clients to avoid multipart/FormData 2GB limits.
+   *     tags:
+   *       - File Manager
+   */
+  app.post(
+    "/ssh/file_manager/ssh/uploadFileChunk",
+    (req: Request, res: Response) => {
+      const userId = (req as AuthenticatedRequest).userId;
+      const sessionId = getRequiredQueryParam(req.query.sessionId as string);
+      const remotePath = getRequiredQueryParam(req.query.path as string);
+      const fileName = getRequiredQueryParam(req.query.fileName as string);
+      const offset = parseByteOffset(
+        getRequiredQueryParam(req.query.offset as string),
+      );
+      const totalSize = parseByteOffset(
+        getRequiredQueryParam(req.query.totalSize as string),
+      );
+
+      if (!sessionId || !remotePath || !fileName) {
+        req.resume();
+        return res
+          .status(400)
+          .json({ error: "Missing sessionId, path, or fileName" });
+      }
+
+      if (offset === null || totalSize === null || offset > totalSize) {
+        req.resume();
+        return res.status(400).json({ error: "Invalid upload offset" });
+      }
+
+      const sshConn = sshSessions[sessionId];
+      if (!sshConn?.isConnected) {
+        req.resume();
+        return res.status(400).json({ error: "SSH connection not established" });
+      }
+
+      if (!verifySessionOwnership(sshConn, userId)) {
+        req.resume();
+        return res.status(403).json({ error: "Session access denied" });
+      }
+
+      sshConn.lastActive = Date.now();
+      const fullPath = remotePath.endsWith("/")
+        ? remotePath + fileName
+        : remotePath + "/" + fileName;
+      let resolved = false;
+      let bytesWritten = 0;
+      const uploadStartTime = Date.now();
+
+      getSessionSftp(sshConn)
+        .then((sftp) => {
+          const writeStream = sftp.createWriteStream(fullPath, {
+            flags: offset === 0 ? "w" : "r+",
+            start: offset,
+          });
+
+          const fail = (status: number, error: string) => {
+            if (resolved) return;
+            resolved = true;
+            req.unpipe(writeStream as unknown as NodeJS.WritableStream);
+            writeStream.destroy();
+            res.status(status).json({ error });
+          };
+
+          writeStream.on("error", (err) => {
+            fileLogger.error("SFTP write stream error during chunk upload:", err);
+            fail(500, `Upload failed: ${err.message}`);
+          });
+
+          writeStream.on("finish", () => {
+            if (resolved) return;
+            resolved = true;
+            const nextOffset = offset + bytesWritten;
+            fileLogger.info("File chunk upload completed", {
+              operation: "file_upload_chunk_complete",
+              sessionId,
+              userId,
+              path: fullPath,
+              offset,
+              bytesWritten,
+              nextOffset,
+              totalSize,
+              duration: Date.now() - uploadStartTime,
+            });
+            res.json({
+              message: "File chunk uploaded successfully",
+              path: fullPath,
+              offset,
+              bytesWritten,
+              nextOffset,
+              complete: nextOffset >= totalSize,
+            });
+          });
+
+          req.on("error", (err) => {
+            fileLogger.error("Request stream error during chunk upload:", err);
+            fail(500, `Upload stream error: ${err.message}`);
+          });
+
+          req.on("data", (chunk: Buffer) => {
+            bytesWritten += chunk.length;
+          });
+
+          req.pipe(writeStream as unknown as NodeJS.WritableStream);
+        })
+        .catch((err: Error) => {
+          req.resume();
+          fileLogger.error("SFTP session error during chunk upload:", err);
+          if (!resolved) {
+            resolved = true;
+            res.status(500).json({ error: `SFTP error: ${err.message}` });
+          }
+        });
     },
   );
 }

--- a/src/ui/api/ssh-file-operations-api.ts
+++ b/src/ui/api/ssh-file-operations-api.ts
@@ -1,6 +1,7 @@
 import axios from "axios";
 import { authApi, fileManagerApi, handleApiError } from "@/main-axios";
 import { fileLogger } from "@/lib/frontend-logger";
+import { isElectron } from "@/lib/electron";
 import type { SSHHost } from "@/types/index";
 
 type ApiConnectionLog = {
@@ -23,6 +24,89 @@ type ConnectErrorResponse = {
   status?: string;
   reason?: string;
 };
+
+const LARGE_UPLOAD_THRESHOLD = 512 * 1024 * 1024;
+const UPLOAD_CHUNK_SIZE = 16 * 1024 * 1024;
+
+type ChunkUploadResponse = {
+  message: string;
+  path: string;
+  offset: number;
+  bytesWritten: number;
+  nextOffset: number;
+  complete: boolean;
+};
+
+function buildFileManagerUrl(path: string): string {
+  const baseURL = String(fileManagerApi.defaults.baseURL || "");
+  return `${baseURL.replace(/\/$/, "")}${path}`;
+}
+
+async function uploadSSHFileInChunks(
+  sessionId: string,
+  path: string,
+  fileName: string,
+  file: File,
+): Promise<ChunkUploadResponse> {
+  let offset = 0;
+  let lastResponse: ChunkUploadResponse | null = null;
+
+  while (offset < file.size || (file.size === 0 && offset === 0)) {
+    const end = Math.min(offset + UPLOAD_CHUNK_SIZE, file.size);
+    const chunk = file.slice(offset, end);
+    const params = new URLSearchParams({
+      sessionId,
+      path,
+      fileName,
+      offset: String(offset),
+      totalSize: String(file.size),
+    });
+    const headers: HeadersInit = {
+      "Content-Type": "application/octet-stream",
+    };
+
+    if (isElectron()) {
+      const jwt = localStorage.getItem("jwt");
+      if (jwt) headers.Authorization = `Bearer ${jwt}`;
+    }
+
+    const response = await fetch(
+      buildFileManagerUrl(`/ssh/uploadFileChunk?${params.toString()}`),
+      {
+        method: "POST",
+        body: chunk,
+        headers,
+        credentials: "include",
+      },
+    );
+    const data = (await response.json().catch(() => ({}))) as Partial<
+      ChunkUploadResponse & { error: string }
+    >;
+
+    if (!response.ok) {
+      throw new Error(data.error || `Chunk upload failed (${response.status})`);
+    }
+
+    if (
+      typeof data.nextOffset !== "number" ||
+      data.nextOffset <= offset ||
+      data.nextOffset > file.size
+    ) {
+      throw new Error("Chunk upload returned an invalid offset");
+    }
+
+    lastResponse = data as ChunkUploadResponse;
+    offset = data.nextOffset;
+
+    if (file.size === 0) break;
+  }
+
+  if (!lastResponse) {
+    throw new Error("Chunk upload did not complete");
+  }
+
+  return lastResponse;
+}
 
 // SSH FILE OPERATIONS
 // ============================================================================
@@ -350,6 +434,10 @@ export async function uploadSSHFile(
   userId?: string,
 ): Promise<Record<string, unknown>> {
   try {
+    if (file.size >= LARGE_UPLOAD_THRESHOLD) {
+      return await uploadSSHFileInChunks(sessionId, path, fileName, file);
+    }
+
     const form = new FormData();
     form.append("sessionId", sessionId);
     form.append("path", path);


### PR DESCRIPTION
## Summary
- upload files at or above 512MiB through raw 16MiB chunks instead of one multipart/FormData request
- add a file-manager chunk upload endpoint that writes each chunk to the remote SFTP file at the supplied byte offset
- keep the existing multipart streaming path for smaller uploads

Refs https://github.com/Termix-SSH/Support/issues/870

## Validation
- npm run type-check
- npx eslint src/backend/ssh/file-manager-content-routes.ts src/ui/api/ssh-file-operations-api.ts
- git diff --check

Note: `npm run build` still fails in this checkout because `@fontsource/jetbrains-mono/400-italic.css` is missing from the local install; the failure occurs before this change's backend build step.
