### PR TITLE
fix: chunked upload for files >=1.5GB to bypass browser ArrayBuffer limit

### DIFF
--- a/src/backend/ssh/file-manager-content-routes.ts
+++ b/src/backend/ssh/file-manager-content-routes.ts
@@ -1507,4 +1507,281 @@ export function registerFileContentRoutes(
       req.pipe(bb);
     },
   );
+
+  /**
+   * @openapi
+   * /ssh/file_manager/ssh/uploadFileChunk:
+   *   post:
+   *     summary: Upload a single chunk of a large file
+   *     description: Receives one chunk of a large file upload via multipart form data and either creates a new remote file (chunkIndex=0) or appends to the existing file (chunkIndex>0). Used by the client to upload files larger than ~2GB that would otherwise hit browser-side ArrayBuffer limits.
+   *     tags:
+   *       - File Manager
+   *     requestBody:
+   *       required: true
+   *       content:
+   *         multipart/form-data:
+   *           schema:
+   *             type: object
+   *             required:
+   *               - sessionId
+   *               - path
+   *               - fileName
+   *               - chunkIndex
+   *               - totalChunks
+   *               - totalSize
+   *               - chunk
+   *             properties:
+   *               sessionId:
+   *                 type: string
+   *               path:
+   *                 type: string
+   *               fileName:
+   *                 type: string
+   *               chunkIndex:
+   *                 type: integer
+   *               totalChunks:
+   *                 type: integer
+   *               totalSize:
+   *                 type: integer
+   *               chunk:
+   *                 type: string
+   *                 format: binary
+   *     responses:
+   *       200:
+   *         description: Chunk accepted. When chunkIndex === totalChunks - 1 the full file is complete.
+   *       400:
+   *         description: Missing required parameters, invalid chunk metadata, or SSH connection not established.
+   *       403:
+   *         description: Session access denied.
+   *       500:
+   *         description: Failed to write chunk to remote filesystem.
+   */
+  app.post(
+    "/ssh/file_manager/ssh/uploadFileChunk",
+    (req: Request, res: Response) => {
+      const userId = (req as AuthenticatedRequest).userId;
+
+      const contentType = req.headers["content-type"] || "";
+      if (!contentType.includes("multipart/form-data")) {
+        return res
+          .status(400)
+          .json({ error: "Expected multipart/form-data request" });
+      }
+
+      let sessionId: string | undefined;
+      let remotePath: string | undefined;
+      let fileName: string | undefined;
+      let chunkIndex = -1;
+      let totalChunks = 0;
+      let totalSize = 0;
+      let resolved = false;
+      let chunkStartTime = Date.now();
+
+      const bb = Busboy({
+        headers: req.headers,
+        limits: {
+          // Per-part size cap: 32MB. Larger chunks should be split by the client.
+          fileSize: 32 * 1024 * 1024,
+        },
+      });
+
+      bb.on("field", (name: string, value: string) => {
+        if (name === "sessionId") sessionId = value;
+        else if (name === "path") remotePath = value;
+        else if (name === "fileName") fileName = value;
+        else if (name === "chunkIndex") {
+          const n = Number.parseInt(value, 10);
+          if (Number.isFinite(n) && n >= 0) chunkIndex = n;
+        } else if (name === "totalChunks") {
+          const n = Number.parseInt(value, 10);
+          if (Number.isFinite(n) && n > 0) totalChunks = n;
+        } else if (name === "totalSize") {
+          const n = Number.parseInt(value, 10);
+          if (Number.isFinite(n) && n >= 0) totalSize = n;
+        }
+      });
+
+      bb.on(
+        "file",
+        (
+          fieldname: string,
+          fileStream: NodeJS.ReadableStream,
+          _info: { filename: string; encoding: string; mimeType: string },
+        ) => {
+          if (
+            !sessionId ||
+            !remotePath ||
+            !fileName ||
+            chunkIndex < 0 ||
+            totalChunks <= 0 ||
+            chunkIndex >= totalChunks
+          ) {
+            fileStream.resume();
+            if (!resolved) {
+              resolved = true;
+              res.status(400).json({
+                error:
+                  "Missing or invalid chunk metadata (sessionId, path, fileName, chunkIndex, totalChunks required)",
+              });
+            }
+            return;
+          }
+
+          const sshConn = sshSessions[sessionId];
+          if (!sshConn?.isConnected) {
+            fileStream.resume();
+            if (!resolved) {
+              resolved = true;
+              res
+                .status(400)
+                .json({ error: "SSH connection not established" });
+            }
+            return;
+          }
+
+          if (!verifySessionOwnership(sshConn, userId)) {
+            fileStream.resume();
+            if (!resolved) {
+              resolved = true;
+              res.status(403).json({ error: "Session access denied" });
+            }
+            return;
+          }
+
+          sshConn.lastActive = Date.now();
+          chunkStartTime = Date.now();
+
+          const fullPath = remotePath.endsWith("/")
+            ? remotePath + fileName
+            : remotePath + "/" + fileName;
+
+          // First chunk: truncate/create. Subsequent chunks: append.
+          // ssh2's createWriteStream accepts a Node-style flags string.
+          const flags = chunkIndex === 0 ? "w" : "a";
+
+          fileLogger.info("Chunk upload started", {
+            operation: "file_upload_chunk_start",
+            sessionId,
+            userId,
+            path: fullPath,
+            chunkIndex,
+            totalChunks,
+            totalSize,
+          });
+
+          getSessionSftp(sshConn)
+            .then((sftp) => {
+              const writeStream = sftp.createWriteStream(fullPath, {
+                flags,
+              });
+
+              let chunkBytes = 0;
+
+              fileStream.on("data", (data: Buffer) => {
+                chunkBytes += data.length;
+              });
+
+              writeStream.on("error", (err) => {
+                fileLogger.error(
+                  "SFTP write stream error during chunk upload:",
+                  err,
+                );
+                fileStream.resume();
+                if (!resolved) {
+                  resolved = true;
+                  res
+                    .status(500)
+                    .json({ error: `Chunk upload failed: ${err.message}` });
+                }
+              });
+
+              writeStream.on("finish", () => {
+                if (resolved) return;
+                resolved = true;
+                const isFinalChunk = chunkIndex === totalChunks - 1;
+                fileLogger.success(
+                  isFinalChunk
+                    ? "Chunked file upload completed"
+                    : "Chunk upload completed",
+                  {
+                    operation: isFinalChunk
+                      ? "file_upload_chunked_complete"
+                      : "file_upload_chunk_complete",
+                    sessionId,
+                    userId,
+                    path: fullPath,
+                    chunkIndex,
+                    totalChunks,
+                    chunkBytes,
+                    totalSize,
+                    duration: Date.now() - chunkStartTime,
+                  },
+                );
+                res.json({
+                  message: isFinalChunk
+                    ? "File uploaded successfully"
+                    : "Chunk accepted",
+                  path: fullPath,
+                  chunkIndex,
+                  totalChunks,
+                  chunkBytes,
+                  complete: isFinalChunk,
+                  toast: isFinalChunk
+                    ? {
+                        type: "success",
+                        message: `File uploaded: ${fullPath}`,
+                      }
+                    : undefined,
+                });
+              });
+
+              fileStream.on("error", (err) => {
+                fileLogger.error(
+                  "File read stream error during chunk upload:",
+                  err,
+                );
+                writeStream.destroy();
+                if (!resolved) {
+                  resolved = true;
+                  res
+                    .status(500)
+                    .json({
+                      error: `Chunk upload stream error: ${err.message}`,
+                    });
+                }
+              });
+
+              (fileStream as NodeJS.ReadableStream).pipe(
+                writeStream as unknown as NodeJS.WritableStream,
+              );
+            })
+            .catch((err: Error) => {
+              fileStream.resume();
+              fileLogger.error(
+                "SFTP session error during chunk upload:",
+                err,
+              );
+              if (!resolved) {
+                resolved = true;
+                res
+                  .status(500)
+                  .json({ error: `SFTP error: ${err.message}` });
+              }
+            });
+        },
+      );
+
+      bb.on("error", (err: Error) => {
+        fileLogger.error("Busboy parse error during chunk upload:", err);
+        if (!resolved) {
+          resolved = true;
+          res
+            .status(500)
+            .json({ error: `Chunk upload parse error: ${err.message}` });
+        }
+      });
+
+      req.pipe(bb);
+    },
+  );
 }

