### PR TITLE
Fix Proxmox import auth fallback

### DIFF
--- a/src/ui/components/proxmox/ProxmoxDiscoverDialog.tsx
+++ b/src/ui/components/proxmox/ProxmoxDiscoverDialog.tsx
@@ -24,6 +24,7 @@ import {
 } from "@/main-axios";
 import type { SSHHostWithStatus } from "@/main-axios";
 import type { ProxmoxGuest } from "@/types/proxmox";
+import { resolveProxmoxImportAuth } from "./proxmox-import-auth";
 
 interface ProxmoxDiscoverDialogProps {
   open: boolean;
@@ -118,8 +119,7 @@ export function ProxmoxDiscoverDialog({
     try {
       // Prefer explicitly configured credential, then fall back to the host's own credential
       const credId = defaultCredentialId ?? discoveredCredentialId;
-      const resolvedAuthType =
-        defaultAuthType ?? (credId != null ? "credential" : "password");
+      const importAuth = resolveProxmoxImportAuth(defaultAuthType, credId);
 
       const toImport = guests
         .filter((g) => selected.has(g.vmid))
@@ -129,13 +129,7 @@ export function ProxmoxDiscoverDialog({
           port: g.connectionType === "rdp" ? 3389 : 22,
           username: defaultUsername ?? "root",
           folder: importFolder,
-          authType: resolvedAuthType,
-          ...(resolvedAuthType === "credential" && credId != null
-            ? {
-                credentialId: credId,
-                overrideCredentialUsername: true,
-              }
-            : {}),
+          ...importAuth,
           enableTerminal: g.connectionType !== "rdp",
           enableFileManager: g.connectionType !== "rdp",
           enableTunnel: g.connectionType !== "rdp",

--- a/src/ui/components/proxmox/proxmox-import-auth.test.ts
+++ b/src/ui/components/proxmox/proxmox-import-auth.test.ts
@@ -1,0 +1,30 @@
+import { describe, expect, it } from "vitest";
+import { resolveProxmoxImportAuth } from "./proxmox-import-auth";
+
+describe("resolveProxmoxImportAuth", () => {
+  it("uses credential auth when a credential is available", () => {
+    expect(resolveProxmoxImportAuth(undefined, 42)).toEqual({
+      authType: "credential",
+      credentialId: 42,
+      overrideCredentialUsername: true,
+    });
+  });
+
+  it("does not import password auth without a password secret", () => {
+    expect(resolveProxmoxImportAuth("password", null)).toEqual({
+      authType: "none",
+    });
+  });
+
+  it("does not import key auth without a private key secret", () => {
+    expect(resolveProxmoxImportAuth("key", undefined)).toEqual({
+      authType: "none",
+    });
+  });
+
+  it("keeps secretless auth types", () => {
+    expect(resolveProxmoxImportAuth("opkssh", null)).toEqual({
+      authType: "opkssh",
+    });
+  });
+});

--- a/src/ui/components/proxmox/proxmox-import-auth.ts
+++ b/src/ui/components/proxmox/proxmox-import-auth.ts
@@ -1,0 +1,38 @@
+const SECRET_BACKED_AUTH_TYPES = new Set(["password", "key"]);
+const SECRETLESS_AUTH_TYPES = new Set([
+  "none",
+  "opkssh",
+  "tailscale",
+  "vault",
+]);
+
+export type ProxmoxImportAuth = {
+  authType: string;
+  credentialId?: number;
+  overrideCredentialUsername?: boolean;
+};
+
+export function resolveProxmoxImportAuth(
+  defaultAuthType: string | undefined,
+  credentialId: number | null | undefined,
+): ProxmoxImportAuth {
+  if (defaultAuthType === "credential" || (!defaultAuthType && credentialId)) {
+    return credentialId
+      ? {
+          authType: "credential",
+          credentialId,
+          overrideCredentialUsername: true,
+        }
+      : { authType: "none" };
+  }
+
+  if (defaultAuthType && SECRETLESS_AUTH_TYPES.has(defaultAuthType)) {
+    return { authType: defaultAuthType };
+  }
+
+  if (defaultAuthType && !SECRET_BACKED_AUTH_TYPES.has(defaultAuthType)) {
+    return { authType: defaultAuthType };
+  }
+
+  return { authType: "none" };
+}

--- a/src/ui/components/proxmox/proxmox-import-auth.ts
+++ b/src/ui/components/proxmox/proxmox-import-auth.ts
@@ -1,10 +1,5 @@
 const SECRET_BACKED_AUTH_TYPES = new Set(["password", "key"]);
-const SECRETLESS_AUTH_TYPES = new Set([
-  "none",
-  "opkssh",
-  "tailscale",
-  "vault",
-]);
+const SECRETLESS_AUTH_TYPES = new Set(["none", "opkssh", "tailscale", "vault"]);
 
 export type ProxmoxImportAuth = {
   authType: string;


### PR DESCRIPTION
## Summary
- avoid importing Proxmox guests as password/key auth when no secret is available
- keep credential auth when a default or discovered credential exists
- add regression coverage for Proxmox import auth resolution

## Test
- npx vitest run src/ui/components/proxmox/proxmox-import-auth.test.ts
- npm run type-check

Fixes Termix-SSH/Support#898