### PR TITLE
Fix jump host SOCKS5 proxy selection

### DIFF
--- a/src/backend/ssh/docker.ts
+++ b/src/backend/ssh/docker.ts
@@ -20,6 +20,7 @@ import type { LogEntry, ConnectionStage } from "../../types/connection-log.js";
 import { SSHHostKeyVerifier } from "./host-key-verifier.js";
 import { registerDockerContainerRoutes } from "./docker-container-routes.js";
 import { preparePrivateKeyForSSH2 } from "../utils/ssh-key-utils.js";
+import { getJumpHostSocks5Config } from "./jump-host-proxy.js";
 
 const sshLogger = logger;
 
@@ -254,13 +255,17 @@ async function createJumpHostChain(
       }
     }
 
+    const firstHopSocks5Config = getJumpHostSocks5Config(
+      jumpHostConfigs[0],
+      socks5Config,
+    );
     let proxySocket: import("net").Socket | null = null;
-    if (socks5Config?.useSocks5) {
+    if (firstHopSocks5Config?.useSocks5) {
       const firstHop = jumpHostConfigs[0]!;
       proxySocket = await createSocks5Connection(
         firstHop.ip,
         firstHop.port || 22,
-        socks5Config,
+        firstHopSocks5Config,
       );
     }
 

--- a/src/backend/ssh/docker.ts
+++ b/src/backend/ssh/docker.ts
@@ -135,6 +135,12 @@ interface JumpHostConfig {
   keyType?: string;
   authType?: string;
   credentialId?: number;
+  useSocks5?: boolean | null;
+  socks5Host?: string | null;
+  socks5Port?: number | null;
+  socks5Username?: string | null;
+  socks5Password?: string | null;
+  socks5ProxyChain?: string | import("../../types/index.js").ProxyNode[] | null;
   [key: string]: unknown;
 }
 

--- a/src/backend/ssh/host-metrics-jump-hosts.ts
+++ b/src/backend/ssh/host-metrics-jump-hosts.ts
@@ -23,6 +23,12 @@ interface JumpHostConfig {
   keyType?: string;
   authType?: string;
   credentialId?: number;
+  useSocks5?: boolean | null;
+  socks5Host?: string | null;
+  socks5Port?: number | null;
+  socks5Username?: string | null;
+  socks5Password?: string | null;
+  socks5ProxyChain?: string | import("../../types/index.js").ProxyNode[] | null;
   [key: string]: unknown;
 }
 

--- a/src/backend/ssh/host-metrics-jump-hosts.ts
+++ b/src/backend/ssh/host-metrics-jump-hosts.ts
@@ -10,6 +10,7 @@ import {
 import { getDb } from "../database/db/index.js";
 import { hosts, sshCredentials } from "../database/db/schema.js";
 import { SSHHostKeyVerifier } from "./host-key-verifier.js";
+import { getJumpHostSocks5Config } from "./jump-host-proxy.js";
 
 interface JumpHostConfig {
   id: number;
@@ -145,13 +146,17 @@ export async function createJumpHostChain(
       }
     }
 
+    const firstHopSocks5Config = getJumpHostSocks5Config(
+      jumpHostConfigs[0],
+      socks5Config,
+    );
     let proxySocket: import("net").Socket | null = null;
-    if (socks5Config?.useSocks5) {
+    if (firstHopSocks5Config?.useSocks5) {
       const firstHop = jumpHostConfigs[0]!;
       proxySocket = await createSocks5Connection(
         firstHop.ip,
         firstHop.port || 22,
-        socks5Config,
+        firstHopSocks5Config,
       );
     }
 

--- a/src/backend/ssh/jump-host-chain.ts
+++ b/src/backend/ssh/jump-host-chain.ts
@@ -10,6 +10,7 @@ import {
 import { SSH_ALGORITHMS } from "../utils/ssh-algorithms.js";
 import { SimpleDBOps } from "../utils/simple-db-ops.js";
 import { SSHHostKeyVerifier } from "./host-key-verifier.js";
+import { getJumpHostSocks5Config } from "./jump-host-proxy.js";
 
 type JumpHostConfig = {
   id: number;
@@ -145,13 +146,17 @@ export async function createJumpHostChain(
       }
     }
 
+    const firstHopSocks5Config = getJumpHostSocks5Config(
+      jumpHostConfigs[0],
+      socks5Config,
+    );
     let proxySocket: import("net").Socket | null = null;
-    if (socks5Config?.useSocks5) {
+    if (firstHopSocks5Config?.useSocks5) {
       const firstHop = jumpHostConfigs[0]!;
       proxySocket = await createSocks5Connection(
         firstHop.ip,
         firstHop.port || 22,
-        socks5Config,
+        firstHopSocks5Config,
       );
     }
 

--- a/src/backend/ssh/jump-host-chain.ts
+++ b/src/backend/ssh/jump-host-chain.ts
@@ -23,6 +23,12 @@ type JumpHostConfig = {
   keyType?: string;
   authType?: string;
   credentialId?: number;
+  useSocks5?: boolean | null;
+  socks5Host?: string | null;
+  socks5Port?: number | null;
+  socks5Username?: string | null;
+  socks5Password?: string | null;
+  socks5ProxyChain?: string | import("../../types/index.js").ProxyNode[] | null;
   [key: string]: unknown;
 };
 

--- a/src/backend/ssh/jump-host-proxy.ts
+++ b/src/backend/ssh/jump-host-proxy.ts
@@ -1,0 +1,51 @@
+import type { ProxyNode } from "../../types/index.js";
+import type { SOCKS5Config } from "../utils/socks5-helper.js";
+
+type JumpHostProxyConfig = {
+  useSocks5?: boolean | null;
+  socks5Host?: string | null;
+  socks5Port?: number | null;
+  socks5Username?: string | null;
+  socks5Password?: string | null;
+  socks5ProxyChain?: ProxyNode[] | string | null;
+};
+
+function parseProxyChain(value: JumpHostProxyConfig["socks5ProxyChain"]) {
+  if (Array.isArray(value)) {
+    return value;
+  }
+
+  if (typeof value !== "string" || value.length === 0) {
+    return [];
+  }
+
+  try {
+    const parsed = JSON.parse(value);
+    return Array.isArray(parsed) ? (parsed as ProxyNode[]) : [];
+  } catch {
+    return [];
+  }
+}
+
+export function getJumpHostSocks5Config(
+  firstHop: JumpHostProxyConfig | null | undefined,
+  fallbackConfig?: SOCKS5Config | null,
+): SOCKS5Config | null {
+  if (!firstHop?.useSocks5) {
+    return fallbackConfig ?? null;
+  }
+
+  const socks5ProxyChain = parseProxyChain(firstHop.socks5ProxyChain);
+  if (!firstHop.socks5Host && socks5ProxyChain.length === 0) {
+    return fallbackConfig ?? null;
+  }
+
+  return {
+    useSocks5: true,
+    socks5Host: firstHop.socks5Host ?? undefined,
+    socks5Port: firstHop.socks5Port ?? undefined,
+    socks5Username: firstHop.socks5Username ?? undefined,
+    socks5Password: firstHop.socks5Password ?? undefined,
+    socks5ProxyChain,
+  };
+}

--- a/src/backend/ssh/terminal-jump-hosts.ts
+++ b/src/backend/ssh/terminal-jump-hosts.ts
@@ -10,6 +10,7 @@ import {
   type SOCKS5Config,
 } from "../utils/socks5-helper.js";
 import { SSHHostKeyVerifier } from "./host-key-verifier.js";
+import { getJumpHostSocks5Config } from "./jump-host-proxy.js";
 
 const { Client } = ssh2Pkg;
 
@@ -149,13 +150,17 @@ export async function createJumpHostChain(
       }
     }
 
+    const firstHopSocks5Config = getJumpHostSocks5Config(
+      jumpHostConfigs[0],
+      socks5Config,
+    );
     let proxySocket: import("net").Socket | null = null;
-    if (socks5Config?.useSocks5) {
+    if (firstHopSocks5Config?.useSocks5) {
       const firstHop = jumpHostConfigs[0];
       proxySocket = await createSocks5Connection(
         firstHop.ip,
         firstHop.port || 22,
-        socks5Config,
+        firstHopSocks5Config,
       );
     }
 

--- a/src/backend/ssh/terminal-jump-hosts.ts
+++ b/src/backend/ssh/terminal-jump-hosts.ts
@@ -25,6 +25,12 @@ interface JumpHostConfig {
   keyType?: string;
   authType?: string;
   credentialId?: number;
+  useSocks5?: boolean | null;
+  socks5Host?: string | null;
+  socks5Port?: number | null;
+  socks5Username?: string | null;
+  socks5Password?: string | null;
+  socks5ProxyChain?: string | import("../../types/index.js").ProxyNode[] | null;
   [key: string]: unknown;
 }
 


### PR DESCRIPTION
## Summary
- prefer the first jump host's SOCKS5 settings when opening the first hop
- keep the destination host proxy config as a fallback for existing setups
- apply the same behavior across terminal, file transfer/shared jump chains, metrics, and Docker SSH paths

## Test
- npm run type-check

Part of Termix-SSH/Support#894