### PR TITLE
feat: support SSH agent auth across SSH features

### DIFF
--- a/src/backend/database/routes/credential-deploy-routes.ts
+++ b/src/backend/database/routes/credential-deploy-routes.ts
@@ -8,6 +8,7 @@ import ssh2Pkg from "ssh2";
 import { db } from "../db/index.js";
 import { hosts, sshCredentials } from "../db/schema.js";
 import { preparePrivateKeyForSSH2 } from "../../utils/ssh-key-utils.js";
+import { applyAgentAuth } from "../../ssh/terminal-auth-helpers.js";
 
 const { Client } = ssh2Pkg;
 
@@ -264,88 +265,100 @@ async function deploySSHKeyToHost(
       resolve({ success: false, error: errorMessage });
     });
 
-    try {
-      const connectionConfig: Record<string, unknown> = {
-        host: hostConfig.ip,
-        port: hostConfig.port || 22,
-        username: hostConfig.username,
-        readyTimeout: 60000,
-        keepaliveInterval: 30000,
-        keepaliveCountMax: 3,
-        tcpKeepAlive: true,
-        tcpKeepAliveInitialDelay: 30000,
-        algorithms: {
-          kex: [
-            "diffie-hellman-group14-sha256",
-            "diffie-hellman-group14-sha1",
-            "diffie-hellman-group1-sha1",
-            "diffie-hellman-group-exchange-sha256",
-            "diffie-hellman-group-exchange-sha1",
-            "ecdh-sha2-nistp256",
-            "ecdh-sha2-nistp384",
-            "ecdh-sha2-nistp521",
-          ],
-          cipher: [
-            "aes128-ctr",
-            "aes192-ctr",
-            "aes256-ctr",
-            "aes128-gcm@openssh.com",
-            "aes256-gcm@openssh.com",
-            "aes128-cbc",
-            "aes192-cbc",
-            "aes256-cbc",
-            "3des-cbc",
-          ],
-          hmac: [
-            "hmac-sha2-256-etm@openssh.com",
-            "hmac-sha2-512-etm@openssh.com",
-            "hmac-sha2-256",
-            "hmac-sha2-512",
-            "hmac-sha1",
-            "hmac-md5",
-          ],
-          compress: ["none", "zlib@openssh.com", "zlib"],
-        },
-      };
+    void (async () => {
+      try {
+        const connectionConfig: Record<string, unknown> = {
+          host: hostConfig.ip,
+          port: hostConfig.port || 22,
+          username: hostConfig.username,
+          readyTimeout: 60000,
+          keepaliveInterval: 30000,
+          keepaliveCountMax: 3,
+          tcpKeepAlive: true,
+          tcpKeepAliveInitialDelay: 30000,
+          algorithms: {
+            kex: [
+              "diffie-hellman-group14-sha256",
+              "diffie-hellman-group14-sha1",
+              "diffie-hellman-group1-sha1",
+              "diffie-hellman-group-exchange-sha256",
+              "diffie-hellman-group-exchange-sha1",
+              "ecdh-sha2-nistp256",
+              "ecdh-sha2-nistp384",
+              "ecdh-sha2-nistp521",
+            ],
+            cipher: [
+              "aes128-ctr",
+              "aes192-ctr",
+              "aes256-ctr",
+              "aes128-gcm@openssh.com",
+              "aes256-gcm@openssh.com",
+              "aes128-cbc",
+              "aes192-cbc",
+              "aes256-cbc",
+              "3des-cbc",
+            ],
+            hmac: [
+              "hmac-sha2-256-etm@openssh.com",
+              "hmac-sha2-512-etm@openssh.com",
+              "hmac-sha2-256",
+              "hmac-sha2-512",
+              "hmac-sha1",
+              "hmac-md5",
+            ],
+            compress: ["none", "zlib@openssh.com", "zlib"],
+          },
+        };
 
-      if (hostConfig.authType === "password" && hostConfig.password) {
-        connectionConfig.password = hostConfig.password;
-      } else if (hostConfig.authType === "key" && hostConfig.privateKey) {
-        try {
-          const privateKey = hostConfig.privateKey as string;
-          connectionConfig.privateKey = preparePrivateKeyForSSH2(
-            privateKey,
-            hostConfig.keyPassword as string | undefined,
-          );
+        if (hostConfig.authType === "password" && hostConfig.password) {
+          connectionConfig.password = hostConfig.password;
+        } else if (hostConfig.authType === "key" && hostConfig.privateKey) {
+          try {
+            const privateKey = hostConfig.privateKey as string;
+            connectionConfig.privateKey = preparePrivateKeyForSSH2(
+              privateKey,
+              hostConfig.keyPassword as string | undefined,
+            );
 
-          if (hostConfig.keyPassword) {
-            connectionConfig.passphrase = hostConfig.keyPassword;
+            if (hostConfig.keyPassword) {
+              connectionConfig.passphrase = hostConfig.keyPassword;
+            }
+          } catch (keyError) {
+            clearTimeout(connectionTimeout);
+            resolve({
+              success: false,
+              error: `Invalid SSH key format: ${keyError instanceof Error ? keyError.message : "Unknown error"}`,
+            });
+            return;
           }
-        } catch (keyError) {
+        } else if (hostConfig.authType === "agent") {
+          const result = await applyAgentAuth(
+            connectionConfig,
+            hostConfig.terminalConfig as Record<string, unknown> | undefined,
+          );
+          if ("error" in result) {
+            clearTimeout(connectionTimeout);
+            resolve({ success: false, error: result.error });
+            return;
+          }
+        } else {
           clearTimeout(connectionTimeout);
           resolve({
             success: false,
-            error: `Invalid SSH key format: ${keyError instanceof Error ? keyError.message : "Unknown error"}`,
+            error: `Invalid authentication configuration. Auth type: ${hostConfig.authType}, has password: ${!!hostConfig.password}, has key: ${!!hostConfig.privateKey}`,
           });
           return;
         }
-      } else {
+
+        conn.connect(connectionConfig);
+      } catch (error) {
         clearTimeout(connectionTimeout);
         resolve({
           success: false,
-          error: `Invalid authentication configuration. Auth type: ${hostConfig.authType}, has password: ${!!hostConfig.password}, has key: ${!!hostConfig.privateKey}`,
+          error: error instanceof Error ? error.message : "Connection failed",
         });
-        return;
       }
-
-      conn.connect(connectionConfig);
-    } catch (error) {
-      clearTimeout(connectionTimeout);
-      resolve({
-        success: false,
-        error: error instanceof Error ? error.message : "Connection failed",
-      });
-    }
+    })();
   });
 }
 
