### PR TITLE
Fix tmux detection on non-login SSH shells

### DIFF
--- a/src/backend/ssh/tmux-helper.test.ts
+++ b/src/backend/ssh/tmux-helper.test.ts
@@ -1,0 +1,20 @@
+import { describe, expect, it } from "vitest";
+import { tmuxCommand, withTmuxPath } from "./tmux-helper.js";
+
+describe("tmux command path handling", () => {
+  it("adds common non-login shell tmux paths", () => {
+    const command = withTmuxPath("command -v tmux");
+
+    expect(command).toContain("/opt/homebrew/bin");
+    expect(command).toContain("/usr/local/bin");
+    expect(command).toContain("/opt/bin");
+    expect(command).toContain("/usr/pkg/bin");
+    expect(command).toContain(":$PATH; command -v tmux");
+  });
+
+  it("wraps tmux invocations with the same path", () => {
+    expect(tmuxCommand("list-sessions")).toMatch(
+      /^PATH=.*:\$PATH; tmux list-sessions$/,
+    );
+  });
+});

--- a/src/backend/ssh/tmux-helper.ts
+++ b/src/backend/ssh/tmux-helper.ts
@@ -14,6 +14,21 @@ export interface TmuxDetectionResult {
   sessions: TmuxSessionInfo[];
 }
 
