### PR TITLE
Sync role credential shares for OIDC users

### DIFF
--- a/src/backend/database/routes/users.ts
+++ b/src/backend/database/routes/users.ts
@@ -41,6 +41,25 @@ const authManager = AuthManager.getInstance();
 
 const router = express.Router();
 
+async function syncSharedCredentialsForUserRoles(
+  userId: string,
+  operation: string,
+) {
+  try {
+    const { SharedCredentialManager } =
+      await import("../../utils/shared-credential-manager.js");
+    const sharedCredManager = SharedCredentialManager.getInstance();
+    await sharedCredManager.createSharedCredentialsForUserRoles(userId);
+    await sharedCredManager.reEncryptPendingCredentialsForUser(userId);
+  } catch (error) {
+    authLogger.warn("Failed to sync role shared credentials", {
+      operation,
+      userId,
+      error,
+    });
+  }
+}
+
 function isNonEmptyString(val: unknown): val is string {
   return typeof val === "string" && val.trim().length > 0;
 }
@@ -946,7 +965,7 @@ router.get("/oidc/callback", async (req, res) => {
               ? 30 * 24 * 60 * 60 * 1000
               : 24 * 60 * 60 * 1000;
           await authManager.registerOIDCUser(ghId, sessionDurationMs);
-        } catch (encryptionError) {
+        } catch {
           await db.delete(users).where(eq(users.id, ghId));
           return res.status(500).json({
             error: "Failed to setup user security - user creation cancelled",
@@ -965,6 +984,10 @@ router.get("/oidc/callback", async (req, res) => {
       } catch {
         /* */
       }
+      await syncSharedCredentialsForUserRoles(
+        ghUserRecord.id,
+        "github_oidc_role_shared_credentials",
+      );
       const ghToken = await authManager.generateJWTToken(ghUserRecord.id, {
         deviceType: deviceInfo.type,
         deviceInfo: deviceInfo.deviceInfo,
@@ -1432,14 +1455,10 @@ router.get("/oidc/callback", async (req, res) => {
       });
     }
 
-    try {
-      const { SharedCredentialManager } =
-        await import("../../utils/shared-credential-manager.js");
-      const sharedCredManager = SharedCredentialManager.getInstance();
-      await sharedCredManager.reEncryptPendingCredentialsForUser(userRecord.id);
-    } catch {
-      // expected - re-encryption may fail if no pending credentials
-    }
+    await syncSharedCredentialsForUserRoles(
+      userRecord.id,
+      "oidc_role_shared_credentials",
+    );
 
     const token = await authManager.generateJWTToken(userRecord.id, {
       deviceType: deviceInfo.type,
@@ -1642,18 +1661,10 @@ router.post("/login", async (req, res) => {
       return res.status(401).json({ error: "Incorrect password" });
     }
 
-    try {
-      const { SharedCredentialManager } =
-        await import("../../utils/shared-credential-manager.js");
-      const sharedCredManager = SharedCredentialManager.getInstance();
-      await sharedCredManager.reEncryptPendingCredentialsForUser(userRecord.id);
-    } catch (error) {
-      authLogger.warn("Failed to re-encrypt pending shared credentials", {
-        operation: "reencrypt_pending_credentials",
-        userId: userRecord.id,
-        error,
-      });
-    }
+    await syncSharedCredentialsForUserRoles(
+      userRecord.id,
+      "login_role_shared_credentials",
+    );
 
     if (userRecord.totpEnabled) {
       const deviceFingerprint = generateDeviceFingerprint(deviceInfo);

--- a/src/backend/utils/shared-credential-manager.ts
+++ b/src/backend/utils/shared-credential-manager.ts
@@ -39,6 +39,19 @@ class SharedCredentialManager {
     ownerId: string,
   ): Promise<void> {
     try {
+      const existing = await db
+        .select({ id: sharedCredentials.id })
+        .from(sharedCredentials)
+        .where(
+          and(
+            eq(sharedCredentials.hostAccessId, hostAccessId),
+            eq(sharedCredentials.targetUserId, targetUserId),
+          ),
+        )
+        .limit(1);
+
+      if (existing.length > 0) return;
+
       const ownerDEK = DataCrypto.getUserDataKey(ownerId);
 
       if (ownerDEK) {
@@ -152,6 +165,83 @@ class SharedCredentialManager {
           operation: "create_shared_credentials_role",
           hostAccessId,
           roleId,
+        },
+      );
+      throw error;
+    }
+  }
+
+  async createSharedCredentialsForRoleMember(
+    roleId: number,
+    targetUserId: string,
+  ): Promise<void> {
+    try {
+      const hostsSharedWithRole = await db
+        .select()
+        .from(hostAccess)
+        .innerJoin(hosts, eq(hostAccess.hostId, hosts.id))
+        .where(eq(hostAccess.roleId, roleId));
+
+      for (const { host_access, ssh_data } of hostsSharedWithRole) {
+        const activeCredentialId =
+          ssh_data.credentialId ??
+          ssh_data.rdpCredentialId ??
+          ssh_data.vncCredentialId ??
+          ssh_data.telnetCredentialId;
+
+        if (!activeCredentialId) continue;
+
+        try {
+          await this.createSharedCredentialForUser(
+            host_access.id,
+            activeCredentialId,
+            targetUserId,
+            ssh_data.userId,
+          );
+        } catch (error) {
+          databaseLogger.error(
+            "Failed to create shared credential for role member",
+            error,
+            {
+              operation: "create_shared_credentials_role_member",
+              roleId,
+              targetUserId,
+              hostId: ssh_data.id,
+            },
+          );
+        }
+      }
+    } catch (error) {
+      databaseLogger.error(
+        "Failed to create shared credentials for role member",
+        error,
+        {
+          operation: "create_shared_credentials_role_member",
+          roleId,
+          targetUserId,
+        },
+      );
+      throw error;
+    }
+  }
+
+  async createSharedCredentialsForUserRoles(userId: string): Promise<void> {
+    try {
+      const roleRows = await db
+        .select({ roleId: userRoles.roleId })
+        .from(userRoles)
+        .where(eq(userRoles.userId, userId));
+
+      for (const { roleId } of roleRows) {
+        await this.createSharedCredentialsForRoleMember(roleId, userId);
+      }
+    } catch (error) {
+      databaseLogger.error(
+        "Failed to create shared credentials for user roles",
+        error,
+        {
+          operation: "create_shared_credentials_user_roles",
+          userId,
         },
       );
       throw error;


### PR DESCRIPTION
## Summary
- create missing shared credential rows for users based on their current role memberships after their data key is unlocked
- apply the sync to OIDC, GitHub OIDC, and normal login paths before pending shared credentials are re-encrypted
- avoid duplicate shared credential rows when the sync runs repeatedly

## Verification
- npm run type-check
- npx eslint src/backend/utils/shared-credential-manager.ts src/backend/database/routes/users.ts
- npx prettier --check src/backend/utils/shared-credential-manager.ts src/backend/database/routes/users.ts
- git diff --check

## Notes
- npm run build still fails before this change is reached because @fontsource/jetbrains-mono/400.css cannot be resolved from src/ui/index.css.

Fixes Termix-SSH/Support#863