### PR TITLE
Fix Electron OIDC browser auth failures

### DIFF
--- a/electron/main.cjs
+++ b/electron/main.cjs
@@ -1231,9 +1231,11 @@ ipcMain.handle(
   async (_event, authUrl, callbackPort) => {
     const http = require("http");
 
-    return new Promise((resolve, reject) => {
+    return new Promise((resolve) => {
+      let timeout;
+      let settled = false;
       const server = http.createServer((req, res) => {
-        const url = new URL(req.url, `http://localhost:${callbackPort}`);
+        const url = new URL(req.url || "/", `http://localhost:${callbackPort}`);
         if (url.pathname === "/oidc-callback") {
           const success = url.searchParams.get("success");
           const error = url.searchParams.get("error");
@@ -1244,27 +1246,54 @@ ipcMain.handle(
             `<html><body><h2>${success === "true" ? "Authentication successful!" : "Authentication failed."}</h2><p>You can close this tab and return to Termix.</p><script>window.close()</script></body></html>`,
           );
 
-          server.close();
           if (success === "true") {
-            resolve({ success: true, token });
+            finish({ success: true, token });
           } else {
-            resolve({
+            finish({
               success: false,
               error: error || "Authentication failed",
             });
           }
+          return;
+        }
+
+        res.writeHead(404, { "Content-Type": "text/plain" });
+        res.end("Not found");
+      });
+
+      const finish = (result) => {
+        if (settled) return;
+        settled = true;
+        if (timeout) clearTimeout(timeout);
+        try {
+          server.close();
+        } catch {
+          // Server may not have started yet.
+        }
+        resolve(result);
+      };
+
+      const fail = (error) => {
+        finish({
+          success: false,
+          error: error instanceof Error ? error.message : String(error),
+        });
+      };
+
+      server.once("error", fail);
+
+      server.listen(callbackPort, "127.0.0.1", async () => {
+        try {
+          await shell.openExternal(authUrl);
+        } catch (error) {
+          fail(error);
         }
       });
 
-      server.listen(callbackPort, "127.0.0.1", () => {
-        shell.openExternal(authUrl);
-      });
-
       // Timeout after 5 minutes
-      setTimeout(
+      timeout = setTimeout(
         () => {
-          server.close();
-          reject(new Error("OIDC authentication timed out"));
+          fail(new Error("OIDC authentication timed out"));
         },
         5 * 60 * 1000,
       );

--- a/src/ui/auth/Auth.tsx
+++ b/src/ui/auth/Auth.tsx
@@ -279,6 +279,27 @@ export function Auth({ onLogin }: AuthProps) {
   }, [rememberMe]);
 
   useEffect(() => {
+    if (!isInElectronWebView()) return;
+
+    const handleOIDCSystemBrowserResult = (event: MessageEvent) => {
+      if (event.source !== window.parent) return;
+      if (!event.data || typeof event.data !== "object") return;
+      if (event.data.type !== "OIDC_SYSTEM_BROWSER_AUTH_RESULT") return;
+
+      const providerId =
+        typeof event.data.providerId === "number" ? event.data.providerId : -1;
+      if (event.data.success) return;
+
+      setProviderLoading((prev) => ({ ...prev, [providerId]: false }));
+      toast.error(event.data.error || t("errors.failedOidcLogin"));
+    };
+
+    window.addEventListener("message", handleOIDCSystemBrowserResult);
+    return () =>
+      window.removeEventListener("message", handleOIDCSystemBrowserResult);
+  }, [t]);
+
+  useEffect(() => {
     getRegistrationAllowed()
       .then((res) => setRegistrationAllowed(res.allowed))
       .catch(() => {});
@@ -770,6 +791,7 @@ export function Auth({ onLogin }: AuthProps) {
               source: "oidc_request",
               authUrl,
               callbackPort,
+              providerId: loadingKey,
             },
             "*",
           );

--- a/src/ui/auth/ElectronLoginForm.tsx
+++ b/src/ui/auth/ElectronLoginForm.tsx
@@ -63,8 +63,15 @@ export function ElectronLoginForm({
       try {
         if (event.source !== iframeRef.current?.contentWindow) return;
         if (!event.data || typeof event.data !== "object") return;
-        const { type, platform, source, token, authUrl, callbackPort } =
-          event.data;
+        const {
+          type,
+          platform,
+          source,
+          token,
+          authUrl,
+          callbackPort,
+          providerId,
+        } = event.data;
 
         if (
           type === "AUTH_SUCCESS" &&
@@ -78,6 +85,20 @@ export function ElectronLoginForm({
         // OIDC login requested from inside the iframe — open the system browser
         // so captcha stages (e.g. Cloudflare Turnstile) render correctly.
         if (type === "OIDC_SYSTEM_BROWSER_AUTH" && authUrl && callbackPort) {
+          const sendResultToIframe = (result: {
+            success: boolean;
+            error?: string;
+          }) => {
+            iframeRef.current?.contentWindow?.postMessage(
+              {
+                type: "OIDC_SYSTEM_BROWSER_AUTH_RESULT",
+                source: "oidc_system_browser_auth",
+                providerId,
+                ...result,
+              },
+              "*",
+            );
+          };
           const electronAPI = (
             window as unknown as {
               electronAPI?: {
@@ -92,23 +113,51 @@ export function ElectronLoginForm({
               };
             }
           ).electronAPI;
-          if (!electronAPI?.oidcSystemBrowserAuth) return;
+          if (!electronAPI?.oidcSystemBrowserAuth) {
+            sendResultToIframe({
+              success: false,
+              error: t("errors.failedOidcLogin"),
+            });
+            return;
+          }
           const result = await electronAPI.oidcSystemBrowserAuth(
             authUrl,
             callbackPort,
           );
           if (result.success && result.token) {
             await handleAuthSuccess(result.token);
+            return;
           }
+          sendResultToIframe({
+            success: false,
+            error: result.error || t("errors.failedOidcLogin"),
+          });
         }
-      } catch {
-        // ignore
+      } catch (err) {
+        const providerId =
+          event.data &&
+          typeof event.data === "object" &&
+          typeof event.data.providerId === "number"
+            ? event.data.providerId
+            : undefined;
+        const error =
+          err instanceof Error ? err.message : t("errors.failedOidcLogin");
+        iframeRef.current?.contentWindow?.postMessage(
+          {
+            type: "OIDC_SYSTEM_BROWSER_AUTH_RESULT",
+            source: "oidc_system_browser_auth",
+            providerId,
+            success: false,
+            error,
+          },
+          "*",
+        );
       }
     };
 
     window.addEventListener("message", handleMessage);
     return () => window.removeEventListener("message", handleMessage);
-  }, [handleAuthSuccess]);
+  }, [handleAuthSuccess, t]);
 
   useEffect(() => {
     const iframe = iframeRef.current;


### PR DESCRIPTION
## Summary
- return Electron OIDC system-browser failures to the iframe so provider buttons stop loading
- handle callback server listen errors, browser launch failures, timeout cleanup, and unknown callback paths
- keep the successful desktop OIDC token path unchanged

## Verification
- npm run type-check
- npx eslint src/ui/auth/Auth.tsx src/ui/auth/ElectronLoginForm.tsx electron/main.cjs
- npx prettier --check src/ui/auth/Auth.tsx src/ui/auth/ElectronLoginForm.tsx electron/main.cjs
- node --check electron/main.cjs
- git diff --check

## Notes
- npm run build still fails before this change is reached because @fontsource/jetbrains-mono/400-italic.css cannot be resolved from src/ui/index.css.

Fixes Termix-SSH/Support#865