### PR TITLE
Prevent sidebar host hover layout shift

### DIFF
--- a/src/ui/sidebar/SidebarTree.tsx
+++ b/src/ui/sidebar/SidebarTree.tsx
@@ -676,7 +676,9 @@ export function HostItem({
 
           {/* Hover tray (non-click-tray mode) */}
           {!shouldUseClickTray && !selectionMode && (
-            <div className="max-h-0 opacity-0 overflow-hidden transition-all duration-150 ease-out group-hover:max-h-[200px] group-hover:opacity-100">
+            <div
+              className={`absolute left-[3px] right-0 top-full z-20 overflow-hidden border-b border-border bg-background/95 shadow-lg opacity-0 pointer-events-none transition-opacity duration-150 ease-out group-hover:opacity-100 group-hover:pointer-events-auto ${isMenuOpen ? "!opacity-100 !pointer-events-auto" : ""}`}
+            >
               <div className="flex items-center flex-wrap gap-1 px-2 pb-1">
                 {getSshActions(host).map(({ type, icon: Icon, label }) => (
                   <button
@@ -1077,9 +1079,13 @@ export function HostItem({
           </div>
         )}
 
-        {/* Action tray — slides open on hover (default) or via chevron in click-tray mode */}
+        {/* Action tray — floats on hover or expands via chevron in click-tray mode */}
         <div
-          className={`overflow-hidden transition-all duration-150 ease-out max-h-0 opacity-0 ${!shouldUseClickTray ? "group-hover:max-h-[300px] group-hover:opacity-100" : ""} ${selectionMode ? "!max-h-0 !opacity-0" : ""} ${(isMenuOpen || (shouldUseClickTray && isTrayOpen)) && !selectionMode ? "!max-h-[300px] !opacity-100" : ""}`}
+          className={
+            shouldUseClickTray
+              ? `overflow-hidden transition-all duration-150 ease-out max-h-0 opacity-0 ${selectionMode ? "!max-h-0 !opacity-0" : ""} ${(isMenuOpen || isTrayOpen) && !selectionMode ? "!max-h-[300px] !opacity-100" : ""}`
+              : `absolute left-[3px] right-0 top-full z-20 overflow-hidden border-b border-border bg-background/95 shadow-lg opacity-0 pointer-events-none transition-opacity duration-150 ease-out group-hover:opacity-100 group-hover:pointer-events-auto ${selectionMode ? "!opacity-0 !pointer-events-none" : ""} ${isMenuOpen && !selectionMode ? "!opacity-100 !pointer-events-auto" : ""}`
+          }
         >
           {isOnline &&
             ((host.cpu != null && host.cpu > 0) ||


### PR DESCRIPTION
## Summary
- make sidebar host hover action trays float outside the row layout
- keep click/touch action trays expanding as before
- apply the same no-layout-shift behavior to compact and regular host rows

## Verification
- npx prettier --check .
- npx tsc --noEmit
- npm run lint
- npm run build

Fixes Termix-SSH/Support#903