### PR TITLE
Confirm closing active host connections

### DIFF
--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -656,6 +656,7 @@ export interface TabContextTab {
 export interface TerminalRefHandle {
   disconnect?: () => void;
   reconnect?: () => void;
+  isConnected?: () => boolean;
   fit?: () => void;
   sendInput?: (data: string) => void;
   notifyResize?: () => void;

--- a/src/types/ui-types.ts
+++ b/src/types/ui-types.ts
@@ -242,6 +242,8 @@ export type Tab = {
   restoredSessionId?: string | null;
   initialFilePath?: string;
   terminalRef?: import("react").RefObject<{
+    disconnect?: () => void;
+    isConnected?: () => boolean;
     sendInput?: (data: string) => void;
     reconnect?: () => void;
     fit?: () => void;

--- a/src/ui/AppShell.tsx
+++ b/src/ui/AppShell.tsx
@@ -838,8 +838,11 @@ export function AppShell({
                 host,
                 openedAt: new Date(saved.createdAt).getTime(),
                 restoredSessionId,
-                terminalRef:
-                  saved.tabType === "terminal" ? createRef() : undefined,
+                terminalRef: SESSION_TAB_TYPES.includes(
+                  saved.tabType as TabType,
+                )
+                  ? createRef()
+                  : undefined,
               });
             }
 
@@ -915,7 +918,7 @@ export function AppShell({
         ? crypto.randomUUID()
         : `${Date.now().toString(36)}-${Math.random().toString(36).slice(2)}-${Math.random().toString(36).slice(2)}`);
     const openedAt = Date.now();
-    const ref = type === "terminal" ? createRef() : undefined;
+    const ref = SESSION_TAB_TYPES.includes(type) ? createRef() : undefined;
     if (ref) terminalRefs.current.set(tabId, ref);
 
     let finalLabel = host.name;
@@ -1092,6 +1095,35 @@ export function AppShell({
   );
 
   const SESSION_TAB_TYPES: TabType[] = ["terminal", "rdp", "vnc", "telnet"];
+  const ACTIVE_CLOSE_CONFIRM_TYPES: TabType[] = SESSION_TAB_TYPES;
+
+  const getTabCloseLabel = useCallback((tab: Tab) => {
+    return tab.customLabel || tab.label || tab.host?.name || String(tab.id);
+  }, []);
+
+  const isActiveConnectionTab = useCallback((tab: Tab) => {
+    if (!ACTIVE_CLOSE_CONFIRM_TYPES.includes(tab.type)) return false;
+    return tab.terminalRef?.current?.isConnected?.() === true;
+  }, []);
+
+  const hasActiveConnection = useCallback(() => {
+    return tabsRef.current.some(isActiveConnectionTab);
+  }, [isActiveConnectionTab]);
+
+  useEffect(() => {
+    const handleBeforeUnload = (event: BeforeUnloadEvent) => {
+      if (!hasActiveConnection()) return;
+
+      event.preventDefault();
+      event.returnValue = "";
+      return "";
+    };
+
+    window.addEventListener("beforeunload", handleBeforeUnload);
+    return () => {
+      window.removeEventListener("beforeunload", handleBeforeUnload);
+    };
+  }, [hasActiveConnection]);
 
   function doCloseTab(id: string) {
     const tabToClose = tabs.find((t) => t.id === id);
@@ -1145,20 +1177,37 @@ export function AppShell({
   function closeTab(id: string) {
     const tab = tabs.find((t) => t.id === id);
     const confirmEnabled = localStorage.getItem("confirmTabClose") === "true";
-    if (tab && SESSION_TAB_TYPES.includes(tab.type) && confirmEnabled) {
-      toast(t("nav.confirmClose"), {
-        duration: 5000,
-        action: {
-          label: t("nav.close"),
-          onClick: () => doCloseTab(id),
+    if (tab && confirmEnabled && isActiveConnectionTab(tab)) {
+      const closeLabel = getTabCloseLabel(tab);
+      const toastId = `close-tab-${id}`;
+      toast(
+        t("nav.confirmCloseHost", {
+          host: closeLabel,
+          defaultValue: `Close ${closeLabel}?`,
+        }),
+        {
+          id: toastId,
+          duration: 8000,
+          action: {
+            label: t("nav.close"),
+            onClick: () => {
+              toast.dismiss(toastId);
+              doCloseTab(id);
+            },
+          },
+          cancel: {
+            label: t("nav.cancel"),
+            onClick: () => toast.dismiss(toastId),
+          },
         },
-        cancel: {
-          label: t("nav.cancel"),
-          onClick: () => {},
-        },
-      });
+      );
       return;
     }
+
+    if (tab && SESSION_TAB_TYPES.includes(tab.type) && confirmEnabled) {
+      toast.dismiss(`close-tab-${id}`);
+    }
+
     doCloseTab(id);
   }
 
@@ -1661,7 +1710,7 @@ export function AppShell({
                           restoredSessionId: null,
                           initialFilePath: filePath,
                         }),
-                      (host, path) => openTab(host, "files"),
+                      (host, _path) => openTab(host, "files"),
                       renameTab,
                     ),
                     tabNode,

--- a/src/ui/features/guacamole/GuacamoleApp.tsx
+++ b/src/ui/features/guacamole/GuacamoleApp.tsx
@@ -1,4 +1,10 @@
-import React, { useState, useEffect, useRef, useCallback } from "react";
+import React, {
+  useState,
+  useEffect,
+  useRef,
+  useCallback,
+  useImperativeHandle,
+} from "react";
 import {
   GuacamoleDisplay,
   type GuacamoleDisplayHandle,
@@ -22,67 +28,71 @@ interface GuacamoleAppProps {
   protocol?: "rdp" | "vnc" | "telnet";
 }
 
-const GuacamoleApp: React.FC<GuacamoleAppProps> = ({
-  hostId,
-  tabId,
-  protocol,
-}) => {
-  const { t } = useTranslation();
-  const [hostConfig, setHostConfig] = useState<SSHHost | null>(null);
-  const [loading, setLoading] = useState(true);
+export interface GuacamoleAppHandle {
+  disconnect: () => void;
+  isConnected: () => boolean;
+}
 
-  useEffect(() => {
-    if (!hostId) {
-      setLoading(false);
-      return;
+const GuacamoleApp = React.forwardRef<GuacamoleAppHandle, GuacamoleAppProps>(
+  function GuacamoleApp({ hostId, tabId, protocol }, ref) {
+    const { t } = useTranslation();
+    const [hostConfig, setHostConfig] = useState<SSHHost | null>(null);
+    const [loading, setLoading] = useState(true);
+
+    useEffect(() => {
+      if (!hostId) {
+        setLoading(false);
+        return;
+      }
+      getSSHHosts()
+        .then((hosts) => {
+          const host = hosts.find((h) => h.id === parseInt(hostId, 10));
+          setHostConfig(host ?? null);
+        })
+        .catch(() => setHostConfig(null))
+        .finally(() => setLoading(false));
+    }, [hostId]);
+
+    if (loading) {
+      return (
+        <div className="relative w-full h-full">
+          <SimpleLoader visible={true} message={t("common.loading")} />
+        </div>
+      );
     }
-    getSSHHosts()
-      .then((hosts) => {
-        const host = hosts.find((h) => h.id === parseInt(hostId, 10));
-        setHostConfig(host ?? null);
-      })
-      .catch(() => setHostConfig(null))
-      .finally(() => setLoading(false));
-  }, [hostId]);
 
-  if (loading) {
-    return (
-      <div className="relative w-full h-full">
-        <SimpleLoader visible={true} message={t("common.loading")} />
-      </div>
-    );
-  }
-
-  if (!hostConfig || !hostId) {
-    return (
-      <div
-        className="flex flex-col items-center justify-center h-full gap-4"
-        style={{ backgroundColor: "var(--bg-base)" }}
-      >
-        <AlertCircle
-          className="size-10"
-          style={{ color: "var(--foreground)" }}
-        />
-        <span
-          className="text-sm font-semibold"
-          style={{ color: "var(--foreground)" }}
+    if (!hostConfig || !hostId) {
+      return (
+        <div
+          className="flex flex-col items-center justify-center h-full gap-4"
+          style={{ backgroundColor: "var(--bg-base)" }}
         >
-          {t("guacamole.hostNotFound")}
-        </span>
-      </div>
-    );
-  }
+          <AlertCircle
+            className="size-10"
+            style={{ color: "var(--foreground)" }}
+          />
+          <span
+            className="text-sm font-semibold"
+            style={{ color: "var(--foreground)" }}
+          >
+            {t("guacamole.hostNotFound")}
+          </span>
+        </div>
+      );
+    }
 
-  return (
-    <GuacamoleAppInner
-      hostId={parseInt(hostId, 10)}
-      hostConfig={hostConfig}
-      hostName={hostConfig.name || hostConfig.ip || String(hostId)}
-      tabId={tabId}
-      protocol={protocol}
-    />
-  );
-};
+    return (
+      <GuacamoleAppInner
+        hostId={parseInt(hostId, 10)}
+        hostConfig={hostConfig}
+        hostName={hostConfig.name || hostConfig.ip || String(hostId)}
+        tabId={tabId}
+        protocol={protocol}
+        ref={ref}
+      />
+    );
+  },
+);
 
 interface GuacamoleAppInnerProps {
   hostId: number;
@@ -92,19 +102,24 @@ interface GuacamoleAppInnerProps {
   protocol?: "rdp" | "vnc" | "telnet";
 }
 
-const GuacamoleAppInner: React.FC<GuacamoleAppInnerProps> = ({
-  hostId,
-  hostConfig,
-  hostName,
-  tabId,
-  protocol,
-}) => {
+const GuacamoleAppInner = React.forwardRef<
+  GuacamoleAppHandle,
+  GuacamoleAppInnerProps
+>(function GuacamoleAppInner(
+  { hostId, hostConfig, hostName, tabId, protocol },
+  ref,
+) {
   const { t } = useTranslation();
   const [token, setToken] = useState<string | null>(null);
   const [error, setError] = useState<string | null>(null);
   const [connectionError, setConnectionError] = useState<string | null>(null);
   const [retryCount, setRetryCount] = useState(0);
   const displayRef = useRef<GuacamoleDisplayHandle>(null);
+
+  useImperativeHandle(ref, () => ({
+    disconnect: () => displayRef.current?.disconnect(),
+    isConnected: () => displayRef.current?.isConnected() === true,
+  }));
 
   useEffect(() => {
     setToken(null);
@@ -127,7 +142,7 @@ const GuacamoleAppInner: React.FC<GuacamoleAppInnerProps> = ({
         }
       })
       .catch((err) => setError(err?.message || t("guacamole.failedToConnect")));
-  }, [hostId, protocol, retryCount, t]);
+  }, [hostConfig.connectionType, hostId, hostName, protocol, retryCount, t]);
 
   const handleReconnect = useCallback(() => {
     setConnectionError(null);
@@ -242,6 +257,6 @@ const GuacamoleAppInner: React.FC<GuacamoleAppInnerProps> = ({
       <GuacamoleToolbar displayRef={displayRef} protocol={resolvedProtocol} />
     </div>
   );
-};
+});
 
 export default GuacamoleApp;

--- a/src/ui/features/guacamole/GuacamoleDisplay.tsx
+++ b/src/ui/features/guacamole/GuacamoleDisplay.tsx
@@ -30,6 +30,7 @@ export interface GuacamoleConnectionConfig {
 
 export interface GuacamoleDisplayHandle {
   disconnect: () => void;
+  isConnected: () => boolean;
   sendKey: (keysym: number, pressed: boolean) => void;
   sendMouse: (x: number, y: number, buttonMask: number) => void;
   setClipboard: (data: string) => void;
@@ -73,6 +74,7 @@ export const GuacamoleDisplay = forwardRef<
         clientRef.current.disconnect();
       }
     },
+    isConnected: () => isReady && !hasError,
     sendKey: (keysym: number, pressed: boolean) => {
       if (clientRef.current) {
         clientRef.current.sendKeyEvent(pressed ? 1 : 0, keysym);

--- a/src/ui/features/terminal/Terminal.tsx
+++ b/src/ui/features/terminal/Terminal.tsx
@@ -652,6 +652,7 @@ const TerminalInner = forwardRef<TerminalHandle, SSHTerminalProps>(
             connectToHost(cols, rows);
           }
         },
+        isConnected: () => isConnected,
         fit: () => {
           if (!fitAddonRef.current || !terminal || isFittingRef.current) return;
           isFittingRef.current = true;
@@ -705,7 +706,7 @@ const TerminalInner = forwardRef<TerminalHandle, SSHTerminalProps>(
           }
         },
       }),
-      [terminal],
+      [isConnected, terminal],
     );
 
     function getUseRightClickCopyPaste() {

--- a/src/ui/features/terminal/terminal-types.ts
+++ b/src/ui/features/terminal/terminal-types.ts
@@ -20,6 +20,7 @@ export interface TerminalHostConfig {
 export interface TerminalHandle {
   disconnect: () => void;
   reconnect: () => void;
+  isConnected: () => boolean;
   fit: () => void;
   focus: () => void;
   sendInput: (data: string) => void;

--- a/src/ui/shell/tabUtils.tsx
+++ b/src/ui/shell/tabUtils.tsx
@@ -28,6 +28,7 @@ import { HostMetricsTab } from "@/features/host-metrics/HostMetricsTab";
 // --- tmux-monitor ---
 import { TmuxMonitor } from "@/features/tmux-monitor/TmuxMonitor";
 import GuacamoleApp from "@/features/guacamole/GuacamoleApp";
+import type { GuacamoleAppHandle } from "@/features/guacamole/GuacamoleApp";
 import { DashboardTab } from "@/dashboard/DashboardTab";
 import { TunnelTab } from "@/features/tunnel/TunnelTab";
 import { NetworkGraphCard } from "@/dashboard/cards/NetworkGraphCard";
@@ -288,6 +289,7 @@ export function renderTabContent(
         );
       return (
         <GuacamoleApp
+          ref={tab.terminalRef as React.Ref<GuacamoleAppHandle>}
           hostId={host.id}
           tabId={tab.id}
           protocol={tab.type as "rdp" | "vnc" | "telnet"}


### PR DESCRIPTION
## Summary
- Expose live connection state from terminal and Guacamole tabs through their tab refs
- Show one close confirmation per active host tab, with the host/tab name in the prompt
- Skip close confirmations for disconnected host tabs and add beforeunload protection while any host connection is still active

Fixes Termix-SSH/Support#857
Fixes Termix-SSH/Support#858

## Verification
- npx prettier --check src/ui/AppShell.tsx src/ui/shell/tabUtils.tsx src/ui/features/terminal/Terminal.tsx src/ui/features/terminal/terminal-types.ts src/ui/features/guacamole/GuacamoleApp.tsx src/ui/features/guacamole/GuacamoleDisplay.tsx src/types/ui-types.ts src/types/index.ts
- npx eslint src/ui/AppShell.tsx src/ui/shell/tabUtils.tsx src/ui/features/terminal/Terminal.tsx src/ui/features/terminal/terminal-types.ts src/ui/features/guacamole/GuacamoleApp.tsx src/ui/features/guacamole/GuacamoleDisplay.tsx src/types/ui-types.ts src/types/index.ts
- npm run type-check
- git diff --check

## Build note
- npm run build still fails before this change completes because src/ui/index.css cannot resolve @fontsource/jetbrains-mono/400.css in the current checkout.