### PR TITLE
Allow RDP connections without stored credentials

### DIFF
--- a/src/backend/guacamole/token-service.test.ts
+++ b/src/backend/guacamole/token-service.test.ts
@@ -1,0 +1,48 @@
+import { describe, expect, it, vi } from "vitest";
+
+vi.mock("../utils/logger.js", () => ({
+  guacLogger: {
+    debug: vi.fn(),
+    info: vi.fn(),
+    warn: vi.fn(),
+    error: vi.fn(),
+    success: vi.fn(),
+  },
+}));
+
+const { GuacamoleTokenService } = await import("./token-service.js");
+
+describe("GuacamoleTokenService", () => {
+  const tokenService = GuacamoleTokenService.getInstance();
+
+  it("disables RDP pre-authentication when no credentials are configured", () => {
+    const token = tokenService.createRdpToken("windows.example.test", "", "");
+    const decrypted = tokenService.decryptToken(token);
+
+    expect(decrypted?.connection.settings).toMatchObject({
+      hostname: "windows.example.test",
+      port: 3389,
+      "ignore-cert": true,
+      "disable-auth": true,
+    });
+    expect(decrypted?.connection.settings.username).toBeUndefined();
+    expect(decrypted?.connection.settings.password).toBeUndefined();
+  });
+
+  it("keeps normal RDP credential authentication unchanged", () => {
+    const token = tokenService.createRdpToken(
+      "windows.example.test",
+      "Administrator",
+      "secret",
+    );
+    const decrypted = tokenService.decryptToken(token);
+
+    expect(decrypted?.connection.settings).toMatchObject({
+      hostname: "windows.example.test",
+      username: "Administrator",
+      password: "secret",
+      port: 3389,
+    });
+    expect(decrypted?.connection.settings["disable-auth"]).toBeUndefined();
+  });
+});

--- a/src/backend/guacamole/token-service.ts
+++ b/src/backend/guacamole/token-service.ts
@@ -16,6 +16,7 @@ export interface GuacamoleConnectionSettings {
     dpi?: number;
     security?: string;
     "ignore-cert"?: boolean;
+    "disable-auth"?: boolean;
     "enable-wallpaper"?: boolean;
     "enable-drive"?: boolean;
     "drive-path"?: string;
@@ -139,6 +140,7 @@ export class GuacamoleTokenService {
           ...(password ? { password } : {}),
           port: 3389,
           "ignore-cert": true,
+          ...(!username && !password ? { "disable-auth": true } : {}),
           ...settingsOptions,
         },
       },


### PR DESCRIPTION
## Summary
- set Guacamole `disable-auth` for RDP tokens when no username or password is configured
- keep normal RDP credential authentication unchanged
- add token-service coverage for empty and populated RDP credentials

## Verification
- npm run type-check
- npx eslint src/backend/guacamole/token-service.ts src/backend/guacamole/token-service.test.ts
- npx prettier --check src/backend/guacamole/token-service.ts src/backend/guacamole/token-service.test.ts
- git diff --check

## Notes
- npx vitest run src/backend/guacamole/token-service.test.ts could not start because the local install does not resolve `vitest/config`.
- npm run build still fails before this change is reached because @fontsource/jetbrains-mono/400.css cannot be resolved from src/ui/index.css.

Fixes Termix-SSH/Support#864