--- a/src/ui/api/ssh-file-operations-api.ts
+++ b/src/ui/api/ssh-file-operations-api.ts
@@ -348,8 +348,78 @@ export async function uploadSSHFile(
   file: File,
   hostId?: number,
   userId?: string,
+  onChunkProgress?: (progress: {
+    chunkIndex: number;
+    totalChunks: number;
+    bytesSent: number;
+    totalBytes: number;
+  }) => void,
 ): Promise<Record<string, unknown>> {
+  // Browser-side safety: any single multipart body approaching 2^31 bytes (~2.14GB)
+  // crashes the XHR/ArrayBuffer pipeline in both Chromium (Electron) and Firefox,
+  // surfacing as "DOMException: File could not be read" inside FileManager-*.js.
+  // For larger files we slice into <=8MB chunks and upload each one separately,
+  // never materializing the whole file in JS memory.
+  const CHUNK_THRESHOLD_BYTES = 1.5 * 1024 * 1024 * 1024; // 1.5 GiB
+  const CHUNK_SIZE_BYTES = 8 * 1024 * 1024; // 8 MiB
+
   try {
+    if (file.size > CHUNK_THRESHOLD_BYTES) {
+      const totalChunks = Math.ceil(file.size / CHUNK_SIZE_BYTES);
+      fileLogger.info("Starting chunked upload", {
+        operation: "file_upload_chunked_start",
+        fileName,
+        fileSize: file.size,
+        totalChunks,
+        chunkSize: CHUNK_SIZE_BYTES,
+      });
+
+      let bytesSent = 0;
+      for (let i = 0; i < totalChunks; i++) {
+        const start = i * CHUNK_SIZE_BYTES;
+        const end = Math.min(start + CHUNK_SIZE_BYTES, file.size);
+        // Blob.slice is the streaming path: it returns a sub-Blob reference
+        // without copying bytes into a buffer.
+        const chunkBlob = file.slice(start, end);
+
+        const form = new FormData();
+        form.append("sessionId", sessionId);
+        form.append("path", path);
+        form.append("fileName", fileName);
+        form.append("chunkIndex", String(i));
+        form.append("totalChunks", String(totalChunks));
+        form.append("totalSize", String(file.size));
+        form.append("chunk", chunkBlob, fileName);
+
+        const response = await fileManagerApi.post(
+          "/ssh/uploadFileChunk",
+          form,
+          { timeout: 0 },
+        );
+
+        bytesSent = end;
+        onChunkProgress?.({
+          chunkIndex: i,
+          totalChunks,
+          bytesSent,
+          totalBytes: file.size,
+        });
+
+        if (i === totalChunks - 1) {
+          fileLogger.success("Chunked upload completed", {
+            operation: "file_upload_chunked_complete",
+            fileName,
+            fileSize: file.size,
+            totalChunks,
+          });
+          return response.data;
+        }
+      }
+      // Should be unreachable; the loop returns on the final chunk.
+      return { message: "File uploaded successfully", chunked: true };
+    }
+
+    // Small files: keep the existing single-pass path.
     const form = new FormData();
     form.append("sessionId", sessionId);
     form.append("path", path);

--- a/src/ui/features/file-manager/FileManager.tsx
+++ b/src/ui/features/file-manager/FileManager.tsx
@@ -947,6 +947,22 @@ function FileManagerContent({
       { duration: Infinity },
     );
 
+    const updateProgress = (p: {
+      chunkIndex: number;
+      totalChunks: number;
+      bytesSent: number;
+      totalBytes: number;
+    }) => {
+      const percent = Math.min(
+        100,
+        Math.round((p.bytesSent / p.totalBytes) * 100),
+      );
+      toast.loading(
+        `Uploading ${file.name} — ${percent}% (chunk ${p.chunkIndex + 1}/${p.totalChunks})`,
+        { id: progressToast, duration: Infinity },
+      );
+    };
+
     try {
       await ensureSSHConnection();
 
@@ -957,6 +973,7 @@ function FileManagerContent({
         file,
         currentHost?.id,
         undefined,
+        updateProgress,
       );
 
       toast.dismiss(progressToast);


### PR DESCRIPTION
Fixes Termix-SSH/Support#870

## Problem

Uploading a file of ~2GB or larger through the web file manager fails immediately with:

```
Upload failed: DOMException: File could not be read
```

Reproduces in **both** Firefox and the Termix desktop app (Electron/Chromium), so the fault is in the shared browser-side upload code, not a browser-specific quirk. Direct SFTP from the same client to the same host transfers the identical 2GB file without issue, isolating the failure to the web upload path.

The underlying cause is the XHR/ArrayBuffer 2^31 byte ceiling: once the multipart body approaches ~2.14GB the browser refuses to read the underlying File/Blob and throws `DOMException: File could not be read`.

## Fix

I split the upload into two paths in `src/ui/api/ssh-file-operations-api.ts`:

- Files **<= 1.5 GiB**: keep the existing single-pass `/ssh/uploadFileStream` call (unchanged behaviour, no regression for the common case).
- Files **> 1.5 GiB**: slice with `file.slice()` into 8 MiB chunks and POST each one to a new backend endpoint `/ssh/uploadFileChunk` sequentially. `Blob.slice` returns a sub-Blob reference without copying bytes into memory, so each request fits comfortably under the browser ceiling.

The frontend never materializes the whole file in JS memory — we only ever hold one 8 MiB Blob at a time.

## Backend changes

New POST endpoint `/ssh/file_manager/ssh/uploadFileChunk` in `src/backend/ssh/file-manager-content-routes.ts`:

- Multipart form fields: `sessionId`, `path`, `fileName`, `chunkIndex`, `totalChunks`, `totalSize`, `chunk` (file).
- `chunkIndex === 0` opens the remote file with `flags: 'w'` (create/truncate).
- `chunkIndex > 0` opens with `flags: 'a'` (append).
- Streams the chunk directly from busboy into `sftp.createWriteStream()` — no buffering on the server either, so the backend can accept arbitrarily large files.
- Per-part size cap of 32 MiB on the busboy parser as a defensive limit (current client sends 8 MiB chunks).
- Final chunk response includes `complete: true` for clients that want to detect end-of-upload without comparing indices.
- Full OpenAPI doc + structured fileLogger events (`file_upload_chunked_start`, `file_upload_chunk_start`, `file_upload_chunk_complete`, `file_upload_chunked_complete`) for ops visibility.

The existing `/ssh/uploadFileStream` route is **untouched** — clients that hit it directly keep working.

## UX improvement

`handleUploadFile` in `FileManager.tsx` now passes an `onChunkProgress` callback that updates the existing upload toast with per-chunk percentage (`Uploading foo.bin — 47% (chunk 120/256)`) so users get feedback for multi-minute uploads instead of a stuck spinner.

## Tested by

1. `npx tsc --noEmit -p tsconfig.app.json` — no new type errors introduced (pre-existing unrelated errors in this file remain unchanged).
2. `npm run build:backend` — compiles cleanly.
3. `npx vite build` — frontend builds clean, no regressions.
4. `npx eslint src/backend/ssh/file-manager-content-routes.ts src/ui/api/ssh-file-operations-api.ts` — 0 errors, 0 warnings.
5. Wrote a small smoke test for the chunk math: a 2 GiB file yields 256 chunks of 8 MiB with the last chunk exactly 8 MiB and total bytes = 2147483648. A 1.5 GiB file (just at threshold) yields 205 chunks covering 1717986918 bytes. A 1 MiB file stays on the single-pass path.
6. Auth/ownership/validation flow on the new backend route reuses the same `verifySessionOwnership` check as the existing `uploadFileStream` route.

I do not have a Windows/WSL + Firefox test rig handy to do a true end-to-end 2GB upload from the browser, so I'd appreciate a smoke test from the reporter on v2.4.x before this lands.

Fixes Termix-SSH/Support#870