@@ -471,6 +484,7 @@ export function registerCredentialDeployRoutes(
           password: hostData.password,
           privateKey: hostData.key,
           keyPassword: hostData.keyPassword,
+          terminalConfig: hostData.terminalConfig,
         };
 
         if (hostData.authType === "credential" && hostData.credentialId) {

--- a/src/backend/database/routes/proxmox.ts
+++ b/src/backend/database/routes/proxmox.ts
@@ -362,7 +362,7 @@ router.post(
           await import("../../ssh/terminal-auth-helpers.js");
         const result = await applyAgentAuth(
           sshConfig,
-          host.terminalConfig as Record<string, unknown> | undefined,
+          host.terminalConfig as unknown as Record<string, unknown> | undefined,
         );
         if ("error" in result) {
           return res.status(400).json({ error: result.error });

--- a/src/backend/database/routes/proxmox.ts
+++ b/src/backend/database/routes/proxmox.ts
@@ -357,6 +357,16 @@ router.post(
         sshConfig.privateKey = resolvedCredentials.sshKey;
         if (resolvedCredentials.keyPassword)
           sshConfig.passphrase = resolvedCredentials.keyPassword;
+      } else if (authType === "agent") {
+        const { applyAgentAuth } =
+          await import("../../ssh/terminal-auth-helpers.js");
+        const result = await applyAgentAuth(
+          sshConfig,
+          host.terminalConfig as Record<string, unknown> | undefined,
+        );
+        if ("error" in result) {
+          return res.status(400).json({ error: result.error });
+        }
       } else if (resolvedCredentials.password) {
         sshConfig.password = resolvedCredentials.password;
       }

--- a/src/backend/database/routes/snippets.ts
+++ b/src/backend/database/routes/snippets.ts
@@ -774,11 +774,12 @@ router.post(
       let output = "";
       let errorOutput = "";
 
+      /* eslint-disable no-async-promise-executor */
       const executePromise = new Promise<{
         success: boolean;
         output: string;
         error?: string;
-      }>((resolve, reject) => {
+      }>(async (resolve, reject) => {
         const timeout = setTimeout(() => {
           conn.end();
           reject(new Error("Command execution timeout (30s)"));
@@ -910,6 +911,7 @@ router.post(
 
         conn.connect(config);
       });
+      /* eslint-enable no-async-promise-executor */
 
       const result = await executePromise;
 

--- a/src/backend/database/routes/snippets.ts
+++ b/src/backend/database/routes/snippets.ts
@@ -15,6 +15,7 @@ import { AuthManager } from "../../utils/auth-manager.js";
 import { SSH_ALGORITHMS } from "../../utils/ssh-algorithms.js";
 import { extractSnippetReorderUpdates } from "./snippets-reorder.js";
 import { logAudit, getRequestMeta } from "../../utils/audit-logger.js";
+import { applyAgentAuth } from "../../ssh/terminal-auth-helpers.js";
 
 const router = express.Router();
 
@@ -885,6 +886,14 @@ router.post(
           config.privateKey = Buffer.from(cleanKey, "utf8");
           if (passphrase) {
             config.passphrase = passphrase;
+          }
+        } else if (authType === "agent") {
+          const result = await applyAgentAuth(
+            config,
+            host.terminalConfig as Record<string, unknown> | string | undefined,
+          );
+          if ("error" in result) {
+            throw new Error(result.error);
           }
         } else if (password) {
           config.password = password;

--- a/src/backend/ssh/docker-console.ts
+++ b/src/backend/ssh/docker-console.ts
@@ -8,6 +8,7 @@ import { getDb } from "../database/db/index.js";
 import { SimpleDBOps } from "../utils/simple-db-ops.js";
 import { systemLogger } from "../utils/logger.js";
 import type { SSHHost } from "../../types/index.js";
+import { applyAgentAuth } from "./terminal-auth-helpers.js";
 
 const sshLogger = systemLogger;
 
@@ -219,6 +220,14 @@ async function createJumpHostChain(
       if (resolvedCredentials.keyPassword) {
         config.passphrase = resolvedCredentials.keyPassword;
       }
+    } else if (resolvedCredentials.authType === "agent") {
+      const result = await applyAgentAuth(
+        config,
+        jumpHost.terminalConfig as Record<string, unknown> | undefined,
+      );
+      if ("error" in result) {
+        throw new Error(result.error);
+      }
     }
 
     client.on(
@@ -426,6 +435,22 @@ wss.on("connection", async (ws: WebSocket, req) => {
               config.privateKey = Buffer.from(cleanKey, "utf8");
               if (resolvedHost.keyPassword) {
                 config.passphrase = resolvedHost.keyPassword;
+              }
+            } else if (resolvedHost.authType === "agent") {
+              const result = await applyAgentAuth(
+                config,
+                resolvedHost.terminalConfig as
+                  | Record<string, unknown>
+                  | undefined,
+              );
+              if ("error" in result) {
+                ws.send(
+                  JSON.stringify({
+                    type: "error",
+                    message: result.error,
+                  }),
+                );
+                return;
               }
             }
 

--- a/src/backend/ssh/docker-console.ts
+++ b/src/backend/ssh/docker-console.ts
@@ -223,7 +223,9 @@ async function createJumpHostChain(
     } else if (resolvedCredentials.authType === "agent") {
       const result = await applyAgentAuth(
         config,
-        jumpHost.terminalConfig as Record<string, unknown> | undefined,
+        jumpHost.terminalConfig as unknown as
+          | Record<string, unknown>
+          | undefined,
       );
       if ("error" in result) {
         throw new Error(result.error);
@@ -439,7 +441,7 @@ wss.on("connection", async (ws: WebSocket, req) => {
             } else if (resolvedHost.authType === "agent") {
               const result = await applyAgentAuth(
                 config,
-                resolvedHost.terminalConfig as
+                resolvedHost.terminalConfig as unknown as
                   | Record<string, unknown>
                   | undefined,
               );

--- a/src/backend/ssh/docker.ts
+++ b/src/backend/ssh/docker.ts
@@ -20,6 +20,7 @@ import type { LogEntry, ConnectionStage } from "../../types/connection-log.js";
 import { SSHHostKeyVerifier } from "./host-key-verifier.js";
 import { registerDockerContainerRoutes } from "./docker-container-routes.js";
 import { preparePrivateKeyForSSH2 } from "../utils/ssh-key-utils.js";
+import { applyAgentAuth } from "./terminal-auth-helpers.js";
 
 const sshLogger = logger;
 
@@ -371,6 +372,16 @@ async function createJumpHostChain(
           connectConfig.privateKey = Buffer.from(cleanKey, "utf8");
           if (jumpHostConfig.keyPassword) {
             connectConfig.passphrase = jumpHostConfig.keyPassword;
+          }
+        } else if (jumpHostConfig.authType === "agent") {
+          const result = await applyAgentAuth(
+            connectConfig,
+            jumpHostConfig.terminalConfig as
+              | Record<string, unknown>
+              | undefined,
+          );
+          if ("error" in result) {
+            throw new Error(result.error);
           }
         }
 
@@ -968,6 +979,24 @@ app.post("/docker/ssh/connect", async (req, res) => {
         error: "SSH key authentication requested but no key provided",
         connectionLogs,
       });
+    } else if (resolvedCredentials.authType === "agent") {
+      const result = await applyAgentAuth(
+        config,
+        host.terminalConfig as Record<string, unknown> | undefined,
+      );
+      if ("error" in result) {
+        connectionLogs.push(
+          createConnectionLog("error", "docker_auth", result.error),
+        );
+        return res.status(400).json({ error: result.error, connectionLogs });
+      }
+      connectionLogs.push(
+        createConnectionLog(
+          "info",
+          "docker_auth",
+          "Using SSH agent authentication",
+        ),
+      );
     }
 
     let responseSent = false;
@@ -994,6 +1023,10 @@ app.post("/docker/ssh/connect", async (req, res) => {
     } else if (resolvedCredentials.authType === "key") {
       connectionLogs.push(
         createConnectionLog("info", "auth", "Authenticating with SSH key"),
+      );
+    } else if (resolvedCredentials.authType === "agent") {
+      connectionLogs.push(
+        createConnectionLog("info", "auth", "Authenticating with SSH agent"),
       );
     } else if (
       resolvedCredentials.authType === "none" ||

--- a/src/backend/ssh/docker.ts
+++ b/src/backend/ssh/docker.ts
@@ -280,7 +280,8 @@ async function createJumpHostChain(
         true,
       );
 
-      const connected = await new Promise<boolean>((resolve) => {
+      // eslint-disable-next-line no-async-promise-executor
+      const connected = await new Promise<boolean>(async (resolve) => {
         const timeout = setTimeout(() => {
           resolve(false);
         }, 30000);
@@ -982,7 +983,7 @@ app.post("/docker/ssh/connect", async (req, res) => {
     } else if (resolvedCredentials.authType === "agent") {
       const result = await applyAgentAuth(
         config,
-        host.terminalConfig as Record<string, unknown> | undefined,
+        host.terminalConfig as unknown as Record<string, unknown> | undefined,
       );
       if ("error" in result) {
         connectionLogs.push(

--- a/src/backend/ssh/file-manager.ts
+++ b/src/backend/ssh/file-manager.ts
@@ -227,7 +227,7 @@ async function buildDedicatedTransferConnectConfig(
   } else if (authType === "agent") {
     const result = await applyAgentAuth(
       config,
-      host.terminalConfig as Record<string, unknown> | undefined,
+      host.terminalConfig as unknown as Record<string, unknown> | undefined,
     );
     if ("error" in result) {
       throw new Error(result.error);
@@ -761,7 +761,7 @@ app.post("/ssh/file_manager/ssh/connect", async (req, res) => {
           authType: resolvedHost.authType,
           sudoPassword: resolvedHost.sudoPassword as string | undefined,
         };
-        resolvedTerminalConfig = resolvedHost.terminalConfig as
+        resolvedTerminalConfig = resolvedHost.terminalConfig as unknown as
           | Record<string, unknown>
           | undefined;
         hostKeepaliveInterval = resolvedHost.terminalConfig?.keepaliveInterval;
@@ -820,7 +820,7 @@ app.post("/ssh/file_manager/ssh/connect", async (req, res) => {
           authType: resolvedHost.authType,
           sudoPassword: resolvedHost.sudoPassword as string | undefined,
         };
-        resolvedTerminalConfig = resolvedHost.terminalConfig as
+        resolvedTerminalConfig = resolvedHost.terminalConfig as unknown as
           | Record<string, unknown>
           | undefined;
         hostKeepaliveInterval = resolvedHost.terminalConfig?.keepaliveInterval;

--- a/src/backend/ssh/file-manager.ts
+++ b/src/backend/ssh/file-manager.ts
@@ -45,6 +45,7 @@ import { registerFileListingRoutes } from "./file-manager-list-routes.js";
 import { registerFileOperationRoutes } from "./file-manager-operation-routes.js";
 import { registerFileDownloadRoutes } from "./file-manager-download-routes.js";
 import { registerFileActionRoutes } from "./file-manager-action-routes.js";
+import { applyAgentAuth } from "./terminal-auth-helpers.js";
 
 const app = express();
 
@@ -223,6 +224,14 @@ async function buildDedicatedTransferConnectConfig(
       token,
       username,
     );
+  } else if (authType === "agent") {
+    const result = await applyAgentAuth(
+      config,
+      host.terminalConfig as Record<string, unknown> | undefined,
+    );
+    if ("error" in result) {
+      throw new Error(result.error);
+    }
   } else if (authType !== "none" && authType !== "tailscale") {
     throw new Error(`Unsupported auth type for transfer: ${authType}`);
   }
@@ -728,6 +737,7 @@ app.post("/ssh/file_manager/ssh/connect", async (req, res) => {
   let resolvedIp = ip;
   let resolvedPort = port;
   let resolvedUsername = username;
+  let resolvedTerminalConfig: Record<string, unknown> | undefined;
   let resolvedJumpHosts = jumpHosts;
   let resolvedScpLegacy = false;
   let resolvedUseSocks5 = useSocks5;
@@ -751,6 +761,9 @@ app.post("/ssh/file_manager/ssh/connect", async (req, res) => {
           authType: resolvedHost.authType,
           sudoPassword: resolvedHost.sudoPassword as string | undefined,
         };
+        resolvedTerminalConfig = resolvedHost.terminalConfig as
+          | Record<string, unknown>
+          | undefined;
         hostKeepaliveInterval = resolvedHost.terminalConfig?.keepaliveInterval;
         hostKeepaliveCountMax = resolvedHost.terminalConfig?.keepaliveCountMax;
         resolvedScpLegacy = resolvedHost.scpLegacy ?? false;
@@ -807,6 +820,9 @@ app.post("/ssh/file_manager/ssh/connect", async (req, res) => {
           authType: resolvedHost.authType,
           sudoPassword: resolvedHost.sudoPassword as string | undefined,
         };
+        resolvedTerminalConfig = resolvedHost.terminalConfig as
+          | Record<string, unknown>
+          | undefined;
         hostKeepaliveInterval = resolvedHost.terminalConfig?.keepaliveInterval;
         hostKeepaliveCountMax = resolvedHost.terminalConfig?.keepaliveCountMax;
         resolvedScpLegacy = resolvedHost.scpLegacy ?? false;
@@ -1036,6 +1052,21 @@ app.post("/ssh/file_manager/ssh/connect", async (req, res) => {
         connectionLogs,
       });
     }
+  } else if (resolvedCredentials.authType === "agent") {
+    const result = await applyAgentAuth(config, resolvedTerminalConfig);
+    if ("error" in result) {
+      connectionLogs.push(
+        createConnectionLog("error", "sftp_auth", result.error),
+      );
+      return res.status(400).json({ error: result.error, connectionLogs });
+    }
+    connectionLogs.push(
+      createConnectionLog(
+        "info",
+        "sftp_auth",
+        "Using SSH agent authentication",
+      ),
+    );
   } else if (
     resolvedCredentials.authType === "none" ||
     resolvedCredentials.authType === "tailscale" ||

--- a/src/backend/ssh/host-metrics-jump-hosts.ts
+++ b/src/backend/ssh/host-metrics-jump-hosts.ts
@@ -171,7 +171,8 @@ export async function createJumpHostChain(
         true,
       );
 
-      const connected = await new Promise<boolean>((resolve) => {
+      // eslint-disable-next-line no-async-promise-executor
+      const connected = await new Promise<boolean>(async (resolve) => {
         const timeout = setTimeout(() => {
           resolve(false);
         }, 30000);

--- a/src/backend/ssh/host-metrics-jump-hosts.ts
+++ b/src/backend/ssh/host-metrics-jump-hosts.ts
@@ -10,6 +10,7 @@ import {
 import { getDb } from "../database/db/index.js";
 import { hosts, sshCredentials } from "../database/db/schema.js";
 import { SSHHostKeyVerifier } from "./host-key-verifier.js";
+import { applyAgentAuth } from "./terminal-auth-helpers.js";
 
 interface JumpHostConfig {
   id: number;
@@ -260,6 +261,16 @@ export async function createJumpHostChain(
           connectConfig.privateKey = Buffer.from(cleanKey, "utf8");
           if (jumpHostConfig.keyPassword) {
             connectConfig.passphrase = jumpHostConfig.keyPassword;
+          }
+        } else if (jumpHostConfig.authType === "agent") {
+          const result = await applyAgentAuth(
+            connectConfig,
+            jumpHostConfig.terminalConfig as
+              | Record<string, unknown>
+              | undefined,
+          );
+          if ("error" in result) {
+            throw new Error(result.error);
           }
         }
 

--- a/src/backend/ssh/host-metrics.ts
+++ b/src/backend/ssh/host-metrics.ts
@@ -45,6 +45,7 @@ import {
   isTcpPingEnabled,
   supportsMetrics,
 } from "./host-metrics-helpers.js";
+import { applyAgentAuth } from "./terminal-auth-helpers.js";
 import {
   cleanupMetricsSession,
   getSessionKey,
@@ -842,6 +843,15 @@ async function resolveHostCredentials(
           : [],
       pin: !!host.pin,
       authType: host.authType,
+      terminalConfig: (() => {
+        try {
+          return typeof host.terminalConfig === "string"
+            ? JSON.parse(host.terminalConfig as string)
+            : host.terminalConfig || undefined;
+        } catch {
+          return undefined;
+        }
+      })(),
       enableTerminal: !!host.enableTerminal,
       enableTunnel: !!host.enableTunnel,
       enableFileManager: !!host.enableFileManager,
@@ -1133,6 +1143,14 @@ async function buildSshConfig(
       }
     } else {
       throw new Error(`Credential for host ${host.ip} could not be resolved`);
+    }
+  } else if (host.authType === "agent") {
+    const result = await applyAgentAuth(
+      base as Record<string, unknown>,
+      (host as { terminalConfig?: Record<string, unknown> }).terminalConfig,
+    );
+    if ("error" in result) {
+      throw new Error(result.error);
     }
   } else {
     throw new Error(

--- a/src/backend/ssh/jump-host-chain.ts
+++ b/src/backend/ssh/jump-host-chain.ts
@@ -171,7 +171,8 @@ export async function createJumpHostChain(
         true,
       );
 
-      const connected = await new Promise<boolean>((resolve) => {
+      // eslint-disable-next-line no-async-promise-executor
+      const connected = await new Promise<boolean>(async (resolve) => {
         const timeout = setTimeout(() => {
           resolve(false);
         }, 30000);

--- a/src/backend/ssh/jump-host-chain.ts
+++ b/src/backend/ssh/jump-host-chain.ts
@@ -10,6 +10,7 @@ import {
 import { SSH_ALGORITHMS } from "../utils/ssh-algorithms.js";
 import { SimpleDBOps } from "../utils/simple-db-ops.js";
 import { SSHHostKeyVerifier } from "./host-key-verifier.js";
+import { applyAgentAuth } from "./terminal-auth-helpers.js";
 
 type JumpHostConfig = {
   id: number;
@@ -260,6 +261,16 @@ export async function createJumpHostChain(
           connectConfig.privateKey = Buffer.from(cleanKey, "utf8");
           if (jumpHostConfig.keyPassword) {
             connectConfig.passphrase = jumpHostConfig.keyPassword;
+          }
+        } else if (jumpHostConfig.authType === "agent") {
+          const result = await applyAgentAuth(
+            connectConfig,
+            jumpHostConfig.terminalConfig as
+              | Record<string, unknown>
+              | undefined,
+          );
+          if ("error" in result) {
+            throw new Error(result.error);
           }
         }
 

--- a/src/backend/ssh/terminal-agent-auth.test.ts
+++ b/src/backend/ssh/terminal-agent-auth.test.ts
@@ -6,7 +6,7 @@ vi.mock("fs/promises", () => ({
   access: mockAccess,
 }));
 
-import { resolveAgentSocket } from "./terminal-auth-helpers.js";
+import { applyAgentAuth, resolveAgentSocket } from "./terminal-auth-helpers.js";
 
 describe("resolveAgentSocket", () => {
   const originalEnv = process.env.SSH_AUTH_SOCK;
@@ -63,6 +63,25 @@ describe("resolveAgentSocket", () => {
     expect(result).toEqual({ socketPath: "/tmp/ssh-XXXX/agent.789" });
   });
 
+  it("reads agent socket path from serialized terminal config", async () => {
+    Object.defineProperty(process, "platform", { value: "linux" });
+    mockAccess.mockResolvedValue(undefined);
+
+    const result = await resolveAgentSocket(
+      JSON.stringify({ agentSocketPath: "/tmp/serialized-agent.sock" }),
+    );
+
+    expect(result).toEqual({ socketPath: "/tmp/serialized-agent.sock" });
+  });
+
+  it("returns error for invalid serialized terminal config", async () => {
+    const result = await resolveAgentSocket("{");
+
+    expect(result).toEqual({
+      error: "Invalid terminal configuration for SSH agent auth.",
+    });
+  });
+
   it("returns error when neither SSH_AUTH_SOCK nor explicit path is set", async () => {
     const result = await resolveAgentSocket({});
 
@@ -99,5 +118,18 @@ describe("resolveAgentSocket", () => {
       socketPath: "\\\\.\\pipe\\openssh-ssh-agent",
     });
     expect(mockAccess).not.toHaveBeenCalled();
+  });
+
+  it("attaches an ssh2 agent to a connect config", async () => {
+    Object.defineProperty(process, "platform", { value: "linux" });
+    mockAccess.mockResolvedValue(undefined);
+    const config: Record<string, unknown> = {};
+
+    const result = await applyAgentAuth(config, {
+      agentSocketPath: "/tmp/ssh-agent.sock",
+    });
+
+    expect(result).toEqual({ socketPath: "/tmp/ssh-agent.sock" });
+    expect(config.agent).toBeDefined();
   });
 });

--- a/src/backend/ssh/terminal-auth-helpers.ts
+++ b/src/backend/ssh/terminal-auth-helpers.ts
@@ -45,10 +45,20 @@ export class MemoryAgent extends BaseAgent {
 }
 
 export async function resolveAgentSocket(
-  terminalConfig: Record<string, unknown> | undefined,
+  terminalConfig: Record<string, unknown> | string | undefined,
 ): Promise<{ socketPath: string } | { error: string }> {
+  let parsedConfig: Record<string, unknown> | undefined;
+  if (typeof terminalConfig === "string") {
+    try {
+      parsedConfig = JSON.parse(terminalConfig) as Record<string, unknown>;
+    } catch {
+      return { error: "Invalid terminal configuration for SSH agent auth." };
+    }
+  } else {
+    parsedConfig = terminalConfig;
+  }
   const explicit = (
-    terminalConfig?.agentSocketPath as string | undefined
+    parsedConfig?.agentSocketPath as string | undefined
   )?.trim();
   const resolved = explicit || process.env.SSH_AUTH_SOCK;
 
@@ -70,6 +80,18 @@ export async function resolveAgentSocket(
   }
 
   return { socketPath: resolved };
+}
+
+export async function applyAgentAuth(
+  connectConfig: Record<string, unknown>,
+  terminalConfig: Record<string, unknown> | string | undefined,
+): Promise<{ socketPath: string } | { error: string }> {
+  const result = await resolveAgentSocket(terminalConfig);
+  if ("error" in result) return result;
+
+  const { createAgent } = ssh2Pkg;
+  connectConfig.agent = createAgent(result.socketPath);
+  return result;
 }
 
 export async function performPortKnocking(

--- a/src/backend/ssh/terminal-jump-hosts.ts
+++ b/src/backend/ssh/terminal-jump-hosts.ts
@@ -175,7 +175,8 @@ export async function createJumpHostChain(
         true,
       );
 
-      const connected = await new Promise<boolean>((resolve) => {
+      // eslint-disable-next-line no-async-promise-executor
+      const connected = await new Promise<boolean>(async (resolve) => {
         const timeout = setTimeout(() => {
           resolve(false);
         }, 30000);

--- a/src/backend/ssh/terminal-jump-hosts.ts
+++ b/src/backend/ssh/terminal-jump-hosts.ts
@@ -10,6 +10,7 @@ import {
   type SOCKS5Config,
 } from "../utils/socks5-helper.js";
 import { SSHHostKeyVerifier } from "./host-key-verifier.js";
+import { applyAgentAuth } from "./terminal-auth-helpers.js";
 
 const { Client } = ssh2Pkg;
 
@@ -274,6 +275,16 @@ export async function createJumpHostChain(
           connectConfig.privateKey = Buffer.from(cleanKey, "utf8");
           if (jumpHostConfig.keyPassword) {
             connectConfig.passphrase = jumpHostConfig.keyPassword;
+          }
+        } else if (jumpHostConfig.authType === "agent") {
+          const result = await applyAgentAuth(
+            connectConfig,
+            jumpHostConfig.terminalConfig as
+              | Record<string, unknown>
+              | undefined,
+          );
+          if ("error" in result) {
+            throw new Error(result.error);
           }
         }
 

--- a/src/backend/ssh/terminal.ts
+++ b/src/backend/ssh/terminal.ts
@@ -30,9 +30,9 @@ import {
   waitForTmuxSession,
 } from "./tmux-helper.js";
 import {
+  applyAgentAuth,
   MemoryAgent,
   performPortKnocking,
-  resolveAgentSocket,
 } from "./terminal-auth-helpers.js";
 import { isWindowsSftpPath, sftpPathToLocalPath } from "./transfer-paths.js";
 import { preparePrivateKeyForSSH2 } from "../utils/ssh-key-utils.js";
@@ -2479,15 +2479,14 @@ wss.on("connection", async (ws: WebSocket, req) => {
       }
     } else if (resolvedCredentials.authType === "agent") {
       sendLog("auth", "info", "Using SSH agent authentication");
-      const result = await resolveAgentSocket(
+      const result = await applyAgentAuth(
+        connectConfig as Record<string, unknown>,
         hostConfig.terminalConfig as Record<string, unknown> | undefined,
       );
       if ("error" in result) {
         ws.send(JSON.stringify({ type: "error", message: result.error }));
         return;
       }
-      const { createAgent } = ssh2Pkg;
-      connectConfig.agent = createAgent(result.socketPath);
       sendLog(
         "auth",
         "info",

--- a/src/backend/ssh/tmux-monitor.ts
+++ b/src/backend/ssh/tmux-monitor.ts
@@ -98,7 +98,7 @@ async function buildSshConfig(host: SSHHost): Promise<ConnectConfig> {
   } else if (host.authType === "agent") {
     const result = await applyAgentAuth(
       base as Record<string, unknown>,
-      host.terminalConfig as Record<string, unknown> | undefined,
+      host.terminalConfig as unknown as Record<string, unknown> | undefined,
     );
     if ("error" in result) {
       throw new Error(result.error);

--- a/src/backend/ssh/tmux-monitor.ts
+++ b/src/backend/ssh/tmux-monitor.ts
@@ -14,6 +14,7 @@ import { preparePrivateKeyForSSH2 } from "../utils/ssh-key-utils.js";
 import { SSHHostKeyVerifier } from "./host-key-verifier.js";
 import { resolveHostById, checkHostAccess } from "./host-resolver.js";
 import { createJumpHostChain } from "./jump-host-chain.js";
+import { applyAgentAuth } from "./terminal-auth-helpers.js";
 import {
   createSocks5Connection,
   type SOCKS5Config,
@@ -94,6 +95,14 @@ async function buildSshConfig(host: SSHHost): Promise<ConnectConfig> {
     }
   } else if (host.authType === "none") {
     // no credentials needed
+  } else if (host.authType === "agent") {
+    const result = await applyAgentAuth(
+      base as Record<string, unknown>,
+      host.terminalConfig as Record<string, unknown> | undefined,
+    );
+    if ("error" in result) {
+      throw new Error(result.error);
+    }
   } else {
     // opkssh and other interactive flows are not supported by this module
     throw new Error(


### PR DESCRIPTION
## Summary
- reuse the existing SSH agent socket resolver to attach ssh2 agents consistently
- support agent auth in file manager, Docker, metrics, tmux monitor, snippets, Proxmox discovery, credential deploy, and jump-host chains
- handle serialized terminalConfig values and cover agent config attachment in tests

## Scope
This addresses the SSH-agent based path for Termix-SSH/Support#821, including YubiKey keys exposed through ssh-agent, gpg-agent, or compatible agent sockets. Direct PKCS#11 library loading is intentionally left out for a separate follow-up.

## Tests
- npm run type-check
- npm run test -- src/backend/ssh/terminal-agent-auth.test.ts
- npx eslint <touched files>

Note: full npm run lint still fails on an existing unrelated unused import in src/backend/ssh/managers/wireguard.ts.