### PR TITLE
fix: resolve SSH tunnel endpoints reliably

### DIFF
--- a/src/backend/ssh/tunnel.ts
+++ b/src/backend/ssh/tunnel.ts
@@ -106,6 +106,24 @@ type ActiveTunnelRuntime = {
 
 const activeTunnelRuntimes = new Map<string, ActiveTunnelRuntime>();
 
+function findHostByTunnelEndpoint(
+  hosts: SSHHost[],
+  endpointHost?: string,
+): SSHHost | undefined {
+  const value = endpointHost?.trim();
+  if (!value) return undefined;
+
+  return hosts.find((host) => {
+    const userAtIp = `${host.username}@${host.ip}`;
+    return (
+      String(host.id) === value ||
+      host.name === value ||
+      host.ip === value ||
+      userAtIp === value
+    );
+  });
+}
+
 function broadcastTunnelStatus(tunnelName: string, status: TunnelStatus): void {
   if (
     status.status === CONNECTION_STATES.CONNECTED &&
@@ -550,6 +568,12 @@ function isSingleHostTunnel(tunnelConfig: TunnelConfig): boolean {
   return false;
 }
 
+function shouldEstablishDirectTunnel(tunnelConfig: TunnelConfig): boolean {
+  if (isSingleHostTunnel(tunnelConfig)) return true;
+  const mode = getTunnelMode(tunnelConfig);
+  return mode !== "remote" && !tunnelConfig.endpointUsername;
+}
+
 async function establishDirectTunnel(
   sourceClient: Client,
   tunnelConfig: TunnelConfig,
@@ -558,7 +582,8 @@ async function establishDirectTunnel(
   const mode = getTunnelMode(tunnelConfig);
   const bindHost = getTunnelBindHost(tunnelConfig);
   const sourcePort = tunnelConfig.sourcePort;
-  const targetHost = tunnelConfig.targetHost || "127.0.0.1";
+  const targetHost =
+    tunnelConfig.targetHost || tunnelConfig.endpointHost || "127.0.0.1";
   const targetPort = tunnelConfig.endpointPort;
 
   if (mode === "remote") {
@@ -993,6 +1018,7 @@ async function connectSSHTunnel(
   }
 
   if (
+    !shouldEstablishDirectTunnel(tunnelConfig) &&
     resolvedEndpointCredentials.authMethod === "password" &&
     !resolvedEndpointCredentials.password
   ) {
@@ -1013,6 +1039,7 @@ async function connectSSHTunnel(
   }
 
   if (
+    !shouldEstablishDirectTunnel(tunnelConfig) &&
     resolvedEndpointCredentials.authMethod === "key" &&
     !resolvedEndpointCredentials.sshKey
   ) {
@@ -1166,7 +1193,7 @@ async function connectSSHTunnel(
         );
       }
 
-      if (isSingleHostTunnel(tunnelConfig)) {
+      if (shouldEstablishDirectTunnel(tunnelConfig)) {
         await establishDirectTunnel(conn, tunnelConfig);
       } else {
         await establishManagedS2STunnel(
@@ -1931,51 +1958,56 @@ app.post(
             );
 
             const allHosts: SSHHost[] = allHostsResponse.data || [];
-            const endpointHost = allHosts.find(
-              (h) =>
-                h.name === tunnelConfig.endpointHost ||
-                `${h.username}@${h.ip}` === tunnelConfig.endpointHost,
+            const endpointHost = findHostByTunnelEndpoint(
+              allHosts,
+              tunnelConfig.endpointHost,
             );
 
             if (!endpointHost) {
-              throw new Error(
-                `Endpoint host '${tunnelConfig.endpointHost}' not found in database`,
-              );
-            }
-
-            tunnelConfig.endpointIP = endpointHost.ip;
-            tunnelConfig.endpointSSHPort = endpointHost.port;
-            tunnelConfig.endpointUsername = endpointHost.username;
-            tunnelConfig.endpointAuthMethod = endpointHost.authType;
-            tunnelConfig.endpointKeyType = endpointHost.keyType;
-            tunnelConfig.endpointCredentialId = endpointHost.credentialId;
-            tunnelConfig.endpointUserId = endpointHost.userId;
-
-            // Resolve credentials server-side instead of from HTTP response
-            if (endpointHost.id && endpointHost.userId) {
-              try {
-                const { resolveHostById } = await import("./host-resolver.js");
-                const resolved = await resolveHostById(
-                  endpointHost.id,
-                  endpointHost.userId,
+              if (getTunnelMode(tunnelConfig) !== "remote") {
+                tunnelConfig.endpointIP =
+                  tunnelConfig.endpointIP || tunnelConfig.endpointHost;
+              } else {
+                throw new Error(
+                  `Endpoint host '${tunnelConfig.endpointHost}' not found in database`,
                 );
-                if (resolved) {
-                  tunnelConfig.endpointPassword = resolved.password;
-                  tunnelConfig.endpointSSHKey = resolved.key;
-                  tunnelConfig.endpointKeyPassword = resolved.keyPassword;
+              }
+            } else {
+              tunnelConfig.endpointIP = endpointHost.ip;
+              tunnelConfig.endpointSSHPort = endpointHost.port;
+              tunnelConfig.endpointUsername = endpointHost.username;
+              tunnelConfig.endpointAuthMethod = endpointHost.authType;
+              tunnelConfig.endpointKeyType = endpointHost.keyType;
+              tunnelConfig.endpointCredentialId = endpointHost.credentialId;
+              tunnelConfig.endpointUserId = endpointHost.userId;
+
+              // Resolve credentials server-side instead of from HTTP response
+              if (endpointHost.id && endpointHost.userId) {
+                try {
+                  const { resolveHostById } =
+                    await import("./host-resolver.js");
+                  const resolved = await resolveHostById(
+                    endpointHost.id,
+                    endpointHost.userId,
+                  );
+                  if (resolved) {
+                    tunnelConfig.endpointPassword = resolved.password;
+                    tunnelConfig.endpointSSHKey = resolved.key;
+                    tunnelConfig.endpointKeyPassword = resolved.keyPassword;
+                  }
+                } catch (credError) {
+                  tunnelLogger.warn(
+                    "Failed to resolve endpoint credentials from DB",
+                    {
+                      operation: "tunnel_endpoint_credential_resolve",
+                      endpointHostId: endpointHost.id,
+                      error:
+                        credError instanceof Error
+                          ? credError.message
+                          : "Unknown",
+                    },
+                  );
                 }
-              } catch (credError) {
-                tunnelLogger.warn(
-                  "Failed to resolve endpoint credentials from DB",
-                  {
-                    operation: "tunnel_endpoint_credential_resolve",
-                    endpointHostId: endpointHost.id,
-                    error:
-                      credError instanceof Error
-                        ? credError.message
-                        : "Unknown",
-                  },
-                );
               }
             }
           } catch (resolveError) {
@@ -2268,13 +2300,15 @@ async function initializeAutoStartTunnels(): Promise<void> {
       if (host.enableTunnel && host.tunnelConnections) {
         for (const tunnelConnection of host.tunnelConnections) {
           if (tunnelConnection.autoStart) {
-            const endpointHost = allHosts.find(
-              (h) =>
-                h.name === tunnelConnection.endpointHost ||
-                `${h.username}@${h.ip}` === tunnelConnection.endpointHost,
+            const endpointHost = findHostByTunnelEndpoint(
+              allHosts,
+              tunnelConnection.endpointHost,
             );
+            const mode =
+              tunnelConnection.mode || tunnelConnection.tunnelType || "remote";
+            const allowDirectTarget = mode !== "remote";
 
-            if (endpointHost) {
+            if (endpointHost || allowDirectTarget) {
               const tunnelIndex =
                 host.tunnelConnections.indexOf(tunnelConnection);
               const tunnelConfig: TunnelConfig = {
@@ -2287,10 +2321,7 @@ async function initializeAutoStartTunnels(): Promise<void> {
                   tunnelConnection.endpointPort,
                 ),
                 scope: tunnelConnection.scope || "s2s",
-                mode:
-                  tunnelConnection.mode ||
-                  tunnelConnection.tunnelType ||
-                  "remote",
+                mode,
                 bindHost: tunnelConnection.bindHost,
                 targetHost: tunnelConnection.targetHost,
                 tunnelType: tunnelConnection.tunnelType || "remote",
@@ -2304,16 +2335,18 @@ async function initializeAutoStartTunnels(): Promise<void> {
                 sourceKeyType: host.keyType,
                 sourceCredentialId: host.credentialId,
                 sourceUserId: host.userId,
-                endpointIP: endpointHost.ip,
-                endpointSSHPort: endpointHost.port,
-                endpointUsername: endpointHost.username,
+                endpointIP: endpointHost?.ip || tunnelConnection.endpointHost,
+                endpointSSHPort: endpointHost?.port || 22,
+                endpointUsername: endpointHost?.username || "",
                 endpointHost: tunnelConnection.endpointHost,
                 endpointAuthMethod:
-                  tunnelConnection.endpointAuthType || endpointHost.authType,
+                  tunnelConnection.endpointAuthType ||
+                  endpointHost?.authType ||
+                  "none",
                 endpointKeyType:
-                  tunnelConnection.endpointKeyType || endpointHost.keyType,
-                endpointCredentialId: endpointHost.credentialId,
-                endpointUserId: endpointHost.userId,
+                  tunnelConnection.endpointKeyType || endpointHost?.keyType,
+                endpointCredentialId: endpointHost?.credentialId,
+                endpointUserId: endpointHost?.userId,
                 sourcePort: tunnelConnection.sourcePort,
                 endpointPort: tunnelConnection.endpointPort,
                 maxRetries: tunnelConnection.maxRetries,

--- a/src/ui/features/tunnel/TunnelTab.tsx
+++ b/src/ui/features/tunnel/TunnelTab.tsx
@@ -26,6 +26,7 @@ import {
 } from "@/main-axios";
 import type { Host as DemoHost } from "@/types/ui-types";
 import type { SSHHost, TunnelConnection, TunnelStatus } from "@/types";
+import { findHostByTunnelEndpoint } from "./tunnel-endpoints";
 
 function tunnelName(
   host: SSHHost,
@@ -304,11 +305,7 @@ export function TunnelTab({ host }: { label: string; host?: DemoHost }) {
         let endpointSsh: SSHHost | undefined;
         if (!isDirect) {
           const allHosts = await getSSHHosts();
-          endpointSsh = allHosts.find(
-            (h) =>
-              h.name === tunnel.endpointHost ||
-              `${h.username}@${h.ip}` === tunnel.endpointHost,
-          );
+          endpointSsh = findHostByTunnelEndpoint(allHosts, tunnel.endpointHost);
         }
         await connectTunnel({
           name,
@@ -351,7 +348,7 @@ export function TunnelTab({ host }: { label: string; host?: DemoHost }) {
             endpointSsh?.authType === "password"
               ? endpointSsh.password
               : undefined,
-          endpointAuthMethod: endpointSsh?.authType ?? "password",
+          endpointAuthMethod: endpointSsh?.authType ?? "none",
           endpointSSHKey:
             endpointSsh?.authType === "key" ? endpointSsh.key : undefined,
           endpointKeyPassword:

--- a/src/ui/features/tunnel/tunnel-endpoints.ts
+++ b/src/ui/features/tunnel/tunnel-endpoints.ts
@@ -1,0 +1,25 @@
+type EndpointHostLike = {
+  id: number | string;
+  name?: string;
+  ip: string;
+  username?: string;
+};
+
+export function findHostByTunnelEndpoint<T extends EndpointHostLike>(
+  hosts: T[],
+  endpointHost?: string | null,
+): T | undefined {
+  const value = endpointHost?.trim();
+  if (!value) return undefined;
+
+  return hosts.find((host) => {
+    const id = String(host.id);
+    const userAtIp = host.username ? `${host.username}@${host.ip}` : "";
+    return (
+      id === value ||
+      host.name === value ||
+      host.ip === value ||
+      userAtIp === value
+    );
+  });
+}

--- a/src/ui/sidebar/HostEditor.tsx
+++ b/src/ui/sidebar/HostEditor.tsx
@@ -63,6 +63,7 @@ import {
 } from "./HostEditorGuacamoleTabs";
 import { HostStatsTab } from "./HostEditorStatsTab";
 import { VaultProfileManager } from "./VaultProfileManager";
+import { findHostByTunnelEndpoint } from "@/features/tunnel/tunnel-endpoints";
 
 export function HostEditor({
   host,
@@ -1428,7 +1429,18 @@ export function HostEditor({
                   </p>
                 )}
                 {form.serverTunnels.map((tun, i) => {
-                  const tunnelName = `${host?.id ?? "new"}-${i}-${tun.sourcePort}`;
+                  const selectedEndpointHost = findHostByTunnelEndpoint(
+                    hosts,
+                    tun.endpointHost,
+                  );
+                  const directEndpoint =
+                    !tun.endpointHost ||
+                    tun.endpointHost === "127.0.0.1" ||
+                    tun.endpointHost === "localhost";
+                  const hostLabel =
+                    host?.name ||
+                    (host ? `${host.username}@${host.ip}` : "new");
+                  const tunnelName = `${host?.id ?? "new"}::${i}::${hostLabel}::${tun.sourcePort}::${tun.endpointHost ?? ""}::${tun.endpointPort}`;
                   const tunnelStatus = tunnelStatuses[tunnelName]?.status as
                     | string
                     | undefined;
@@ -1486,12 +1498,30 @@ export function HostEditor({
                                       sourceCredentialId: form.credentialId
                                         ? Number(form.credentialId)
                                         : undefined,
-                                      endpointIP: host.ip,
-                                      endpointSSHPort:
-                                        host.sshPort ?? host.port,
+                                      endpointIP: directEndpoint
+                                        ? host.ip
+                                        : (selectedEndpointHost?.ip ??
+                                          tun.endpointHost ??
+                                          ""),
+                                      endpointSSHPort: directEndpoint
+                                        ? (host.sshPort ?? host.port)
+                                        : (selectedEndpointHost?.sshPort ??
+                                          selectedEndpointHost?.port ??
+                                          22),
                                       endpointHost: tun.endpointHost ?? "",
-                                      endpointUsername: form.username,
-                                      endpointAuthMethod: form.authType,
+                                      endpointUsername: directEndpoint
+                                        ? form.username
+                                        : (selectedEndpointHost?.username ??
+                                          ""),
+                                      endpointAuthMethod:
+                                        selectedEndpointHost?.authType ??
+                                        "none",
+                                      endpointCredentialId:
+                                        selectedEndpointHost?.credentialId
+                                          ? Number(
+                                              selectedEndpointHost.credentialId,
+                                            )
+                                          : undefined,
                                       sourcePort: tun.sourcePort,
                                       endpointPort: tun.endpointPort ?? 0,
                                       bindHost: tun.bindHost ?? "127.0.0.1",


### PR DESCRIPTION
## Summary
- resolve tunnel endpoint hosts by id, name, IP, or username@IP on both client and server paths
- allow local/dynamic tunnels to use ordinary target addresses without forcing a database endpoint host lookup
- keep remote tunnels strict when an endpoint SSH host is required
- align HostEditor manual tunnel starts with the normalized tunnel name format and endpoint credentials
- preserve autostart behavior for database endpoint hosts while allowing direct local targets

Refs https://github.com/Termix-SSH/Support/issues/866

## Validation
- npm run type-check
- npx eslint src/backend/ssh/tunnel.ts src/ui/features/tunnel/TunnelTab.tsx src/ui/features/tunnel/tunnel-endpoints.ts src/ui/sidebar/HostEditor.tsx
- npx prettier --check src/backend/ssh/tunnel.ts src/ui/features/tunnel/TunnelTab.tsx src/ui/features/tunnel/tunnel-endpoints.ts src/ui/sidebar/HostEditor.tsx
- git diff --check

Note: targeted vitest was not run because node_modules/.bin/vitest is not installed in this checkout.