### PR TITLE
Fix custom SSH port handling

### DIFF
--- a/src/backend/database/routes/host-normalizers.test.ts
+++ b/src/backend/database/routes/host-normalizers.test.ts
@@ -98,6 +98,15 @@ describe("normalizeImportedHost", () => {
     expect(host.port).toBe(2222);
   });
 
+  it("prefers sshPort over the legacy port field for ssh hosts", () => {
+    const host = normalizeImportedHost({
+      connectionType: "ssh",
+      port: 22,
+      sshPort: 2222,
+    });
+    expect(host.port).toBe(2222);
+  });
+
   it("resolves ip from common aliases", () => {
     expect(normalizeImportedHost({ address: "a.example" }).ip).toBe(
       "a.example",

--- a/src/backend/database/routes/host-normalizers.ts
+++ b/src/backend/database/routes/host-normalizers.ts
@@ -41,6 +41,25 @@ function asPort(value: unknown): number | undefined {
   return isValidPort(port) ? port : undefined;
 }
 
+export function resolvePrimaryPort(
+  hostData: Record<string, unknown>,
+  connectionType: string,
+): number {
+  const genericPort = asPort(hostData.port);
+
+  if (connectionType === "rdp") {
+    return asPort(hostData.rdpPort) || genericPort || 3389;
+  }
+  if (connectionType === "vnc") {
+    return asPort(hostData.vncPort) || genericPort || 5900;
+  }
+  if (connectionType === "telnet") {
+    return asPort(hostData.telnetPort) || genericPort || 23;
+  }
+
+  return asPort(hostData.sshPort) || genericPort || 22;
+}
+
 function asInteger(value: unknown): number | undefined {
   const number =
     typeof value === "number"
@@ -148,15 +167,7 @@ export function normalizeImportedHost(
           ? "telnet"
           : "ssh");
 
-  const port =
-    asPort(hostData.port) ||
-    (connectionType === "rdp"
-      ? asPort(hostData.rdpPort) || 3389
-      : connectionType === "vnc"
-        ? asPort(hostData.vncPort) || 5900
-        : connectionType === "telnet"
-          ? asPort(hostData.telnetPort) || 23
-          : asPort(hostData.sshPort) || 22);
+  const port = resolvePrimaryPort(hostData, connectionType);
 
   return {
     ...hostData,

--- a/src/backend/database/routes/host.ts
+++ b/src/backend/database/routes/host.ts
@@ -29,6 +29,7 @@ import { pickResolvedUsername } from "../../ssh/credential-username.js";
 import {
   isNonEmptyString,
   isValidPort,
+  resolvePrimaryPort,
   stripSensitiveFields,
   transformHostResponse,
 } from "./host-normalizers.js";
@@ -215,22 +216,25 @@ router.post(
       ip,
     });
 
+    const effectiveConnectionType =
+      typeof connectionType === "string" ? connectionType : "ssh";
+    const effectivePort = resolvePrimaryPort(hostData, effectiveConnectionType);
+
     if (
       !isNonEmptyString(userId) ||
       !isNonEmptyString(ip) ||
-      !isValidPort(port)
+      !isValidPort(effectivePort)
     ) {
       sshLogger.warn("Invalid SSH data input validation failed", {
         operation: "host_create",
         userId,
         hasIp: !!ip,
-        port,
-        isValidPort: isValidPort(port),
+        port: effectivePort,
+        isValidPort: isValidPort(effectivePort),
       });
       return res.status(400).json({ error: "Invalid SSH data" });
     }
 
-    const effectiveConnectionType = connectionType || "ssh";
     const effectiveAuthType =
       authType ||
       authMethod ||
@@ -246,7 +250,7 @@ router.post(
       folder: folder || null,
       tags: Array.isArray(tags) ? tags.join(",") : tags || "",
       ip,
-      port,
+      port: effectivePort,
       username: effectiveUsername,
       authType: effectiveAuthType,
       useWarpgate: useWarpgate ? 1 : 0,
@@ -318,7 +322,10 @@ router.post(
       enableRdp: enableRdp ? 1 : 0,
       enableVnc: enableVnc ? 1 : 0,
       enableTelnet: enableTelnet ? 1 : 0,
-      sshPort: sshPort || port || 22,
+      sshPort:
+        effectiveConnectionType === "ssh"
+          ? effectivePort
+          : sshPort || port || 22,
       rdpPort: rdpPort || 3389,
       vncPort: vncPort || 5900,
       telnetPort: telnetPort || 23,
@@ -791,10 +798,14 @@ router.put(
       changes: Object.keys(hostData),
     });
 
+    const effectiveConnectionType =
+      typeof connectionType === "string" ? connectionType : "ssh";
+    const effectivePort = resolvePrimaryPort(hostData, effectiveConnectionType);
+
     if (
       !isNonEmptyString(userId) ||
       !isNonEmptyString(ip) ||
-      !isValidPort(port) ||
+      !isValidPort(effectivePort) ||
       !hostId
     ) {
       sshLogger.warn("Invalid SSH data input validation failed for update", {
@@ -802,8 +813,8 @@ router.put(
         hostId: parseInt(hostId),
         userId,
         hasIp: !!ip,
-        port,
-        isValidPort: isValidPort(port),
+        port: effectivePort,
+        isValidPort: isValidPort(effectivePort),
       });
       return res.status(400).json({ error: "Invalid SSH data" });
     }
@@ -814,12 +825,12 @@ router.put(
     const effectiveName =
       name || (effectiveUsername ? `${effectiveUsername}@${ip}` : String(ip));
     const sshDataObj: Record<string, unknown> = {
-      connectionType: connectionType || "ssh",
+      connectionType: effectiveConnectionType,
       name: effectiveName,
       folder,
       tags: Array.isArray(tags) ? tags.join(",") : tags || "",
       ip,
-      port,
+      port: effectivePort,
       username: effectiveUsername,
       authType: effectiveAuthType,
       useWarpgate: useWarpgate ? 1 : 0,
@@ -891,7 +902,10 @@ router.put(
       enableRdp: enableRdp ? 1 : 0,
       enableVnc: enableVnc ? 1 : 0,
       enableTelnet: enableTelnet ? 1 : 0,
-      sshPort: sshPort || port || 22,
+      sshPort:
+        effectiveConnectionType === "ssh"
+          ? effectivePort
+          : sshPort || port || 22,
       rdpPort: rdpPort || 3389,
       vncPort: vncPort || 5900,
       telnetPort: telnetPort || 23,


### PR DESCRIPTION
## Summary
- persist SSH hosts with the protocol-specific sshPort as the primary connection port
- reuse the same protocol port resolution for host create/update/import paths
- add a regression test for sshPort overriding legacy port 22

## Verification
- npm run lint
- npx prettier --check .
- npx tsc --noEmit
- npm exec vitest run -- src/backend/database/routes/host-normalizers.test.ts
- npm run build

Fixes Termix-SSH/Support#905