### PR TITLE
Fix SSH heading syntax highlighting

### DIFF
--- a/src/ui/lib/terminal-syntax-highlighter.test.ts
+++ b/src/ui/lib/terminal-syntax-highlighter.test.ts
@@ -222,6 +222,17 @@ describe("highlightTerminalOutput", () => {
     expect(out).toBe(prompt);
   });
 
+  it("does not highlight log keywords inside bracketed SSH headings", () => {
+    const out = highlightTerminalOutput("[info@archlinux] command output");
+    expect(out).toBe("[info@archlinux] command output");
+  });
+
+  it("still highlights log keywords after a bracketed SSH heading", () => {
+    const out = highlightTerminalOutput("[warning@host] command ERROR");
+    expect(out).not.toContain(`${ESC}[93mwarning`);
+    expect(out).toContain(`${ESC}[91mERROR`);
+  });
+
   it("does not highlight 'success' when immediately followed by a path (cd output)", () => {
     // Some shells print "success~/new/dir" or "success/path" after a cd command
     const out = highlightTerminalOutput("success~/home/user/projects");

--- a/src/ui/lib/terminal-syntax-highlighter.ts
+++ b/src/ui/lib/terminal-syntax-highlighter.ts
@@ -280,9 +280,7 @@ function highlightPlainText(
           captureEnd,
         });
       } else {
-        if (
-          isProtectedRange(m.index, m.index + m[0].length, protectedRanges)
-        ) {
+        if (isProtectedRange(m.index, m.index + m[0].length, protectedRanges)) {
           continue;
         }
         matches.push({

--- a/src/ui/lib/terminal-syntax-highlighter.ts
+++ b/src/ui/lib/terminal-syntax-highlighter.ts
@@ -50,6 +50,11 @@ interface TextSegment {
   activeSgr?: string;
 }
 
+interface ProtectedRange {
+  start: number;
+  end: number;
+}
+
 const MAX_LINE_LENGTH = 2000;
 
 // Cursor-positioning and erase sequences used by TUI apps (nano, vim, htop).
@@ -65,6 +70,8 @@ const MID_LINE_CR = /\r(?!\n)/;
 // These should not be highlighted — the server already colored them, and injecting
 // additional ANSI codes into the prompt fragments causes display corruption.
 const STRIP_ANSI_RE = /\x1b(?:[@-Z\\-_]|\[[0-9;?>=!]*[@-~])/g;
+const SSH_BRACKET_HEADING_RE =
+  /(?:(?<=^)|(?<=\s))\[[\w.-]+@[\w.-]+(?:[^\]\r\n]*)?\]/g;
 
 function isShellPromptLine(bare: string): boolean {
   const plain = bare.replace(STRIP_ANSI_RE, "");
@@ -250,6 +257,7 @@ function highlightPlainText(
   if (text.length > MAX_LINE_LENGTH || !text.trim()) return text;
 
   const matches: MatchResult[] = [];
+  const protectedRanges = getProtectedRanges(text);
 
   for (const pattern of activePatterns) {
     pattern.regex.lastIndex = 0;
@@ -260,6 +268,9 @@ function highlightPlainText(
         const captureOffset = m[0].indexOf(m[1], m[0].search(/\d/));
         const captureStart = m.index + captureOffset;
         const captureEnd = captureStart + m[1].length;
+        if (isProtectedRange(captureStart, captureEnd, protectedRanges)) {
+          continue;
+        }
         matches.push({
           start: m.index,
           end: m.index + m[0].length,
@@ -269,6 +280,11 @@ function highlightPlainText(
           captureEnd,
         });
       } else {
+        if (
+          isProtectedRange(m.index, m.index + m[0].length, protectedRanges)
+        ) {
+          continue;
+        }
         matches.push({
           start: m.index,
           end: m.index + m[0].length,
@@ -322,6 +338,29 @@ function highlightPlainText(
   }
 
   return result;
+}
+
+function getProtectedRanges(text: string): ProtectedRange[] {
+  const ranges: ProtectedRange[] = [];
+  SSH_BRACKET_HEADING_RE.lastIndex = 0;
+
+  let match;
+  while ((match = SSH_BRACKET_HEADING_RE.exec(text)) !== null) {
+    ranges.push({
+      start: match.index,
+      end: match.index + match[0].length,
+    });
+  }
+
+  return ranges;
+}
+
+function isProtectedRange(
+  start: number,
+  end: number,
+  ranges: ProtectedRange[],
+): boolean {
+  return ranges.some((range) => start < range.end && end > range.start);
 }
 
 function buildActivePatterns(


### PR DESCRIPTION
## Summary
- protect bracketed SSH headings like [user@host] from terminal syntax highlighting
- keep log-level highlighting active for text after the heading
- add regression tests for bracketed headings containing log-level words

## Test
- npx vitest run src/ui/lib/terminal-syntax-highlighter.test.ts
- npm run type-check

Fixes Termix-SSH/Support#896