### PR TITLE
chore: fix CI checks

### DIFF
--- a/electron/main.cjs
+++ b/electron/main.cjs
@@ -852,7 +852,13 @@ function createTray() {
     // use the unpacked path so the OS sees a real file.
     const publicRoot = isDev
       ? path.join(appRoot, "public")
-      : path.join(appRoot.replace(/app(-[a-z0-9]+)?\.asar(?!\.unpacked)/, "app.asar.unpacked"), "public");
+      : path.join(
+          appRoot.replace(
+            /app(-[a-z0-9]+)?\.asar(?!\.unpacked)/,
+            "app.asar.unpacked",
+          ),
+          "public",
+        );
 
     let trayIcon;
     if (process.platform === "darwin") {

--- a/scripts/publish-youtube.cjs
+++ b/scripts/publish-youtube.cjs
@@ -50,7 +50,8 @@ async function getVideoStatus(accessToken, videoId) {
     `https://www.googleapis.com/youtube/v3/videos?part=status&id=${videoId}`,
     { headers: { Authorization: `Bearer ${accessToken}` } },
   );
-  if (!res.ok) throw new Error(`videos.list failed (${res.status}): ${await res.text()}`);
+  if (!res.ok)
+    throw new Error(`videos.list failed (${res.status}): ${await res.text()}`);
   const json = await res.json();
   return json.items?.[0]?.status?.privacyStatus ?? null;
 }

--- a/src/backend/ssh/file-manager-content-routes.ts
+++ b/src/backend/ssh/file-manager-content-routes.ts
@@ -1560,7 +1560,9 @@ export function registerFileContentRoutes(
       const sshConn = sshSessions[sessionId];
       if (!sshConn?.isConnected) {
         req.resume();
-        return res.status(400).json({ error: "SSH connection not established" });
+        return res
+          .status(400)
+          .json({ error: "SSH connection not established" });
       }
 
       if (!verifySessionOwnership(sshConn, userId)) {
@@ -1592,7 +1594,10 @@ export function registerFileContentRoutes(
           };
 
           writeStream.on("error", (err) => {
-            fileLogger.error("SFTP write stream error during chunk upload:", err);
+            fileLogger.error(
+              "SFTP write stream error during chunk upload:",
+              err,
+            );
             fail(500, `Upload failed: ${err.message}`);
           });
 

--- a/src/backend/ssh/host-metrics-settings-routes.ts
+++ b/src/backend/ssh/host-metrics-settings-routes.ts
@@ -254,11 +254,9 @@ export function registerHostMetricsSettingsRoutes(
       metricsHistoryRetentionDays < 1 ||
       metricsHistoryRetentionDays > 90
     ) {
-      return res
-        .status(400)
-        .json({
-          error: "metricsHistoryRetentionDays must be between 1 and 90",
-        });
+      return res.status(400).json({
+        error: "metricsHistoryRetentionDays must be between 1 and 90",
+      });
     }
     try {
       const db = getDb();

--- a/src/backend/ssh/managers/tailscale.ts
+++ b/src/backend/ssh/managers/tailscale.ts
@@ -51,7 +51,12 @@ export function parseTailscaleData(output: string): TailscaleData {
       Self?: { HostName?: string; TailscaleIPs?: string[] };
       Peer?: Record<
         string,
-        { HostName?: string; TailscaleIPs?: string[]; Online?: boolean; ExitNode?: boolean }
+        {
+          HostName?: string;
+          TailscaleIPs?: string[];
+          Online?: boolean;
+          ExitNode?: boolean;
+        }
       >;
       CurrentExitNode?: string;
     };

--- a/src/backend/ssh/managers/wireguard.ts
+++ b/src/backend/ssh/managers/wireguard.ts
@@ -1,5 +1,4 @@
 import type { Express } from "express";
-import { execCommand } from "../widgets/common-utils.js";
 import { execElevated } from "./exec-elevated.js";
 import { managerHandler } from "./route-helpers.js";
 import { ManagerInputError } from "./route-helpers.js";
@@ -45,7 +44,8 @@ export function parseWireGuardData(output: string): WireGuardData {
 
   const dumpIdx = output.indexOf("__DUMP__");
   const ipLinkPart = dumpIdx >= 0 ? output.slice(0, dumpIdx) : "";
-  const dumpPart = dumpIdx >= 0 ? output.slice(dumpIdx + "__DUMP__".length) : "";
+  const dumpPart =
+    dumpIdx >= 0 ? output.slice(dumpIdx + "__DUMP__".length) : "";
 
   // Collect up interface names from `ip link show type wireguard`
   const upSet = new Set<string>();
@@ -77,8 +77,16 @@ export function parseWireGuardData(output: string): WireGuardData {
       });
     } else if (cols.length === 9) {
       // Peer row: iface public_key preshared_key endpoint allowed_ips latest_handshake rx_bytes tx_bytes persistent_keepalive
-      const [name, publicKey, , endpoint, allowedIPsStr, handshakeStr, rxStr, txStr] =
-        cols;
+      const [
+        name,
+        publicKey,
+        ,
+        endpoint,
+        allowedIPsStr,
+        handshakeStr,
+        rxStr,
+        txStr,
+      ] = cols;
       if (!name) continue;
 
       if (!ifaceMap.has(name)) {
@@ -138,10 +146,15 @@ export function registerWireGuardRoutes(
       "read",
       "wireguard_read",
       async (client, host) => {
-        const result = await execElevated(client, PROBE_CMD, host.sudoPassword, {
-          forceSudo: false,
-          timeoutMs: 15000,
-        });
+        const result = await execElevated(
+          client,
+          PROBE_CMD,
+          host.sudoPassword,
+          {
+            forceSudo: false,
+            timeoutMs: 15000,
+          },
+        );
         return parseWireGuardData(result.stdout);
       },
     ),

--- a/src/backend/utils/ssh-key-utils.ts
+++ b/src/backend/utils/ssh-key-utils.ts
@@ -317,7 +317,9 @@ export function parseSSHKey(
       keyType,
       success: keyType !== "unknown",
       error:
-        keyType === "unknown" ? getUnsupportedPrivateKeyError(cleanKey) : undefined,
+        keyType === "unknown"
+          ? getUnsupportedPrivateKeyError(cleanKey)
+          : undefined,
     };
   } catch (error) {
     try {

--- a/src/ui/api/ssh-file-operations-api.ts
+++ b/src/ui/api/ssh-file-operations-api.ts
@@ -445,9 +445,13 @@ export async function uploadSSHFile(
     if (userId !== undefined) form.append("userId", userId);
     form.append("file", file, fileName);
 
-    const response = await fileManagerApi.postForm("/ssh/uploadFileStream", form, {
-      timeout: 0,
-    });
+    const response = await fileManagerApi.postForm(
+      "/ssh/uploadFileStream",
+      form,
+      {
+        timeout: 0,
+      },
+    );
     return response.data;
   } catch (error) {
     handleApiError(error, "upload SSH file");

--- a/src/ui/features/host-metrics/cards/managers/TailscaleManagerCard.tsx
+++ b/src/ui/features/host-metrics/cards/managers/TailscaleManagerCard.tsx
@@ -88,7 +88,10 @@ export function TailscaleManagerCard({ hostId }: { hostId: number | null }) {
                   </span>
                 )}
                 {data.tailscaleIPs.map((ip) => (
-                  <span key={ip} className="truncate font-mono text-[10px] text-muted-foreground/60">
+                  <span
+                    key={ip}
+                    className="truncate font-mono text-[10px] text-muted-foreground/60"
+                  >
                     {ip}
                   </span>
                 ))}
@@ -145,7 +148,10 @@ export function TailscaleManagerCard({ hostId }: { hostId: number | null }) {
                     {peer.hostname}
                   </span>
                   {peer.tailscaleIPs.map((ip) => (
-                    <span key={ip} className="truncate font-mono text-[10px] text-muted-foreground">
+                    <span
+                      key={ip}
+                      className="truncate font-mono text-[10px] text-muted-foreground"
+                    >
                       {ip}
                     </span>
                   ))}

--- a/src/ui/features/host-metrics/cards/managers/WireGuardManagerCard.tsx
+++ b/src/ui/features/host-metrics/cards/managers/WireGuardManagerCard.tsx
@@ -1,5 +1,11 @@
 import { useState } from "react";
-import { ChevronDown, ChevronRight, Network, ArrowUp, ArrowDown } from "lucide-react";
+import {
+  ChevronDown,
+  ChevronRight,
+  Network,
+  ArrowUp,
+  ArrowDown,
+} from "lucide-react";
 import { useTranslation } from "react-i18next";
 import { useManagerData, useManagerAction } from "./useManagerData";
 import { ManagerCardShell } from "./ManagerCardShell";
@@ -27,7 +33,8 @@ interface WireGuardData {
 }
 
 function fmtBytes(n: number): string {
-  if (n >= 1024 * 1024 * 1024) return `${(n / 1024 / 1024 / 1024).toFixed(1)}GB`;
+  if (n >= 1024 * 1024 * 1024)
+    return `${(n / 1024 / 1024 / 1024).toFixed(1)}GB`;
   if (n >= 1024 * 1024) return `${(n / 1024 / 1024).toFixed(1)}MB`;
   if (n >= 1024) return `${(n / 1024).toFixed(1)}KB`;
   return `${n}B`;
@@ -78,7 +85,9 @@ export function WireGuardManagerCard({ hostId }: { hostId: number | null }) {
         successMsg:
           action === "up"
             ? t("hostMetrics.managers.wgInterfaceUpDone", { name: iface.name })
-            : t("hostMetrics.managers.wgInterfaceDownDone", { name: iface.name }),
+            : t("hostMetrics.managers.wgInterfaceDownDone", {
+                name: iface.name,
+              }),
         onDone: refresh,
       },
     );
@@ -103,7 +112,10 @@ export function WireGuardManagerCard({ hostId }: { hostId: number | null }) {
     >
       <div className="flex flex-col">
         {data?.interfaces.map((iface) => (
-          <div key={iface.name} className="border-b border-border/50 last:border-0">
+          <div
+            key={iface.name}
+            className="border-b border-border/50 last:border-0"
+          >
             <div className="flex items-center justify-between gap-2 py-1.5">
               <button
                 className="flex min-w-0 flex-1 items-center gap-2 text-left"
@@ -118,7 +130,9 @@ export function WireGuardManagerCard({ hostId }: { hostId: number | null }) {
                   className={`size-1.5 shrink-0 rounded-full ${iface.up ? "bg-accent-brand" : "bg-muted-foreground/40"}`}
                 />
                 <div className="flex min-w-0 flex-col">
-                  <span className="text-xs font-semibold font-mono">{iface.name}</span>
+                  <span className="text-xs font-semibold font-mono">
+                    {iface.name}
+                  </span>
                   <span className="text-[10px] text-muted-foreground">
                     {iface.up ? "up" : "down"}
                     {iface.listenPort ? ` · :${iface.listenPort}` : ""}

--- a/src/ui/lib/host-connection-tabs.ts
+++ b/src/ui/lib/host-connection-tabs.ts
@@ -29,7 +29,10 @@ export function getDefaultConnectionTab(host: Host): ConnectionTabType {
   return "terminal";
 }
 
-export function resolveHostTabType(host: Host, preferredType?: TabType): TabType {
+export function resolveHostTabType(
+  host: Host,
+  preferredType?: TabType,
+): TabType {
   if (!preferredType) return getDefaultConnectionTab(host);
   if (!isConnectionTabType(preferredType)) return preferredType;
   if (isConnectionEnabled(host, preferredType)) return preferredType;


### PR DESCRIPTION
## Summary
- remove the unused WireGuard manager import that fails ESLint
- apply Prettier formatting to files currently failing the PR formatting gate

## Verification
- npm run lint
- npx prettier --check .
- npx tsc --noEmit
- npm run build