### PR TITLE
Preserve file path case in file manager UI

### DIFF
--- a/src/ui/features/file-manager/components/DraggableWindow.tsx
+++ b/src/ui/features/file-manager/components/DraggableWindow.tsx
@@ -284,7 +284,7 @@ export function DraggableWindow({
             {t("fileManager.editor")}
           </span>
           <div className="h-4 w-px bg-border/50 shrink-0" />
-          <span className="text-[10px] font-bold uppercase tracking-widest text-muted-foreground truncate">
+          <span className="text-[10px] font-bold tracking-tight text-muted-foreground truncate">
             {title}
           </span>
         </div>

--- a/src/ui/features/file-manager/components/PermissionsDialog.tsx
+++ b/src/ui/features/file-manager/components/PermissionsDialog.tsx
@@ -174,7 +174,7 @@ export function PermissionsDialog({
             <Lock className="size-4 text-accent-brand" />
             {t("fileManager.changePermissions")}
           </DialogTitle>
-          <DialogDescription className="text-[10px] font-bold uppercase tracking-tight text-muted-foreground font-mono break-all">
+          <DialogDescription className="text-[10px] font-bold tracking-tight text-muted-foreground font-mono break-all">
             {file.path}
           </DialogDescription>
         </DialogHeader>


### PR DESCRIPTION
## Summary
- Preserve the original case of file editor titles instead of uppercasing filenames
- Preserve the original case of the file path shown in file properties/permissions

Fixes Termix-SSH/Support#860

## Verification
- npx prettier --check src/ui/features/file-manager/components/DraggableWindow.tsx src/ui/features/file-manager/components/PermissionsDialog.tsx
- npx eslint src/ui/features/file-manager/components/DraggableWindow.tsx src/ui/features/file-manager/components/PermissionsDialog.tsx
- npm run type-check
- git diff --check

## Build note
- npm run build still fails before this change completes because src/ui/index.css cannot resolve @fontsource/jetbrains-mono/400.css in the current checkout.