### PR TITLE
Fix PUID html ownership in Docker entrypoint

### DIFF
--- a/docker/entrypoint.sh
+++ b/docker/entrypoint.sh
@@ -14,7 +14,7 @@ if [ "$(id -u)" = "0" ]; then
         groupmod -o -g "$PGID" node 2>/dev/null || true
         usermod -o -u "$PUID" node 2>/dev/null || true
 
-        chown -R node:node /app/data /app/uploads /tmp/nginx 2>/dev/null || true
+        chown -R node:node /app/data /app/uploads /app/html /tmp/nginx 2>/dev/null || true
 
         echo "User node is now UID: $PUID, GID: $PGID"
 


### PR DESCRIPTION
## Summary
- include /app/html in the runtime ownership fixup after changing the node UID/GID
- allow BASE_PATH sed injection to run when PUID/PGID remap the node user

## Test
- sh -n docker/entrypoint.sh

Part of Termix-SSH/Support#894