### PR TITLE
fix: route dashboard hosts by enabled protocol

### DIFF
--- a/src/ui/AppShell.tsx
+++ b/src/ui/AppShell.tsx
@@ -56,65 +56,8 @@ import { dbHealthMonitor } from "@/lib/db-health-monitor";
 import type { SSHHostWithStatus } from "@/main-axios";
 import { ConnectionsPanel } from "@/sidebar/ConnectionsPanel";
 import { TransferMonitor } from "@/features/file-manager/TransferMonitor.tsx";
-
-function sshHostToHost(h: SSHHostWithStatus): Host {
-  return {
-    id: String(h.id),
-    name: h.name,
-    username: h.username,
-    ip: h.ip,
-    port: h.port,
-    folder: h.folder ?? "",
-    online: h.status === "online",
-    cpu: 0,
-    ram: 0,
-    lastAccess: "",
-    tags: h.tags ?? [],
-    authType: h.authType,
-    password: h.password,
-    key: typeof h.key === "string" ? h.key : undefined,
-    keyPassword: h.keyPassword,
-    keyType: h.keyType,
-    credentialId: h.credentialId != null ? String(h.credentialId) : undefined,
-    notes: h.notes,
-    pin: h.pin ?? false,
-    macAddress: h.macAddress,
-    enableSsh: h.enableSsh ?? (h.connectionType === "ssh" || !h.connectionType),
-    enableTerminal: h.enableTerminal ?? true,
-    enableTunnel: h.enableTunnel ?? false,
-    enableFileManager: h.enableFileManager ?? true,
-    enableDocker: h.enableDocker ?? false,
-    enableProxmox: h.enableProxmox ?? false,
-    enableTmuxMonitor: h.enableTmuxMonitor ?? false, // --- tmux-monitor ---
-    proxmoxConfig: (h.proxmoxConfig as Host["proxmoxConfig"]) ?? null,
-    enableRdp: h.enableRdp ?? h.connectionType === "rdp",
-    enableVnc: h.enableVnc ?? h.connectionType === "vnc",
-    enableTelnet: h.enableTelnet ?? h.connectionType === "telnet",
-    sshPort: h.port,
-    rdpPort: 3389,
-    vncPort: 5900,
-    telnetPort: 23,
-    quickActions: (h.quickActions ?? []).map((a) => ({
-      name: a.name,
-      snippetId: String(a.snippetId),
-    })),
-    jumpHosts: (h.jumpHosts ?? []).map((j) => ({
-      hostId: String(j.hostId),
-    })),
-    serverTunnels: [],
-    defaultPath: h.defaultPath,
-    terminalConfig: h.terminalConfig as Host["terminalConfig"],
-    useSocks5: h.useSocks5,
-    socks5Host: h.socks5Host,
-    socks5Port: h.socks5Port,
-    socks5Username: h.socks5Username,
-    socks5Password: h.socks5Password,
-    socks5ProxyChain: h.socks5ProxyChain ?? [],
-    statsConfig: (typeof h.statsConfig === "string"
-      ? JSON.parse(h.statsConfig)
-      : h.statsConfig) as Host["statsConfig"],
-  };
-}
+import { sshHostToHost } from "@/sidebar/HostManagerData";
+import { resolveHostTabType } from "@/lib/host-connection-tabs";
 
 function buildHostTree(
   hosts: SSHHostWithStatus[],
@@ -991,17 +934,7 @@ export function AppShell({
   }, []);
 
   function connectHost(host: Host, preferredType?: TabType) {
-    const type: TabType =
-      preferredType ??
-      (host.enableSsh
-        ? "terminal"
-        : host.enableRdp
-          ? "rdp"
-          : host.enableVnc
-            ? "vnc"
-            : host.enableTelnet
-              ? "telnet"
-              : "terminal");
+    const type = resolveHostTabType(host, preferredType);
     // --- tmux-monitor --- singleton tab, not a per-host tab
     if (type === "tmux_monitor") {
       openSingletonTab(type, undefined, host);
@@ -1661,7 +1594,7 @@ export function AppShell({
                           restoredSessionId: null,
                           initialFilePath: filePath,
                         }),
-                      (host, path) => openTab(host, "files"),
+                      (host, _path) => openTab(host, "files"),
                       renameTab,
                     ),
                     tabNode,

--- a/src/ui/dashboard/DashboardTab.tsx
+++ b/src/ui/dashboard/DashboardTab.tsx
@@ -45,7 +45,6 @@ import {
 } from "@/main-axios";
 import type {
   RecentActivityItem,
-  SSHHostWithStatus,
   ServiceLink,
 } from "@/main-axios";
 import { useTranslation } from "react-i18next";
@@ -54,59 +53,8 @@ import {
   useStatusColorScheme,
   getStatusClasses,
 } from "@/hooks/use-status-color-scheme";
-
-function sshHostToHost(h: SSHHostWithStatus): Host {
-  return {
-    id: String(h.id),
-    name: h.name,
-    username: h.username,
-    ip: h.ip,
-    port: h.port,
-    folder: h.folder ?? "",
-    online: h.status === "online",
-    cpu: 0,
-    ram: 0,
-    lastAccess: "",
-    tags: h.tags ?? [],
-    authType: h.authType,
-    password: h.password,
-    key: typeof h.key === "string" ? h.key : undefined,
-    keyPassword: h.keyPassword,
-    keyType: h.keyType,
-    credentialId: h.credentialId != null ? String(h.credentialId) : undefined,
-    notes: h.notes,
-    pin: h.pin ?? false,
-    macAddress: h.macAddress,
-    enableTerminal: h.enableTerminal ?? true,
-    enableTunnel: h.enableTunnel ?? false,
-    enableFileManager: h.enableFileManager ?? true,
-    enableDocker: h.enableDocker ?? false,
-    enableSsh: h.connectionType === "ssh" || !h.connectionType,
-    enableRdp: h.connectionType === "rdp",
-    enableVnc: h.connectionType === "vnc",
-    enableTelnet: h.connectionType === "telnet",
-    sshPort: h.port,
-    rdpPort: 3389,
-    vncPort: 5900,
-    telnetPort: 23,
-    quickActions: (h.quickActions ?? []).map((a) => ({
-      name: a.name,
-      snippetId: String(a.snippetId),
-    })),
-    jumpHosts: (h.jumpHosts ?? []).map((j) => ({
-      hostId: String(j.hostId),
-    })),
-    serverTunnels: [],
-    defaultPath: h.defaultPath,
-    terminalConfig: h.terminalConfig as Host["terminalConfig"],
-    useSocks5: h.useSocks5,
-    socks5Host: h.socks5Host,
-    socks5Port: h.socks5Port,
-    socks5Username: h.socks5Username,
-    socks5Password: h.socks5Password,
-    socks5ProxyChain: h.socks5ProxyChain ?? [],
-  };
-}
+import { sshHostToHost } from "@/sidebar/HostManagerData";
+import { getDefaultConnectionTab } from "@/lib/host-connection-tabs";
 
 // ─── Types ────────────────────────────────────────────────────────────────────
 
@@ -277,6 +225,25 @@ function QuickActionsCard({
 }) {
   const { t } = useTranslation();
   const pinnedHosts = hosts.filter((h) => h.pin);
+  const getConnectionEndpoint = (host: Host) => {
+    const type = getDefaultConnectionTab(host);
+    const port =
+      type === "rdp"
+        ? host.rdpPort
+        : type === "vnc"
+          ? host.vncPort
+          : type === "telnet"
+            ? host.telnetPort
+            : host.sshPort;
+    return `${host.ip}:${port}`;
+  };
+  const renderConnectionIcon = (host: Host) => {
+    const type = getDefaultConnectionTab(host);
+    if (type === "terminal" || type === "telnet") {
+      return <Terminal className="size-3 text-accent-brand" />;
+    }
+    return <Server className="size-3 text-accent-brand" />;
+  };
   return (
     <Card className="flex flex-col overflow-hidden w-full h-full py-0 gap-0">
       <div className="flex items-center gap-2 px-4 py-2.5 border-b border-border shrink-0">
@@ -330,18 +297,18 @@ function QuickActionsCard({
               {pinnedHosts.slice(0, 4).map((host) => (
                 <button
                   key={host.id}
-                  onClick={() => onOpenTab(host, "terminal")}
+                  onClick={() => onOpenTab(host, getDefaultConnectionTab(host))}
                   className="group/btn flex items-center gap-2.5 px-4 py-2 hover:bg-muted transition-colors cursor-pointer border-b border-border last:border-b-0"
                 >
                   <div className="size-7 border border-border bg-muted flex items-center justify-center shrink-0 group-hover/btn:bg-accent-brand/20 group-hover/btn:border-accent-brand/40 transition-colors">
-                    <Terminal className="size-3 text-accent-brand" />
+                    {renderConnectionIcon(host)}
                   </div>
                   <div className="flex flex-col items-start text-left min-w-0">
                     <span className="text-xs font-semibold truncate w-full">
                       {host.name || host.ip}
                     </span>
                     <span className="text-[10px] text-muted-foreground truncate w-full">
-                      {host.ip}:{host.sshPort}
+                      {getConnectionEndpoint(host)}
                     </span>
                   </div>
                 </button>

--- a/src/ui/dashboard/cards/NetworkGraphCard.tsx
+++ b/src/ui/dashboard/cards/NetworkGraphCard.tsx
@@ -554,7 +554,7 @@ export function NetworkGraphCard({
 
   const hideMenu = () => setContextMenu((p) => ({ ...p, visible: false }));
 
-  const fireOpen = (hostId: string, type: string) => {
+  const fireOpen = (hostId: string, type?: string) => {
     window.dispatchEvent(
       new CustomEvent("termix:open-tab", { detail: { hostId, type } }),
     );
@@ -571,7 +571,7 @@ export function NetworkGraphCard({
         setShowNodeDetail(true);
       }
     } else if (action === "connect") {
-      fireOpen(targetId, "terminal");
+      fireOpen(targetId);
     } else if (action === "move") {
       setSelectedNodeId(targetId);
       const node = cyRef.current.$id(targetId);

--- a/src/ui/lib/host-connection-tabs.ts
+++ b/src/ui/lib/host-connection-tabs.ts
@@ -1,0 +1,37 @@
+import type { Host, TabType } from "@/types/ui-types";
+
+type ConnectionTabType = "terminal" | "rdp" | "vnc" | "telnet";
+
+function isConnectionTabType(type: TabType): type is ConnectionTabType {
+  return (
+    type === "terminal" || type === "rdp" || type === "vnc" || type === "telnet"
+  );
+}
+
+function isConnectionEnabled(host: Host, type: ConnectionTabType): boolean {
+  switch (type) {
+    case "terminal":
+      return host.enableSsh;
+    case "rdp":
+      return host.enableRdp;
+    case "vnc":
+      return host.enableVnc;
+    case "telnet":
+      return host.enableTelnet;
+  }
+}
+
+export function getDefaultConnectionTab(host: Host): ConnectionTabType {
+  if (host.enableSsh) return "terminal";
+  if (host.enableRdp) return "rdp";
+  if (host.enableVnc) return "vnc";
+  if (host.enableTelnet) return "telnet";
+  return "terminal";
+}
+
+export function resolveHostTabType(host: Host, preferredType?: TabType): TabType {
+  if (!preferredType) return getDefaultConnectionTab(host);
+  if (!isConnectionTabType(preferredType)) return preferredType;
+  if (isConnectionEnabled(host, preferredType)) return preferredType;
+  return getDefaultConnectionTab(host);
+}

--- a/src/ui/sidebar/HostManagerData.ts
+++ b/src/ui/sidebar/HostManagerData.ts
@@ -32,6 +32,7 @@ function parseJson<T>(v: unknown): T | undefined {
 
 export function sshHostToHost(h: SSHHostWithStatus): Host {
   const host = h as RawSSHHost;
+  const isSshHost = h.connectionType === "ssh" || !h.connectionType;
   return {
     id: String(h.id),
     name: h.name,
@@ -59,10 +60,9 @@ export function sshHostToHost(h: SSHHostWithStatus): Host {
     notes: h.notes,
     pin: h.pin ?? false,
     macAddress: h.macAddress,
-    enableSsh: h.enableSsh != null ? h.enableSsh : h.connectionType === "ssh",
+    enableSsh: h.enableSsh != null ? h.enableSsh : isSshHost,
     enableTerminal:
-      h.enableTerminal ??
-      (h.enableSsh != null ? h.enableSsh : h.connectionType === "ssh"),
+      h.enableTerminal ?? (h.enableSsh != null ? h.enableSsh : isSshHost),
     enableSessionLogging: h.enableSessionLogging ?? true,
     enableCommandHistory: h.enableCommandHistory ?? true,
     enableTunnel: h.enableTunnel ?? false,


### PR DESCRIPTION
## Summary
- add shared host connection tab resolution so disabled SSH no longer wins over enabled RDP/VNC/Telnet
- route dashboard pinned hosts through the enabled default protocol and show the matching endpoint port
- let network graph generic connect actions fall back to the host default protocol
- reuse the shared host mapper in AppShell/Dashboard and preserve legacy SSH defaults when connection_type is missing

Refs https://github.com/Termix-SSH/Support/issues/867

## Validation
- npm run type-check
- npx eslint src/ui/AppShell.tsx src/ui/dashboard/DashboardTab.tsx src/ui/dashboard/cards/NetworkGraphCard.tsx src/ui/lib/host-connection-tabs.ts src/ui/sidebar/HostManagerData.ts
- git diff --check