### PR TITLE
Make file downloads reliable in desktop app

### DIFF
--- a/src/ui/api/ssh-file-operations-api.ts
+++ b/src/ui/api/ssh-file-operations-api.ts
@@ -42,6 +42,22 @@ function buildFileManagerUrl(path: string): string {
   return `${baseURL.replace(/\/$/, "")}${path}`;
 }
 
+function triggerBlobDownload(blob: Blob, fileName: string): void {
+  const url = URL.createObjectURL(blob);
+  const link = document.createElement("a");
+  link.href = url;
+  link.download = fileName;
+  link.style.display = "none";
+
+  document.body.appendChild(link);
+  link.click();
+
+  window.setTimeout(() => {
+    link.remove();
+    URL.revokeObjectURL(url);
+  }, 1000);
+}
+
 async function uploadSSHFileInChunks(
   sessionId: string,
   path: string,
@@ -492,12 +508,7 @@ export async function downloadSSHFileStream(
   );
   const blob = response.data as Blob;
   const fileName = filePath.split("/").pop() || "download";
-  const url = URL.createObjectURL(blob);
-  const a = document.createElement("a");
-  a.href = url;
-  a.download = fileName;
-  a.click();
-  URL.revokeObjectURL(url);
+  triggerBlobDownload(blob, fileName);
 }
 
 export async function createSSHFile(


### PR DESCRIPTION
## Summary
- keep blob download URLs alive briefly after triggering a file-manager download
- append the temporary download anchor to the document before clicking it for better Electron/Windows reliability
- leave the backend download stream unchanged

## Notes
- The upload side of Support#901 is already covered by #929/#932. This PR addresses the remaining fragile client-side download trigger path.

## Verification
- npx prettier --check .
- npx tsc --noEmit
- npx eslint src/ui/api/ssh-file-operations-api.ts
- npm run lint
- npm run build

Refs Termix-SSH/Support#901