### PR TITLE
Support GUACD_URL environment config

### DIFF
--- a/src/backend/database/db/index.ts
+++ b/src/backend/database/db/index.ts
@@ -8,6 +8,7 @@ import { DatabaseFileEncryption } from "../../utils/database-file-encryption.js"
 import { SystemCrypto } from "../../utils/system-crypto.js";
 import { DatabaseMigration } from "../../utils/database-migration.js";
 import { DatabaseSaveTrigger } from "../../utils/database-save-trigger.js";
+import { getDefaultGuacdUrl } from "../../utils/guacd-config.js";
 
 const dataDir = process.env.DATA_DIR || "./db/data";
 const dbDir = path.resolve(dataDir);
@@ -636,12 +637,11 @@ async function initializeCompleteDatabase(): Promise<void> {
       .prepare("SELECT value FROM settings WHERE key = 'guac_url'")
       .get();
     if (!row) {
-      const defaultGuacUrl = `${process.env.GUACD_HOST || "localhost"}:${process.env.GUACD_PORT || "4822"}`;
       sqlite
         .prepare(
           "INSERT INTO settings (key, value) VALUES ('guac_url', ?)",
         )
-        .run(defaultGuacUrl);
+        .run(getDefaultGuacdUrl());
     }
   } catch (e) {
     databaseLogger.warn("Could not initialize guac_url setting", {

--- a/src/backend/database/routes/user-settings-routes.ts
+++ b/src/backend/database/routes/user-settings-routes.ts
@@ -10,10 +10,10 @@ import {
 import { db } from "../db/index.js";
 import { users } from "../db/schema.js";
 import { logAudit, getRequestMeta } from "../../utils/audit-logger.js";
-
-function getDefaultGuacUrl(): string {
-  return `${process.env.GUACD_HOST || "localhost"}:${process.env.GUACD_PORT || "4822"}`;
-}
+import {
+  formatGuacdOptions,
+  resolveGuacdOptions,
+} from "../../utils/guacd-config.js";
 
 export type HostDefaults = {
   useSocks5?: boolean;
@@ -70,7 +70,7 @@ export function registerUserSettingsRoutes(
         .get() as { value: string } | undefined;
       res.json({
         enabled: enabledRow ? enabledRow.value !== "false" : true,
-        url: urlRow ? urlRow.value : getDefaultGuacUrl(),
+        url: formatGuacdOptions(resolveGuacdOptions(urlRow?.value)),
       });
     } catch (err) {
       authLogger.error("Failed to get guacamole settings", err);
@@ -161,7 +161,7 @@ export function registerUserSettingsRoutes(
 
       res.json({
         enabled: enabledRow ? enabledRow.value !== "false" : true,
-        url: urlRow ? urlRow.value : getDefaultGuacUrl(),
+        url: formatGuacdOptions(resolveGuacdOptions(urlRow?.value)),
       });
     } catch (err) {
       authLogger.error("Failed to update guacamole settings", err);

--- a/src/backend/guacamole/guacamole-server.ts
+++ b/src/backend/guacamole/guacamole-server.ts
@@ -2,34 +2,22 @@ import GuacamoleLite from "guacamole-lite";
 import { guacLogger } from "../utils/logger.js";
 import { GuacamoleTokenService } from "./token-service.js";
 import { getDb } from "../database/db/index.js";
+import { resolveGuacdOptions } from "../utils/guacd-config.js";
 
 const tokenService = GuacamoleTokenService.getInstance();
 
-function parseGuacUrl(url: string): { host: string; port: number } {
-  const parts = url.split(":");
-  return {
-    host: parts[0] || "localhost",
-    port: parseInt(parts[1] || "4822", 10),
-  };
-}
-
 function readGuacdOptions(): { host: string; port: number } {
-  let host = process.env.GUACD_HOST || "localhost";
-  let port = parseInt(process.env.GUACD_PORT || "4822", 10);
+  let dbUrl: string | undefined;
   try {
     const db = getDb();
     const urlRow = db.$client
       .prepare("SELECT value FROM settings WHERE key = 'guac_url'")
       .get() as { value: string } | undefined;
-    if (urlRow?.value) {
-      const parsed = parseGuacUrl(urlRow.value);
-      host = parsed.host;
-      port = parsed.port;
-    }
+    dbUrl = urlRow?.value;
   } catch {
     // DB not available yet, use env var defaults
   }
-  return { host, port };
+  return resolveGuacdOptions(dbUrl);
 }
 
 const GUAC_WS_PORT = 30008;

--- a/src/backend/guacamole/routes.ts
+++ b/src/backend/guacamole/routes.ts
@@ -10,6 +10,7 @@ import { eq, and } from "drizzle-orm";
 import { Client } from "ssh2";
 import net from "net";
 import type { AuthenticatedRequest } from "../../types/index.js";
+import { resolveGuacdOptions } from "../utils/guacd-config.js";
 
 const router = express.Router();
 const tokenService = GuacamoleTokenService.getInstance();
@@ -589,21 +590,17 @@ router.post(
  */
 router.get("/status", async (req, res) => {
   try {
-    let guacdHost = process.env.GUACD_HOST || "localhost";
-    let guacdPort = parseInt(process.env.GUACD_PORT || "4822", 10);
+    let dbUrl: string | undefined;
     try {
       const db = getDb();
       const urlRow = db.$client
         .prepare("SELECT value FROM settings WHERE key = 'guac_url'")
         .get() as { value: string } | undefined;
-      if (urlRow?.value) {
-        const parts = urlRow.value.split(":");
-        guacdHost = parts[0] || guacdHost;
-        guacdPort = parseInt(parts[1] || String(guacdPort), 10);
-      }
+      dbUrl = urlRow?.value;
     } catch {
       // Fall back to env vars
     }
+    const { host: guacdHost, port: guacdPort } = resolveGuacdOptions(dbUrl);
 
     const net = await import("net");
 

--- a/src/backend/utils/guacd-config.ts
+++ b/src/backend/utils/guacd-config.ts
@@ -1,0 +1,86 @@
+export type GuacdOptions = {
+  host: string;
+  port: number;
+};
+
+const DEFAULT_GUACD_OPTIONS: GuacdOptions = {
+  host: "localhost",
+  port: 4822,
+};
+
+function parsePort(value: string | undefined, fallback: number) {
+  const port = parseInt(value || "", 10);
+  return Number.isFinite(port) ? port : fallback;
+}
+
+export function parseGuacdUrl(
+  value: string,
+  fallback: GuacdOptions = DEFAULT_GUACD_OPTIONS,
+): GuacdOptions {
+  const raw = value.trim();
+  if (!raw) {
+    return fallback;
+  }
+
+  if (raw.includes("://")) {
+    try {
+      const url = new URL(raw);
+      return {
+        host: url.hostname || fallback.host,
+        port: parsePort(url.port, fallback.port),
+      };
+    } catch {
+      return fallback;
+    }
+  }
+
+  const bracketedIpv6 = raw.match(/^\[([^\]]+)\](?::(\d+))?$/);
+  if (bracketedIpv6) {
+    return {
+      host: bracketedIpv6[1],
+      port: parsePort(bracketedIpv6[2], fallback.port),
+    };
+  }
+
+  const [host, port] = raw.split(":");
+  return {
+    host: host || fallback.host,
+    port: parsePort(port, fallback.port),
+  };
+}
+
+export function getGuacdEnvOptions(): GuacdOptions | null {
+  if (process.env.GUACD_URL) {
+    return parseGuacdUrl(process.env.GUACD_URL);
+  }
+
+  if (!process.env.GUACD_HOST && !process.env.GUACD_PORT) {
+    return null;
+  }
+
+  return {
+    host: process.env.GUACD_HOST || DEFAULT_GUACD_OPTIONS.host,
+    port: parsePort(process.env.GUACD_PORT, DEFAULT_GUACD_OPTIONS.port),
+  };
+}
+
+export function resolveGuacdOptions(dbUrl?: string | null): GuacdOptions {
+  const envOptions = getGuacdEnvOptions();
+  if (envOptions) {
+    return envOptions;
+  }
+
+  if (dbUrl) {
+    return parseGuacdUrl(dbUrl);
+  }
+
+  return DEFAULT_GUACD_OPTIONS;
+}
+
+export function formatGuacdOptions(options: GuacdOptions): string {
+  return `${options.host}:${options.port}`;
+}
+
+export function getDefaultGuacdUrl(): string {
+  return formatGuacdOptions(resolveGuacdOptions());
+}


### PR DESCRIPTION
## Summary
- add shared guacd config parsing for GUACD_URL and GUACD_HOST/GUACD_PORT
- make environment configuration take precedence over the saved guac_url setting
- report the effective guacd URL from settings/status paths

## Test
- npm run type-check

Part of Termix-SSH/Support#894