### PR TITLE
Persist VNC authentication settings

### DIFF
--- a/src/backend/database/routes/host.ts
+++ b/src/backend/database/routes/host.ts
@@ -201,6 +201,8 @@ router.post(
       rdpDomain,
       rdpSecurity,
       rdpIgnoreCert,
+      vncAuthType,
+      vncCredentialId,
       vncPassword,
       vncUser,
       telnetUser,
@@ -324,6 +326,11 @@ router.post(
       rdpDomain: rdpDomain || null,
       rdpSecurity: rdpSecurity || null,
       rdpIgnoreCert: rdpIgnoreCert ? 1 : 0,
+      vncAuthType: enableVnc ? vncAuthType || null : null,
+      vncCredentialId:
+        enableVnc && vncAuthType === "credential" && vncCredentialId
+          ? vncCredentialId
+          : null,
       vncUser: vncUser || null,
       telnetUser: telnetUser || null,
     };
@@ -778,6 +785,8 @@ router.put(
       rdpDomain,
       rdpSecurity,
       rdpIgnoreCert,
+      vncAuthType,
+      vncCredentialId,
       vncPassword,
       vncUser,
       telnetUser,
@@ -898,6 +907,11 @@ router.put(
       rdpDomain: rdpDomain || null,
       rdpSecurity: rdpSecurity || null,
       rdpIgnoreCert: rdpIgnoreCert ? 1 : 0,
+      vncAuthType: enableVnc ? vncAuthType || null : null,
+      vncCredentialId:
+        enableVnc && vncAuthType === "credential" && vncCredentialId
+          ? vncCredentialId
+          : null,
       vncUser: vncUser || null,
       telnetUser: telnetUser || null,
     };
@@ -1254,6 +1268,7 @@ router.get(
           rdpDomain: hosts.rdpDomain,
           rdpSecurity: hosts.rdpSecurity,
           rdpIgnoreCert: hosts.rdpIgnoreCert,
+          vncAuthType: hosts.vncAuthType,
           vncCredentialId: hosts.vncCredentialId,
           vncUser: hosts.vncUser,
           vncPassword: hosts.vncPassword,
@@ -1449,7 +1464,7 @@ router.get(
  *         name: field
  *         schema:
  *           type: string
- *           enum: [password, sudoPassword]
+ *           enum: [password, sudoPassword, vncPassword]
  *     responses:
  *       200:
  *         description: The requested password value.
@@ -1465,7 +1480,7 @@ router.get(
     const userId = (req as AuthenticatedRequest).userId;
     const field = (req.query.field as string) || "password";
 
-    if (!["password", "sudoPassword"].includes(field)) {
+    if (!["password", "sudoPassword", "vncPassword"].includes(field)) {
       return res.status(400).json({ error: "Invalid field" });
     }
 
@@ -1604,6 +1619,8 @@ router.get(
             rdpDomain: resolvedHost.rdpDomain || null,
             rdpSecurity: resolvedHost.rdpSecurity || null,
             rdpIgnoreCert: !!resolvedHost.rdpIgnoreCert,
+            vncAuthType: resolvedHost.vncAuthType || null,
+            vncCredentialId: resolvedHost.vncCredentialId || null,
             vncUser: resolvedHost.vncUser || null,
             vncPassword: resolvedHost.vncPassword || null,
             telnetUser: resolvedHost.telnetUser || null,

--- a/src/ui/api/credentials-api.ts
+++ b/src/ui/api/credentials-api.ts
@@ -96,7 +96,7 @@ export async function getSSHHostWithCredentials(
 
 export async function getHostPassword(
   hostId: number,
-  field: "password" | "sudoPassword" = "password",
+  field: "password" | "sudoPassword" | "vncPassword" = "password",
 ): Promise<string | null> {
   try {
     const response = await sshHostApi.get(

--- a/src/ui/sidebar/HostEditor.tsx
+++ b/src/ui/sidebar/HostEditor.tsx
@@ -34,6 +34,7 @@ import {
   disconnectTunnel,
   getUserInfo,
   getVaultProfiles,
+  getHostPassword,
 } from "@/main-axios";
 import { getTailscaleDevices, getHostDefaults } from "@/api/settings-api";
 import type { Host, VaultProfile } from "@/types/ui-types";
@@ -142,6 +143,22 @@ export function HostEditor({
       .then((d) => setForm(createHostEditorForm(null, d)))
       .catch(() => {});
   }, [host]);
+
+  useEffect(() => {
+    if (!host?.id || form.vncAuthType !== "direct" || form.vncPassword) return;
+
+    let cancelled = false;
+    getHostPassword(Number(host.id), "vncPassword").then((password) => {
+      if (cancelled || !password) return;
+      setForm((prev) =>
+        prev.vncPassword ? prev : { ...prev, vncPassword: password },
+      );
+    });
+
+    return () => {
+      cancelled = true;
+    };
+  }, [form.vncAuthType, form.vncPassword, host?.id]);
 
   useEffect(() => {
     if (activeTab !== "tunnels") return;

--- a/src/ui/sidebar/HostManagerData.ts
+++ b/src/ui/sidebar/HostManagerData.ts
@@ -86,6 +86,8 @@ export function sshHostToHost(h: SSHHostWithStatus): Host {
     domain: h.rdpDomain,
     security: h.rdpSecurity,
     ignoreCert: h.rdpIgnoreCert ?? false,
+    vncAuthType: h.vncAuthType ?? (h.vncCredentialId ? "credential" : "direct"),
+    vncCredentialId: h.vncCredentialId ?? null,
     vncPassword: h.vncPassword ?? "",
     vncUser: h.vncUser,
     telnetUser: h.telnetUser,

--- a/src/ui/sidebar/SidebarTree.tsx
+++ b/src/ui/sidebar/SidebarTree.tsx
@@ -1888,6 +1888,8 @@ export function SidebarTree({
         rdpDomain: host.domain ?? null,
         rdpSecurity: host.security ?? null,
         rdpIgnoreCert: host.ignoreCert ?? false,
+        vncAuthType: host.vncAuthType ?? null,
+        vncCredentialId: host.vncCredentialId ?? null,
         vncPassword: host.vncPassword ?? null,
         vncUser: host.vncUser ?? null,
         telnetUser: host.telnetUser ?? null,


### PR DESCRIPTION
## Summary
- Persist VNC auth mode and selected credential IDs when creating or updating hosts
- Return and map VNC auth metadata so the editor and sharing UI reopen with the saved credential selection
- Reuse the protected password endpoint to repopulate direct VNC passwords when editing a host

Fixes Termix-SSH/Support#855

## Verification
- npx prettier --check src/backend/database/routes/host.ts src/ui/api/credentials-api.ts src/ui/sidebar/HostEditor.tsx src/ui/sidebar/HostManagerData.ts src/ui/sidebar/SidebarTree.tsx
- npx eslint src/backend/database/routes/host.ts src/ui/api/credentials-api.ts src/ui/sidebar/HostEditor.tsx src/ui/sidebar/HostManagerData.ts src/ui/sidebar/SidebarTree.tsx
- npm run type-check
- git diff --check

## Build note
- npm run build still fails before this change completes because src/ui/index.css cannot resolve @fontsource/jetbrains-mono/400.css in the current checkout.