### PR TITLE
Initialize auth before fullscreen terminal routes

### DIFF
--- a/src/main.tsx
+++ b/src/main.tsx
@@ -119,6 +119,54 @@ function FullscreenApp() {
   }
 }
 
+function FullscreenAppGate() {
+  const { t } = useTranslation();
+  const [ready, setReady] = useState(false);
+  const [authFailed, setAuthFailed] = useState(false);
+
+  useEffect(() => {
+    let cancelled = false;
+
+    appReadyPromise
+      .then(() => getUserInfo())
+      .then(async () => {
+        if (isElectron()) {
+          try {
+            const token = await getCurrentToken();
+            if (token) localStorage.setItem("jwt", token);
+          } catch {
+            // WebSocket connections can still fall back to cookie auth.
+          }
+        }
+        if (!cancelled) setReady(true);
+      })
+      .catch(() => {
+        if (!cancelled) setAuthFailed(true);
+      });
+
+    return () => {
+      cancelled = true;
+    };
+  }, []);
+
+  if (authFailed) {
+    return <FullscreenApp />;
+  }
+
+  if (!ready) {
+    return (
+      <div className="fixed inset-0 flex items-center justify-center bg-background">
+        <div className="flex flex-col items-center gap-4">
+          <div className="w-5 h-5 border-2 border-primary border-t-transparent rounded-full animate-spin" />
+          <p className="text-sm text-muted-foreground">{t("common.loading")}</p>
+        </div>
+      </div>
+    );
+  }
+
+  return <FullscreenApp />;
+}
+
 function App() {
   const stored = getStoredAuth();
   const [phase, setPhase] = useState<Phase>(
@@ -276,7 +324,7 @@ function RootApp() {
   if (isFullscreen) {
     return (
       <Suspense fallback={null}>
-        <FullscreenApp />
+        <FullscreenAppGate />
       </Suspense>
     );
   }


### PR DESCRIPTION
## Summary
- gate fullscreen feature routes until the app API/session bootstrap completes
- restore the Electron JWT into localStorage before rendering terminal views
- preserve the existing fullscreen login fallback when authentication is unavailable

## Test
- npm run type-check

Fixes Termix-SSH/Support#899