### PR TITLE
Add host temperature metrics card

### DIFF
--- a/src/backend/ssh/host-metrics.ts
+++ b/src/backend/ssh/host-metrics.ts
@@ -24,6 +24,7 @@ import { collectSystemMetrics } from "./widgets/system-collector.js";
 import { collectLoginStats } from "./widgets/login-stats-collector.js";
 import { collectPortsMetrics } from "./widgets/ports-collector.js";
 import { collectFirewallMetrics } from "./widgets/firewall-collector.js";
+import { collectTemperatureMetrics } from "./widgets/temperature-collector.js";
 import {
   createSocks5Connection,
   type SOCKS5Config,
@@ -132,6 +133,7 @@ const DEFAULT_STATS_CONFIG: StatsConfig = {
     "processes",
     "ports",
     "firewall",
+    "temperature",
   ],
   statusCheckEnabled: true,
   statusCheckInterval: 60,
@@ -1373,6 +1375,14 @@ async function collectMetrics(host: SSHHostWithCredentials): Promise<{
     kernel: string | null;
     os: string | null;
   };
+  temperature: {
+    source: "sysfs" | "sensors" | "none";
+    highestCelsius: number | null;
+    sensors: Array<{
+      label: string;
+      celsius: number;
+    }>;
+  };
 }> {
   if (!supportsMetrics(host)) {
     throw new Error("Metrics collection only supported for SSH hosts");
@@ -1403,6 +1413,7 @@ async function collectMetrics(host: SSHHostWithCredentials): Promise<{
         const uptime = await collectUptimeMetrics(client);
         const processes = await collectProcessesMetrics(client);
         const system = await collectSystemMetrics(client);
+        const temperature = await collectTemperatureMetrics(client);
 
         let login_stats = {
           recentLogins: [],
@@ -1474,6 +1485,7 @@ async function collectMetrics(host: SSHHostWithCredentials): Promise<{
           uptime,
           processes,
           system,
+          temperature,
           login_stats,
           ports,
           firewall,

--- a/src/backend/ssh/widgets/temperature-collector.test.ts
+++ b/src/backend/ssh/widgets/temperature-collector.test.ts
@@ -1,0 +1,33 @@
+import { describe, expect, it } from "vitest";
+import {
+  parseSensorsOutput,
+  parseSysfsThermalOutput,
+} from "./temperature-collector.js";
+
+describe("temperature collectors", () => {
+  it("parses sysfs thermal zone output", () => {
+    const result = parseSysfsThermalOutput(
+      "x86_pkg_temp\t51000\nacpitz\t42\nbad\tnope\n",
+    );
+
+    expect(result).toEqual([
+      { label: "x86_pkg_temp", celsius: 51 },
+      { label: "acpitz", celsius: 42 },
+    ]);
+  });
+
+  it("parses lm-sensors temperature lines", () => {
+    const result = parseSensorsOutput(`
+coretemp-isa-0000
+Adapter: ISA adapter
+Package id 0:  +52.0°C  (high = +80.0°C, crit = +100.0°C)
+Core 0:        +48.5°C
+fan1:          1200 RPM
+`);
+
+    expect(result).toEqual([
+      { label: "Package id 0", celsius: 52 },
+      { label: "Core 0", celsius: 48.5 },
+    ]);
+  });
+});

--- a/src/backend/ssh/widgets/temperature-collector.ts
+++ b/src/backend/ssh/widgets/temperature-collector.ts
@@ -1,0 +1,117 @@
+import type { Client } from "ssh2";
+import { execCommand, toFixedNum } from "./common-utils.js";
+
+export interface TemperatureSensor {
+  label: string;
+  celsius: number;
+}
+
+export interface TemperatureMetrics {
+  source: "sysfs" | "sensors" | "none";
+  highestCelsius: number | null;
+  sensors: TemperatureSensor[];
+}
+
+function normalizeSensor(
+  label: string,
+  celsius: number,
+): TemperatureSensor | null {
+  const cleanLabel = label.trim().replace(/\s+/g, " ");
+  if (!cleanLabel || !Number.isFinite(celsius)) return null;
+  return {
+    label: cleanLabel,
+    celsius: toFixedNum(celsius, 1) ?? celsius,
+  };
+}
+
+function summarizeSensors(
+  source: TemperatureMetrics["source"],
+  sensors: TemperatureSensor[],
+): TemperatureMetrics {
+  const highest = sensors.reduce<number | null>(
+    (max, sensor) =>
+      max === null ? sensor.celsius : Math.max(max, sensor.celsius),
+    null,
+  );
+
+  return {
+    source: sensors.length > 0 ? source : "none",
+    highestCelsius:
+      highest === null ? null : (toFixedNum(highest, 1) ?? highest),
+    sensors,
+  };
+}
+
+export function parseSysfsThermalOutput(output: string): TemperatureSensor[] {
+  return output
+    .split("\n")
+    .map((line) => {
+      const [label, rawValue] = line.split("\t");
+      const value = Number(rawValue);
+      if (!label || !Number.isFinite(value)) return null;
+      const celsius = Math.abs(value) >= 1000 ? value / 1000 : value;
+      return normalizeSensor(label, celsius);
+    })
+    .filter((sensor): sensor is TemperatureSensor => sensor !== null);
+}
+
+export function parseSensorsOutput(output: string): TemperatureSensor[] {
+  const seen = new Set<string>();
+  const sensors: TemperatureSensor[] = [];
+
+  for (const line of output.split("\n")) {
+    const match = line.match(/^\s*([^:]+):\s*([+-]?\d+(?:\.\d+)?)\s*°?C\b/i);
+    if (!match) continue;
+
+    const sensor = normalizeSensor(match[1], Number(match[2]));
+    if (!sensor) continue;
+
+    const key = `${sensor.label.toLowerCase()}:${sensor.celsius}`;
+    if (seen.has(key)) continue;
+    seen.add(key);
+    sensors.push(sensor);
+  }
+
+  return sensors;
+}
+
+export async function collectTemperatureMetrics(
+  client: Client,
+): Promise<TemperatureMetrics> {
+  try {
+    const sysfs = await execCommand(
+      client,
+      [
+        "for zone in /sys/class/thermal/thermal_zone*; do",
+        '[ -r "$zone/temp" ] || continue;',
+        'label="$(cat "$zone/type" 2>/dev/null || basename "$zone")";',
+        'value="$(cat "$zone/temp" 2>/dev/null || true)";',
+        '[ -n "$value" ] && printf "%s\\t%s\\n" "$label" "$value";',
+        "done",
+      ].join(" "),
+      10000,
+    );
+    const sensors = parseSysfsThermalOutput(sysfs.stdout);
+    if (sensors.length > 0) {
+      return summarizeSensors("sysfs", sensors);
+    }
+  } catch {
+    // expected on systems without readable thermal zones
+  }
+
+  try {
+    const lmSensors = await execCommand(client, "sensors 2>/dev/null", 10000);
+    const sensors = parseSensorsOutput(lmSensors.stdout);
+    if (sensors.length > 0) {
+      return summarizeSensors("sensors", sensors);
+    }
+  } catch {
+    // expected when lm-sensors is not installed
+  }
+
+  return {
+    source: "none",
+    highestCelsius: null,
+    sensors: [],
+  };
+}

--- a/src/types/host-metrics.ts
+++ b/src/types/host-metrics.ts
@@ -53,6 +53,7 @@ export const METRIC_CARD_IDS: HostMetricCardId[] = [
   "processes",
   "ports",
   "firewall",
+  "temperature",
 ];
 
 export const MANAGER_CARD_IDS: HostMetricManagerId[] = [
@@ -100,6 +101,7 @@ const DEFAULT_COLSPAN: Partial<Record<HostMetricsCardId, HostMetricsColSpan>> =
     uptime: 1,
     system: 1,
     network: 1,
+    temperature: 1,
     processes: 2,
     ports: 2,
     firewall: 2,

--- a/src/types/stats-widgets.ts
+++ b/src/types/stats-widgets.ts
@@ -8,7 +8,8 @@ export type WidgetType =
   | "system"
   | "login_stats"
   | "ports"
-  | "firewall";
+  | "firewall"
+  | "temperature";
 
 export interface ListeningPort {
   protocol: "tcp" | "udp";
@@ -49,6 +50,17 @@ export interface FirewallMetrics {
   chains: FirewallChain[];
 }
 
+export interface TemperatureSensor {
+  label: string;
+  celsius: number;
+}
+
+export interface TemperatureMetrics {
+  source: "sysfs" | "sensors" | "none";
+  highestCelsius: number | null;
+  sensors: TemperatureSensor[];
+}
+
 export interface StatsConfig {
   enabledWidgets: WidgetType[];
   statusCheckEnabled: boolean;
@@ -72,6 +84,7 @@ export const DEFAULT_STATS_CONFIG: StatsConfig = {
     "processes",
     "ports",
     "firewall",
+    "temperature",
   ],
   statusCheckEnabled: true,
   statusCheckInterval: 30,

--- a/src/ui/features/host-metrics/cards/TemperatureCard.tsx
+++ b/src/ui/features/host-metrics/cards/TemperatureCard.tsx
@@ -1,0 +1,56 @@
+import { Thermometer } from "lucide-react";
+import { useTranslation } from "react-i18next";
+import type { ServerMetrics } from "@/main-axios";
+import { StatRow } from "@/components/charts";
+import { MetricCard } from "./MetricCard";
+
+function formatTemperature(value: number | null | undefined): string {
+  return typeof value === "number" && Number.isFinite(value)
+    ? `${value.toFixed(1)}°C`
+    : "N/A";
+}
+
+export function TemperatureCard({
+  metrics,
+}: {
+  metrics: ServerMetrics | null;
+}) {
+  const { t } = useTranslation();
+  const temperature = metrics?.temperature;
+  const sensors = temperature?.sensors ?? [];
+
+  return (
+    <MetricCard
+      title={t("hostMetrics.temperature")}
+      icon={<Thermometer className="size-3.5" />}
+      scroll={sensors.length > 4}
+      scrollMax={220}
+    >
+      <div className="flex flex-col gap-3">
+        <div>
+          <div className="text-3xl font-semibold tabular-nums">
+            {formatTemperature(temperature?.highestCelsius)}
+          </div>
+          <div className="mt-1 text-xs text-muted-foreground">
+            {t("hostMetrics.highestTemperature")}
+          </div>
+        </div>
+
+        {sensors.length === 0 ? (
+          <span className="text-xs text-muted-foreground">N/A</span>
+        ) : (
+          <div className="flex flex-col divide-y divide-border">
+            {sensors.map((sensor) => (
+              <StatRow
+                key={`${sensor.label}-${sensor.celsius}`}
+                label={sensor.label}
+                value={formatTemperature(sensor.celsius)}
+                mono
+              />
+            ))}
+          </div>
+        )}
+      </div>
+    </MetricCard>
+  );
+}

--- a/src/ui/features/host-metrics/cards/index.tsx
+++ b/src/ui/features/host-metrics/cards/index.tsx
@@ -12,6 +12,7 @@ import { LoginStatsCard } from "./LoginStatsCard";
 import { PortsCard } from "./PortsCard";
 import { ProcessesCard } from "./ProcessesCard";
 import { FirewallCard } from "./FirewallCard";
+import { TemperatureCard } from "./TemperatureCard";
 import { ServiceManagerCard } from "./managers/ServiceManagerCard";
 import { ProcessInspectorCard } from "./managers/ProcessInspectorCard";
 import { PackageManagerCard } from "./managers/PackageManagerCard";
@@ -123,6 +124,11 @@ export const CARD_DEFINITIONS: Record<string, CardDefinition> = {
   ports: metricCard("ports", "hostMetrics.ports.title", PortsCard),
   processes: metricCard("processes", "hostMetrics.processes", ProcessesCard),
   firewall: metricCard("firewall", "hostMetrics.firewall.title", FirewallCard),
+  temperature: metricCard(
+    "temperature",
+    "hostMetrics.temperature",
+    TemperatureCard,
+  ),
   service_manager: managerCard(
     "service_manager",
     "hostMetrics.managers.services",

--- a/src/ui/locales/en.json
+++ b/src/ui/locales/en.json
@@ -1694,6 +1694,8 @@
     "cpuUsage": "CPU Usage",
     "memoryUsage": "Memory Usage",
     "diskUsage": "Disk Usage",
+    "temperature": "Temperature",
+    "highestTemperature": "Highest temperature",
     "failedToFetchHostConfig": "Failed to fetch host configuration",
     "serverOffline": "Server Offline",
     "cannotFetchMetrics": "Cannot fetch metrics from offline server",

--- a/src/ui/locales/translated/af_ZA.json
+++ b/src/ui/locales/translated/af_ZA.json
@@ -1690,7 +1690,9 @@
       "logGrep": "Filter lines...",
       "firewallPersist": "Persist rules",
       "firewallPersisted": "Firewall rules persisted"
-    }
+    },
+    "temperature": "Temperature",
+    "highestTemperature": "Highest temperature"
   },
   "auth": {
     "tagline": "Self-gehoste SSH en afstandrekenaarbestuur",

--- a/src/ui/locales/translated/ar_SA.json
+++ b/src/ui/locales/translated/ar_SA.json
@@ -1690,7 +1690,9 @@
       "logGrep": "Filter lines...",
       "firewallPersist": "Persist rules",
       "firewallPersisted": "Firewall rules persisted"
-    }
+    },
+    "temperature": "Temperature",
+    "highestTemperature": "Highest temperature"
   },
   "auth": {
     "tagline": "إدارة SSH وسطح المكتب عن بُعد ذاتية الاستضافة",

--- a/src/ui/locales/translated/bg_BG.json
+++ b/src/ui/locales/translated/bg_BG.json
@@ -1690,7 +1690,9 @@
       "logGrep": "Filter lines...",
       "firewallPersist": "Persist rules",
       "firewallPersisted": "Firewall rules persisted"
-    }
+    },
+    "temperature": "Temperature",
+    "highestTemperature": "Highest temperature"
   },
   "auth": {
     "tagline": "Самостоятелно хоствано SSH и управление на отдалечен работен плот",

--- a/src/ui/locales/translated/bn_BD.json
+++ b/src/ui/locales/translated/bn_BD.json
@@ -1690,7 +1690,9 @@
       "logGrep": "Filter lines...",
       "firewallPersist": "Persist rules",
       "firewallPersisted": "Firewall rules persisted"
-    }
+    },
+    "temperature": "Temperature",
+    "highestTemperature": "Highest temperature"
   },
   "auth": {
     "tagline": "সেলফ-হোস্টেড SSH এবং রিমোট ডেস্কটপ ম্যানেজমেন্ট",

--- a/src/ui/locales/translated/ca_ES.json
+++ b/src/ui/locales/translated/ca_ES.json
@@ -1690,7 +1690,9 @@
       "logGrep": "Filter lines...",
       "firewallPersist": "Persist rules",
       "firewallPersisted": "Firewall rules persisted"
-    }
+    },
+    "temperature": "Temperature",
+    "highestTemperature": "Highest temperature"
   },
   "auth": {
     "tagline": "SSH autoallotjat i gestió d'escriptori remot",

--- a/src/ui/locales/translated/cs_CZ.json
+++ b/src/ui/locales/translated/cs_CZ.json
@@ -1690,7 +1690,9 @@
       "logGrep": "Filter lines...",
       "firewallPersist": "Persist rules",
       "firewallPersisted": "Firewall rules persisted"
-    }
+    },
+    "temperature": "Temperature",
+    "highestTemperature": "Highest temperature"
   },
   "auth": {
     "tagline": "Samostatně hostované SSH a správa vzdálené plochy",

--- a/src/ui/locales/translated/da_DK.json
+++ b/src/ui/locales/translated/da_DK.json
@@ -1690,7 +1690,9 @@
       "logGrep": "Filter lines...",
       "firewallPersist": "Persist rules",
       "firewallPersisted": "Firewall rules persisted"
-    }
+    },
+    "temperature": "Temperature",
+    "highestTemperature": "Highest temperature"
   },
   "auth": {
     "tagline": "Selvhostet SSH og fjernskrivebordsadministration",

--- a/src/ui/locales/translated/de_DE.json
+++ b/src/ui/locales/translated/de_DE.json
@@ -1690,7 +1690,9 @@
       "logGrep": "Filter lines...",
       "firewallPersist": "Persist rules",
       "firewallPersisted": "Firewall rules persisted"
-    }
+    },
+    "temperature": "Temperature",
+    "highestTemperature": "Highest temperature"
   },
   "auth": {
     "tagline": "Selbstgehostete SSH- und Remote-Desktop-Verwaltung",

--- a/src/ui/locales/translated/el_GR.json
+++ b/src/ui/locales/translated/el_GR.json
@@ -1690,7 +1690,9 @@
       "logGrep": "Filter lines...",
       "firewallPersist": "Persist rules",
       "firewallPersisted": "Firewall rules persisted"
-    }
+    },
+    "temperature": "Temperature",
+    "highestTemperature": "Highest temperature"
   },
   "auth": {
     "tagline": "Αυτοφιλοξενούμενη διαχείριση SSH και απομακρυσμένης επιφάνειας εργασίας",

--- a/src/ui/locales/translated/es_ES.json
+++ b/src/ui/locales/translated/es_ES.json
@@ -1690,7 +1690,9 @@
       "logGrep": "Filter lines...",
       "firewallPersist": "Persist rules",
       "firewallPersisted": "Firewall rules persisted"
-    }
+    },
+    "temperature": "Temperature",
+    "highestTemperature": "Highest temperature"
   },
   "auth": {
     "tagline": "Gestión de escritorio remoto y SSH autogestionada",

--- a/src/ui/locales/translated/fi_FI.json
+++ b/src/ui/locales/translated/fi_FI.json
@@ -1690,7 +1690,9 @@
       "logGrep": "Filter lines...",
       "firewallPersist": "Persist rules",
       "firewallPersisted": "Firewall rules persisted"
-    }
+    },
+    "temperature": "Temperature",
+    "highestTemperature": "Highest temperature"
   },
   "auth": {
     "tagline": "Itse isännöity SSH ja etätyöpöytähallinta",

--- a/src/ui/locales/translated/fr_FR.json
+++ b/src/ui/locales/translated/fr_FR.json
@@ -1690,7 +1690,9 @@
       "logGrep": "Filter lines...",
       "firewallPersist": "Persist rules",
       "firewallPersisted": "Firewall rules persisted"
-    }
+    },
+    "temperature": "Temperature",
+    "highestTemperature": "Highest temperature"
   },
   "auth": {
     "tagline": "Gestion SSH et de bureau à distance auto-hébergée",

--- a/src/ui/locales/translated/he_IL.json
+++ b/src/ui/locales/translated/he_IL.json
@@ -1690,7 +1690,9 @@
       "logGrep": "Filter lines...",
       "firewallPersist": "Persist rules",
       "firewallPersisted": "Firewall rules persisted"
-    }
+    },
+    "temperature": "Temperature",
+    "highestTemperature": "Highest temperature"
   },
   "auth": {
     "tagline": "ניהול SSH ושולחן עבודה מרוחק באחסון עצמי",

--- a/src/ui/locales/translated/hi_IN.json
+++ b/src/ui/locales/translated/hi_IN.json
@@ -1690,7 +1690,9 @@
       "logGrep": "Filter lines...",
       "firewallPersist": "Persist rules",
       "firewallPersisted": "Firewall rules persisted"
-    }
+    },
+    "temperature": "Temperature",
+    "highestTemperature": "Highest temperature"
   },
   "auth": {
     "tagline": "सेल्फ-होस्टेड एसएसएच और रिमोट डेस्कटॉप प्रबंधन",

--- a/src/ui/locales/translated/hu_HU.json
+++ b/src/ui/locales/translated/hu_HU.json
@@ -1690,7 +1690,9 @@
       "logGrep": "Filter lines...",
       "firewallPersist": "Persist rules",
       "firewallPersisted": "Firewall rules persisted"
-    }
+    },
+    "temperature": "Temperature",
+    "highestTemperature": "Highest temperature"
   },
   "auth": {
     "tagline": "Saját üzemeltetésű SSH és távoli asztalkezelés",

--- a/src/ui/locales/translated/id_ID.json
+++ b/src/ui/locales/translated/id_ID.json
@@ -1690,7 +1690,9 @@
       "logGrep": "Filter lines...",
       "firewallPersist": "Persist rules",
       "firewallPersisted": "Firewall rules persisted"
-    }
+    },
+    "temperature": "Temperature",
+    "highestTemperature": "Highest temperature"
   },
   "auth": {
     "tagline": "Manajemen SSH dan desktop jarak jauh yang dihosting sendiri",

--- a/src/ui/locales/translated/it_IT.json
+++ b/src/ui/locales/translated/it_IT.json
@@ -1690,7 +1690,9 @@
       "logGrep": "Filter lines...",
       "firewallPersist": "Persist rules",
       "firewallPersisted": "Firewall rules persisted"
-    }
+    },
+    "temperature": "Temperature",
+    "highestTemperature": "Highest temperature"
   },
   "auth": {
     "tagline": "Gestione SSH e desktop remoto self-hosted",

--- a/src/ui/locales/translated/ja_JP.json
+++ b/src/ui/locales/translated/ja_JP.json
@@ -1690,7 +1690,9 @@
       "logGrep": "Filter lines...",
       "firewallPersist": "Persist rules",
       "firewallPersisted": "Firewall rules persisted"
-    }
+    },
+    "temperature": "Temperature",
+    "highestTemperature": "Highest temperature"
   },
   "auth": {
     "tagline": "セルフホスト型のSSHおよびリモートデスクトップ管理",

--- a/src/ui/locales/translated/ko_KR.json
+++ b/src/ui/locales/translated/ko_KR.json
@@ -1690,7 +1690,9 @@
       "logGrep": "Filter lines...",
       "firewallPersist": "Persist rules",
       "firewallPersisted": "Firewall rules persisted"
-    }
+    },
+    "temperature": "Temperature",
+    "highestTemperature": "Highest temperature"
   },
   "auth": {
     "tagline": "자체 호스팅 SSH 및 원격 데스크톱 관리",

--- a/src/ui/locales/translated/nl_NL.json
+++ b/src/ui/locales/translated/nl_NL.json
@@ -1690,7 +1690,9 @@
       "logGrep": "Filter lines...",
       "firewallPersist": "Persist rules",
       "firewallPersisted": "Firewall rules persisted"
-    }
+    },
+    "temperature": "Temperature",
+    "highestTemperature": "Highest temperature"
   },
   "auth": {
     "tagline": "Zelf gehoste SSH- en beheerservices voor externe bureaubladen",

--- a/src/ui/locales/translated/no_NO.json
+++ b/src/ui/locales/translated/no_NO.json
@@ -1690,7 +1690,9 @@
       "logGrep": "Filter lines...",
       "firewallPersist": "Persist rules",
       "firewallPersisted": "Firewall rules persisted"
-    }
+    },
+    "temperature": "Temperature",
+    "highestTemperature": "Highest temperature"
   },
   "auth": {
     "tagline": "Selvhostet SSH og ekstern skrivebordsadministrasjon",

--- a/src/ui/locales/translated/pl_PL.json
+++ b/src/ui/locales/translated/pl_PL.json
@@ -1690,7 +1690,9 @@
       "logGrep": "Filter lines...",
       "firewallPersist": "Persist rules",
       "firewallPersisted": "Firewall rules persisted"
-    }
+    },
+    "temperature": "Temperature",
+    "highestTemperature": "Highest temperature"
   },
   "auth": {
     "tagline": "Samodzielnie hostowany SSH i zdalne zarządzanie pulpitem",

--- a/src/ui/locales/translated/pt_BR.json
+++ b/src/ui/locales/translated/pt_BR.json
@@ -1690,7 +1690,9 @@
       "logGrep": "Filter lines...",
       "firewallPersist": "Persist rules",
       "firewallPersisted": "Firewall rules persisted"
-    }
+    },
+    "temperature": "Temperature",
+    "highestTemperature": "Highest temperature"
   },
   "auth": {
     "tagline": "SSH autohospedado e gerenciamento de desktop remoto",

--- a/src/ui/locales/translated/pt_PT.json
+++ b/src/ui/locales/translated/pt_PT.json
@@ -1690,7 +1690,9 @@
       "logGrep": "Filter lines...",
       "firewallPersist": "Persist rules",
       "firewallPersisted": "Firewall rules persisted"
-    }
+    },
+    "temperature": "Temperature",
+    "highestTemperature": "Highest temperature"
   },
   "auth": {
     "tagline": "SSH auto-hospedado e gestão de desktop remoto",

--- a/src/ui/locales/translated/ro_RO.json
+++ b/src/ui/locales/translated/ro_RO.json
@@ -1690,7 +1690,9 @@
       "logGrep": "Filter lines...",
       "firewallPersist": "Persist rules",
       "firewallPersisted": "Firewall rules persisted"
-    }
+    },
+    "temperature": "Temperature",
+    "highestTemperature": "Highest temperature"
   },
   "auth": {
     "tagline": "Gestionare SSH și desktop la distanță auto-găzduită",

--- a/src/ui/locales/translated/ru_RU.json
+++ b/src/ui/locales/translated/ru_RU.json
@@ -1690,7 +1690,9 @@
       "logGrep": "Filter lines...",
       "firewallPersist": "Persist rules",
       "firewallPersisted": "Firewall rules persisted"
-    }
+    },
+    "temperature": "Temperature",
+    "highestTemperature": "Highest temperature"
   },
   "auth": {
     "tagline": "Самостоятельно размещаемые SSH-серверы и системы удаленного управления рабочим столом",

--- a/src/ui/locales/translated/sr_SP.json
+++ b/src/ui/locales/translated/sr_SP.json
@@ -1690,7 +1690,9 @@
       "logGrep": "Filter lines...",
       "firewallPersist": "Persist rules",
       "firewallPersisted": "Firewall rules persisted"
-    }
+    },
+    "temperature": "Temperature",
+    "highestTemperature": "Highest temperature"
   },
   "auth": {
     "tagline": "Самостално хостовано SSH и управљање удаљеном радном површином",

--- a/src/ui/locales/translated/sv_SE.json
+++ b/src/ui/locales/translated/sv_SE.json
@@ -1690,7 +1690,9 @@
       "logGrep": "Filter lines...",
       "firewallPersist": "Persist rules",
       "firewallPersisted": "Firewall rules persisted"
-    }
+    },
+    "temperature": "Temperature",
+    "highestTemperature": "Highest temperature"
   },
   "auth": {
     "tagline": "Självhostad SSH och fjärrskrivbordshantering",

--- a/src/ui/locales/translated/th_TH.json
+++ b/src/ui/locales/translated/th_TH.json
@@ -1690,7 +1690,9 @@
       "logGrep": "Filter lines...",
       "firewallPersist": "Persist rules",
       "firewallPersisted": "Firewall rules persisted"
-    }
+    },
+    "temperature": "Temperature",
+    "highestTemperature": "Highest temperature"
   },
   "auth": {
     "tagline": "การจัดการ SSH และเดสก์ท็อประยะไกลแบบโฮสต์เอง",

--- a/src/ui/locales/translated/tr_TR.json
+++ b/src/ui/locales/translated/tr_TR.json
@@ -1690,7 +1690,9 @@
       "logGrep": "Filter lines...",
       "firewallPersist": "Persist rules",
       "firewallPersisted": "Firewall rules persisted"
-    }
+    },
+    "temperature": "Temperature",
+    "highestTemperature": "Highest temperature"
   },
   "auth": {
     "tagline": "Kendi sunucunuzda barındırılan SSH ve uzaktan masaüstü yönetimi",

--- a/src/ui/locales/translated/uk_UA.json
+++ b/src/ui/locales/translated/uk_UA.json
@@ -1690,7 +1690,9 @@
       "logGrep": "Filter lines...",
       "firewallPersist": "Persist rules",
       "firewallPersisted": "Firewall rules persisted"
-    }
+    },
+    "temperature": "Temperature",
+    "highestTemperature": "Highest temperature"
   },
   "auth": {
     "tagline": "Власне керування SSH та віддаленим робочим столом",

--- a/src/ui/locales/translated/vi_VN.json
+++ b/src/ui/locales/translated/vi_VN.json
@@ -1690,7 +1690,9 @@
       "logGrep": "Filter lines...",
       "firewallPersist": "Persist rules",
       "firewallPersisted": "Firewall rules persisted"
-    }
+    },
+    "temperature": "Temperature",
+    "highestTemperature": "Highest temperature"
   },
   "auth": {
     "tagline": "Quản lý SSH và máy tính từ xa tự lưu trữ",

--- a/src/ui/locales/translated/zh_CN.json
+++ b/src/ui/locales/translated/zh_CN.json
@@ -1690,7 +1690,9 @@
       "logGrep": "Filter lines...",
       "firewallPersist": "Persist rules",
       "firewallPersisted": "Firewall rules persisted"
-    }
+    },
+    "temperature": "温度",
+    "highestTemperature": "最高温度"
   },
   "auth": {
     "tagline": "自托管 SSH 和远程桌面管理",

--- a/src/ui/locales/translated/zh_TW.json
+++ b/src/ui/locales/translated/zh_TW.json
@@ -1690,7 +1690,9 @@
       "logGrep": "Filter lines...",
       "firewallPersist": "Persist rules",
       "firewallPersisted": "Firewall rules persisted"
-    }
+    },
+    "temperature": "溫度",
+    "highestTemperature": "最高溫度"
   },
   "auth": {
     "tagline": "自託管 SSH 和遠端桌面管理",

--- a/src/ui/main-axios.ts
+++ b/src/ui/main-axios.ts
@@ -170,6 +170,14 @@ export type ServerMetrics = {
     status?: "active" | "inactive" | "unknown";
     chains?: FirewallChain[];
   };
+  temperature?: {
+    source?: "sysfs" | "sensors" | "none";
+    highestCelsius?: number | null;
+    sensors?: Array<{
+      label: string;
+      celsius: number;
+    }>;
+  };
   lastChecked: string;
 };
 

--- a/src/ui/sidebar/HostEditorData.ts
+++ b/src/ui/sidebar/HostEditorData.ts
@@ -229,6 +229,7 @@ export function createHostEditorForm(
         "processes",
         "ports",
         "firewall",
+        "temperature",
       ],
     },
   };


### PR DESCRIPTION
## Summary
- collect host temperature sensors from Linux thermal sysfs with an lm-sensors fallback
- add a Host Metrics temperature card showing the highest reading and sensor list
- include temperature in default metric widgets and translated locale keys

## Notes
- This displays hardware thermal sensors exposed by the host OS. It does not attempt GPU-specific tools or metrics history storage in this PR.

## Verification
- npx vitest run src/backend/ssh/widgets/temperature-collector.test.ts
- npx prettier --check .
- npx tsc --noEmit
- npm run lint
- npm run build

Fixes Termix-SSH/Support#890