### PR TITLE
Fix Guacamole websocket base path behind reverse proxies

### DIFF
--- a/src/ui/features/guacamole/GuacamoleDisplay.test.ts
+++ b/src/ui/features/guacamole/GuacamoleDisplay.test.ts
@@ -1,0 +1,68 @@
+import { describe, expect, it } from "vitest";
+import { buildGuacamoleWebSocketBaseUrl } from "./guacamole-websocket-url.js";
+
+const httpsLocation = {
+  protocol: "https:",
+  host: "termix.example.com",
+} as Location;
+
+describe("buildGuacamoleWebSocketBaseUrl", () => {
+  it("uses the same origin guacamole websocket path in production web builds", () => {
+    expect(
+      buildGuacamoleWebSocketBaseUrl({
+        isDev: false,
+        isElectronApp: false,
+        isEmbeddedApp: false,
+        basePath: "",
+        location: httpsLocation,
+      }),
+    ).toBe("wss://termix.example.com/guacamole/websocket/");
+  });
+
+  it("preserves the runtime base path for proxied web deployments", () => {
+    expect(
+      buildGuacamoleWebSocketBaseUrl({
+        isDev: false,
+        isElectronApp: false,
+        isEmbeddedApp: false,
+        basePath: "/termix",
+        location: httpsLocation,
+      }),
+    ).toBe("wss://termix.example.com/termix/guacamole/websocket/");
+  });
+
+  it("keeps direct local websocket access for development and embedded electron", () => {
+    expect(
+      buildGuacamoleWebSocketBaseUrl({
+        isDev: true,
+        isElectronApp: false,
+        isEmbeddedApp: false,
+        basePath: "/termix",
+        location: httpsLocation,
+      }),
+    ).toBe("ws://localhost:30008");
+
+    expect(
+      buildGuacamoleWebSocketBaseUrl({
+        isDev: false,
+        isElectronApp: true,
+        isEmbeddedApp: true,
+        basePath: "/termix",
+        location: httpsLocation,
+      }),
+    ).toBe("ws://127.0.0.1:30008");
+  });
+
+  it("uses the configured remote server URL for electron remote mode", () => {
+    expect(
+      buildGuacamoleWebSocketBaseUrl({
+        isDev: false,
+        isElectronApp: true,
+        isEmbeddedApp: false,
+        configuredServerUrl: "https://termix.example.com/termix/",
+        basePath: "",
+        location: httpsLocation,
+      }),
+    ).toBe("wss://termix.example.com/termix/guacamole/websocket/");
+  });
+});

--- a/src/ui/features/guacamole/GuacamoleDisplay.tsx
+++ b/src/ui/features/guacamole/GuacamoleDisplay.tsx
@@ -10,6 +10,8 @@ import Guacamole from "guacamole-common-js";
 import { useTranslation } from "react-i18next";
 import { getGuacamoleToken, isElectron, isEmbeddedMode } from "@/main-axios.ts";
 import { SimpleLoader } from "@/lib/SimpleLoader.tsx";
+import { getBasePath } from "@/lib/base-path.ts";
+import { buildGuacamoleWebSocketBaseUrl } from "./guacamole-websocket-url.ts";
 
 export type GuacamoleConnectionType = "rdp" | "vnc" | "telnet";
 
@@ -138,29 +140,15 @@ export const GuacamoleDisplay = forwardRef<
         const width = connectionConfig.width ?? containerWidth ?? 1280;
         const height = connectionConfig.height ?? containerHeight ?? 720;
 
-        const wsBase = isDev
-          ? `ws://localhost:30008`
-          : isElectron()
-            ? (() => {
-                const configuredUrl = (
-                  window as { configuredServerUrl?: string }
-                ).configuredServerUrl;
-
-                // Embedded mode or no configured remote server: connect directly
-                // to the local guacamole websocket service.
-                if (isEmbeddedMode() || !configuredUrl) {
-                  return "ws://127.0.0.1:30008";
-                }
-
-                const wsProtocol = configuredUrl.startsWith("https://")
-                  ? "wss://"
-                  : "ws://";
-                const wsHost = configuredUrl
-                  .replace(/^https?:\/\//, "")
-                  .replace(/\/$/, "");
-                return `${wsProtocol}${wsHost}/guacamole/websocket/`;
-              })()
-            : `${window.location.protocol === "https:" ? "wss" : "ws"}://${window.location.host}/guacamole/websocket/`;
+        const wsBase = buildGuacamoleWebSocketBaseUrl({
+          isDev,
+          isElectronApp: isElectron(),
+          isEmbeddedApp: isEmbeddedMode(),
+          configuredServerUrl: (window as { configuredServerUrl?: string })
+            .configuredServerUrl,
+          basePath: getBasePath(),
+          location: window.location,
+        });
 
         const params = new URLSearchParams({
           token,

--- a/src/ui/features/guacamole/guacamole-websocket-url.ts
+++ b/src/ui/features/guacamole/guacamole-websocket-url.ts
@@ -1,0 +1,31 @@
+export function buildGuacamoleWebSocketBaseUrl({
+  isDev,
+  isElectronApp,
+  isEmbeddedApp,
+  configuredServerUrl,
+  basePath,
+  location,
+}: {
+  isDev: boolean;
+  isElectronApp: boolean;
+  isEmbeddedApp: boolean;
+  configuredServerUrl?: string;
+  basePath: string;
+  location: Pick<Location, "protocol" | "host">;
+}) {
+  if (isDev) return "ws://localhost:30008";
+  if (isElectronApp) {
+    if (isEmbeddedApp || !configuredServerUrl) return "ws://127.0.0.1:30008";
+
+    const wsProtocol = configuredServerUrl.startsWith("https://")
+      ? "wss://"
+      : "ws://";
+    const wsHost = configuredServerUrl
+      .replace(/^https?:\/\//, "")
+      .replace(/\/$/, "");
+    return `${wsProtocol}${wsHost}/guacamole/websocket/`;
+  }
+
+  const wsProtocol = location.protocol === "https:" ? "wss" : "ws";
+  return `${wsProtocol}://${location.host}${basePath}/guacamole/websocket/`;
+}


### PR DESCRIPTION
## Summary
- move Guacamole websocket URL construction into a shared helper
- include the runtime base path for production web deployments
- keep existing dev, embedded Electron, and configured remote Electron websocket behavior

## Tests
- npm run test -- src/ui/features/guacamole/GuacamoleDisplay.test.ts src/ui/lib/base-path.test.ts
- ./node_modules/.bin/eslint src/ui/features/guacamole/GuacamoleDisplay.tsx src/ui/features/guacamole/GuacamoleDisplay.test.ts src/ui/features/guacamole/guacamole-websocket-url.ts
- ./node_modules/.bin/prettier --check src/ui/features/guacamole/GuacamoleDisplay.tsx src/ui/features/guacamole/GuacamoleDisplay.test.ts src/ui/features/guacamole/guacamole-websocket-url.ts
- npm run type-check
- npm run build

Fixes Termix-SSH/Support#848