### PR TITLE
Promote file manager terminals to tabs

### DIFF
--- a/src/ui/AppShell.tsx
+++ b/src/ui/AppShell.tsx
@@ -1644,6 +1644,15 @@ export function AppShell({
                           initialFilePath: filePath,
                         }),
                       (host, _path) => openTab(host, "files"),
+                      (host, path) =>
+                        openTab(host, "terminal", {
+                          instanceId:
+                            typeof crypto.randomUUID === "function"
+                              ? crypto.randomUUID()
+                              : `${Date.now().toString(36)}-${Math.random().toString(36).slice(2)}`,
+                          restoredSessionId: null,
+                          initialFilePath: path,
+                        }),
                       renameTab,
                     ),
                     tabNode,

--- a/src/ui/features/file-manager/FileManager.tsx
+++ b/src/ui/features/file-manager/FileManager.tsx
@@ -86,6 +86,7 @@ function FileManagerContent({
   initialFilePath,
   initialPath,
   onClose,
+  onOpenTerminalTab,
 }: FileManagerProps) {
   const { openWindow } = useWindowManager();
   const { t } = useTranslation();
@@ -2483,6 +2484,7 @@ function FileManagerContent({
         initialPath={path}
         initialX={offsetX}
         initialY={offsetY}
+        onPromoteToTab={onOpenTerminalTab}
       />
     );
 
@@ -2529,6 +2531,7 @@ function FileManagerContent({
         initialX={offsetX}
         initialY={offsetY}
         executeCommand={executeCmd}
+        onPromoteToTab={onOpenTerminalTab}
       />
     );
 
@@ -2989,6 +2992,7 @@ function FileManagerInner({
   initialFilePath,
   initialPath,
   onClose,
+  onOpenTerminalTab,
 }: FileManagerProps) {
   return (
     <WindowManager>
@@ -2997,6 +3001,7 @@ function FileManagerInner({
         initialFilePath={initialFilePath}
         initialPath={initialPath}
         onClose={onClose}
+        onOpenTerminalTab={onOpenTerminalTab}
       />
     </WindowManager>
   );

--- a/src/ui/features/file-manager/components/DraggableWindow.tsx
+++ b/src/ui/features/file-manager/components/DraggableWindow.tsx
@@ -20,6 +20,7 @@ interface DraggableWindowProps {
   zIndex?: number;
   onFocus?: () => void;
   targetSize?: { width: number; height: number };
+  titleActions?: React.ReactNode;
 }
 
 export function DraggableWindow({
@@ -39,6 +40,7 @@ export function DraggableWindow({
   zIndex = 1000,
   onFocus,
   targetSize,
+  titleActions,
 }: DraggableWindowProps) {
   const { t } = useTranslation();
   const [position, setPosition] = useState({ x: initialX, y: initialY });
@@ -290,6 +292,8 @@ export function DraggableWindow({
         </div>
 
         <div className="flex items-center gap-0.5">
+          {titleActions}
+
           {onMinimize && (
             <button
               className="size-6 flex items-center justify-center rounded-none hover:bg-accent-brand/10 hover:text-accent-brand text-muted-foreground transition-colors"

--- a/src/ui/features/file-manager/components/TerminalWindow.tsx
+++ b/src/ui/features/file-manager/components/TerminalWindow.tsx
@@ -9,6 +9,7 @@ import { useWindowManager } from "./WindowManager.tsx";
 import { useTranslation } from "react-i18next";
 import { CommandHistoryProvider } from "@/features/terminal/command-history/CommandHistoryContext.tsx";
 import type { SSHHost } from "@/types/index.ts";
+import { ExternalLink } from "lucide-react";
 
 interface TerminalWindowProps {
   windowId: string;
@@ -17,6 +18,7 @@ interface TerminalWindowProps {
   initialX?: number;
   initialY?: number;
   executeCommand?: string;
+  onPromoteToTab?: (path?: string) => void;
 }
 
 export function TerminalWindow({
@@ -26,6 +28,7 @@ export function TerminalWindow({
   initialX = 200,
   initialY = 150,
   executeCommand,
+  onPromoteToTab,
 }: TerminalWindowProps) {
   const { t } = useTranslation();
   const { closeWindow, maximizeWindow, focusWindow, windows } =
@@ -78,6 +81,11 @@ export function TerminalWindow({
     }, 100);
   };
 
+  const handlePromoteToTab = () => {
+    onPromoteToTab?.(initialPath);
+    closeWindow(windowId);
+  };
+
   const terminalTitle = executeCommand
     ? t("terminal.runTitle", { host: hostConfig.name, command: executeCommand })
     : initialPath
@@ -103,6 +111,20 @@ export function TerminalWindow({
         onResize={handleResize}
         isMaximized={currentWindow.isMaximized}
         zIndex={currentWindow.zIndex}
+        titleActions={
+          onPromoteToTab ? (
+            <button
+              className="size-6 flex items-center justify-center rounded-none hover:bg-accent-brand/10 hover:text-accent-brand text-muted-foreground transition-colors"
+              onClick={(e) => {
+                e.stopPropagation();
+                handlePromoteToTab();
+              }}
+              title={t("common.openInNewTab")}
+            >
+              <ExternalLink className="size-3.5" />
+            </button>
+          ) : null
+        }
       >
         <Terminal
           ref={terminalRef}

--- a/src/ui/features/file-manager/file-manager-types.ts
+++ b/src/ui/features/file-manager/file-manager-types.ts
@@ -6,6 +6,7 @@ export interface FileManagerProps {
   initialFilePath?: string;
   initialPath?: string;
   onClose?: () => void;
+  onOpenTerminalTab?: (path?: string) => void;
 }
 
 export type ConnectionLogPayload = Omit<LogEntry, "id" | "timestamp">;

--- a/src/ui/shell/tabUtils.tsx
+++ b/src/ui/shell/tabUtils.tsx
@@ -160,6 +160,7 @@ function TerminalTabContent({
               } as TerminalHostConfig
             }
             isVisible={isVisible}
+            initialPath={tab.initialFilePath}
             title={label}
             showTitle={false}
             splitScreen={false}
@@ -194,6 +195,7 @@ export function renderTabContent(
   isVisible = true,
   onOpenFileInEditor?: (host: Host, filePath: string) => void,
   onOpenFileManager?: (host: Host, path?: string) => void,
+  onOpenTerminalTab?: (host: Host, path?: string) => void,
   onRenameTab?: (tabId: string, newLabel: string) => void,
 ) {
   const { host, label } = tab;
@@ -246,6 +248,11 @@ export function renderTabContent(
         <FileManager
           initialHost={hostToSSHHost(host)}
           initialFilePath={tab.initialFilePath}
+          onOpenTerminalTab={
+            onOpenTerminalTab
+              ? (path) => onOpenTerminalTab(host, path)
+              : undefined
+          }
         />
       );
 


### PR DESCRIPTION
## Summary
- add a title-bar action to file-manager terminal windows that opens the session as a normal terminal tab
- carry the terminal window's current initial path into the promoted terminal tab
- wire file-manager terminal promotion through the existing AppShell tab creation path

## Verification
- npm run type-check
- npx eslint src/ui/AppShell.tsx src/ui/shell/tabUtils.tsx src/ui/features/file-manager/FileManager.tsx src/ui/features/file-manager/file-manager-types.ts src/ui/features/file-manager/components/TerminalWindow.tsx src/ui/features/file-manager/components/DraggableWindow.tsx
- npx prettier --check src/ui/AppShell.tsx src/ui/shell/tabUtils.tsx src/ui/features/file-manager/FileManager.tsx src/ui/features/file-manager/file-manager-types.ts src/ui/features/file-manager/components/TerminalWindow.tsx src/ui/features/file-manager/components/DraggableWindow.tsx
- git diff --check

## Notes
- npm run build still fails before this change is reached because @fontsource/jetbrains-mono/400.css cannot be resolved from src/ui/index.css.

Fixes Termix-SSH/Support#862