+const TMUX_PATH_DIRS = [
+  "/opt/homebrew/bin",
+  "/usr/local/bin",
+  "/opt/bin",
+  "/usr/pkg/bin",
+];
+
+export function withTmuxPath(command: string): string {
+  return `PATH=${TMUX_PATH_DIRS.join(":")}:$PATH; ${command}`;
+}
+
+export function tmuxCommand(args: string): string {
+  return withTmuxPath(`tmux ${args}`);
+}
+
 /**
  * Run a command on the remote host via a separate exec channel.
  * Returns stdout as a string. Does not pollute the interactive shell.
@@ -54,7 +69,7 @@ export function execCommand(conn: Client, command: string): Promise<string> {
  */
 export async function detectTmux(conn: Client): Promise<TmuxDetectionResult> {
   try {
-    await execCommand(conn, "command -v tmux");
+    await execCommand(conn, withTmuxPath("command -v tmux"));
   } catch {
     return { available: false, sessions: [] };
   }
@@ -63,7 +78,9 @@ export async function detectTmux(conn: Client): Promise<TmuxDetectionResult> {
   try {
     const output = await execCommand(
       conn,
-      `tmux list-sessions -F "#{session_name}|#{session_created}|#{session_activity}|#{session_windows}|#{session_attached}" 2>/dev/null`,
+      tmuxCommand(
+        `list-sessions -F "#{session_name}|#{session_created}|#{session_activity}|#{session_windows}|#{session_attached}" 2>/dev/null`,
+      ),
     );
     if (output) {
       sessions = output
@@ -126,7 +143,7 @@ export async function waitForTmuxSession(
     try {
       await execCommand(
         conn,
-        `tmux has-session -t ${shellEscape(sessionName)} 2>/dev/null`,
+        tmuxCommand(`has-session -t ${shellEscape(sessionName)} 2>/dev/null`),
       );
       return sessionName;
     } catch {
@@ -148,10 +165,10 @@ export function attachOrCreateTmuxSession(
 ): void {
   let command: string;
   if (existingSessionName) {
-    command = `tmux ${TMUX_OPTS} \\; attach-session -t ${shellEscape(existingSessionName)} && exit\r`;
+    command = `${tmuxCommand(`${TMUX_OPTS} \\; attach-session -t ${shellEscape(existingSessionName)}`)} && exit\r`;
   } else {
     const nameFlag = newSessionName ? ` -s ${shellEscape(newSessionName)}` : "";
-    command = `tmux ${TMUX_OPTS} \\; new-session${nameFlag} && exit\r`;
+    command = `${tmuxCommand(`${TMUX_OPTS} \\; new-session${nameFlag}`)} && exit\r`;
   }
 
   sshLogger.info("Writing tmux command to shell", {
@@ -172,7 +189,9 @@ export async function queryNewestTmuxSession(
   try {
     const output = await execCommand(
       conn,
-      `tmux list-sessions -F "#{session_created}:#{session_name}" 2>/dev/null | sort -rn | head -1 | cut -d: -f2-`,
+      tmuxCommand(
+        `list-sessions -F "#{session_created}:#{session_name}" 2>/dev/null | sort -rn | head -1 | cut -d: -f2-`,
+      ),
     );
     return output || null;
   } catch {

--- a/src/backend/ssh/tmux-monitor.ts
+++ b/src/backend/ssh/tmux-monitor.ts
@@ -19,7 +19,7 @@ import {
   type SOCKS5Config,
 } from "../utils/socks5-helper.js";
 import { withConnection } from "./ssh-connection-pool.js";
-import { execCommand } from "./tmux-helper.js";
+import { execCommand, tmuxCommand, withTmuxPath } from "./tmux-helper.js";
 import {
   SEP,
   parseSessions,
@@ -219,7 +219,7 @@ async function withHostConnection<T>(
 
 async function tmuxAvailable(conn: Client): Promise<boolean> {
   try {
-    await execCommand(conn, "command -v tmux");
+    await execCommand(conn, withTmuxPath("command -v tmux"));
     return true;
   } catch {
     return false;
@@ -235,15 +235,21 @@ async function runTmuxList(conn: Client, command: string): Promise<string> {
 }
 
 function listSessionsCmd(): string {
-  return `tmux list-sessions -F "#{session_name}${SEP}#{session_created}${SEP}#{session_activity}${SEP}#{session_attached}" 2>/dev/null`;
+  return tmuxCommand(
+    `list-sessions -F "#{session_name}${SEP}#{session_created}${SEP}#{session_activity}${SEP}#{session_attached}" 2>/dev/null`,
+  );
 }
 
 function listWindowsCmd(): string {
-  return `tmux list-windows -a -F "#{session_name}${SEP}#{window_index}${SEP}#{window_active}${SEP}#{window_name}" 2>/dev/null`;
+  return tmuxCommand(
+    `list-windows -a -F "#{session_name}${SEP}#{window_index}${SEP}#{window_active}${SEP}#{window_name}" 2>/dev/null`,
+  );
 }
 
 function listPanesCmd(): string {
-  return `tmux list-panes -a -F "#{session_name}${SEP}#{window_index}${SEP}#{pane_id}${SEP}#{pane_index}${SEP}#{pane_pid}${SEP}#{pane_active}${SEP}#{pane_width}${SEP}#{pane_height}${SEP}#{pane_current_command}${SEP}#{pane_current_path}${SEP}#{pane_title}" 2>/dev/null`;
+  return tmuxCommand(
+    `list-panes -a -F "#{session_name}${SEP}#{window_index}${SEP}#{pane_id}${SEP}#{pane_index}${SEP}#{pane_pid}${SEP}#{pane_active}${SEP}#{pane_width}${SEP}#{pane_height}${SEP}#{pane_current_command}${SEP}#{pane_current_path}${SEP}#{pane_title}" 2>/dev/null`,
+  );
 }
 
 async function listPanesRaw(conn: Client): Promise<RawPane[]> {
@@ -504,7 +510,9 @@ app.post("/tmux_monitor/:hostId/focus", async (req, res) => {
       // containing the pane.
       execCommand(
         conn,
-        `tmux select-window -t ${shellEscape(paneId)} \\; select-pane -t ${shellEscape(paneId)}`,
+        tmuxCommand(
+          `select-window -t ${shellEscape(paneId)} \\; select-pane -t ${shellEscape(paneId)}`,
+        ),
       ),
     );
     res.json({ ok: true });
@@ -525,7 +533,7 @@ app.post("/tmux_monitor/:hostId/sessions", async (req, res) => {
 
   try {
     await withHostConnection(host, (conn) =>
-      execCommand(conn, `tmux new-session -d -s ${shellEscape(name)}`),
+      execCommand(conn, tmuxCommand(`new-session -d -s ${shellEscape(name)}`)),
     );
     sshLogger.info("tmux session created", {
       operation: "tmux_session_create",
@@ -560,7 +568,10 @@ app.post("/tmux_monitor/:hostId/windows", async (req, res) => {
 
   try {
     await withHostConnection(host, (conn) =>
-      execCommand(conn, `tmux new-window -t ${shellEscape(`=${sessionName}`)}`),
+      execCommand(
+        conn,
+        tmuxCommand(`new-window -t ${shellEscape(`=${sessionName}`)}`),
+      ),
     );
     sshLogger.info("tmux window created", {
       operation: "tmux_window_create",
@@ -596,7 +607,9 @@ app.post("/tmux_monitor/:hostId/rename", async (req, res) => {
     await withHostConnection(host, (conn) =>
       execCommand(
         conn,
-        `tmux rename-session -t ${shellEscape(`=${sessionName}`)} ${shellEscape(newName)}`,
+        tmuxCommand(
+          `rename-session -t ${shellEscape(`=${sessionName}`)} ${shellEscape(newName)}`,
+        ),
       ),
     );
     await getDb()
@@ -648,7 +661,7 @@ app.post("/tmux_monitor/:hostId/kill", async (req, res) => {
     await withHostConnection(host, (conn) =>
       execCommand(
         conn,
-        `tmux kill-session -t ${shellEscape(`=${sessionName}`)}`,
+        tmuxCommand(`kill-session -t ${shellEscape(`=${sessionName}`)}`),
       ),
     );
     await getDb()
@@ -695,7 +708,9 @@ app.post("/tmux_monitor/:hostId/kill-window", async (req, res) => {
     await withHostConnection(host, (conn) =>
       execCommand(
         conn,
-        `tmux kill-window -t ${shellEscape(`=${sessionName}:${windowIndex}`)}`,
+        tmuxCommand(
+          `kill-window -t ${shellEscape(`=${sessionName}:${windowIndex}`)}`,
+        ),
       ),
     );
     sshLogger.info("tmux window killed", {
@@ -733,7 +748,7 @@ app.post("/tmux_monitor/:hostId/kill-pane", async (req, res) => {
 
   try {
     await withHostConnection(host, (conn) =>
-      execCommand(conn, `tmux kill-pane -t ${shellEscape(paneId)}`),
+      execCommand(conn, tmuxCommand(`kill-pane -t ${shellEscape(paneId)}`)),
     );
     sshLogger.info("tmux pane killed", {
       operation: "tmux_pane_kill",
@@ -771,7 +786,9 @@ app.post("/tmux_monitor/:hostId/split", async (req, res) => {
     await withHostConnection(host, (conn) =>
       execCommand(
         conn,
-        `tmux split-window ${direction} -t ${shellEscape(paneId)} -c ${shellEscape("#{pane_current_path}")}`,
+        tmuxCommand(
+          `split-window ${direction} -t ${shellEscape(paneId)} -c ${shellEscape("#{pane_current_path}")}`,
+        ),
       ),
     );
     sshLogger.info("tmux pane split", {
@@ -819,7 +836,9 @@ app.get("/tmux_monitor/:hostId/search", async (req, res) => {
             try {
               const output = await execCommand(
                 conn,
-                `tmux capture-pane -p -J -t ${shellEscape(pane.id)} -S -${SEARCH_HISTORY_LINES} 2>/dev/null | grep -n -i -F -- ${shellEscape(query)} | head -${MAX_MATCHES_PER_PANE}`,
+                tmuxCommand(
+                  `capture-pane -p -J -t ${shellEscape(pane.id)} -S -${SEARCH_HISTORY_LINES} 2>/dev/null | grep -n -i -F -- ${shellEscape(query)} | head -${MAX_MATCHES_PER_PANE}`,
+                ),
               );
               const lines = output.split("\n").filter(Boolean);
               if (lines.length >= MAX_MATCHES_PER_PANE) truncated = true;


### PR DESCRIPTION
## Summary
- add a shared tmux command wrapper that prepends common non-login shell paths
- use the wrapper for auto-tmux detection, session polling, and interactive attach/create commands
- apply the same path handling to tmux monitor detection and actions
- add unit coverage for the tmux path wrapper

Fixes Termix-SSH/Support#891.

## Tests
- git diff --check
- npx prettier --check src/backend/ssh/tmux-helper.ts src/backend/ssh/tmux-monitor.ts src/backend/ssh/tmux-helper.test.ts
- npx eslint src/backend/ssh/tmux-helper.ts src/backend/ssh/tmux-monitor.ts src/backend/ssh/tmux-helper.test.ts
- npx vitest run src/backend/ssh/tmux-helper.test.ts
- npm run build:backend (fails on existing unrelated missing serialport types: src/backend/serial/serial.ts imports serialport)