### PR TITLE
Add app rail hover expansion setting

### DIFF
--- a/src/backend/database/db/index.ts
+++ b/src/backend/database/db/index.ts
@@ -689,6 +689,11 @@ const migrateSchema = () => {
   addColumnIfNotExists("user_preferences", "show_host_tags", "INTEGER");
   addColumnIfNotExists("user_preferences", "host_tray_on_click", "INTEGER");
   addColumnIfNotExists("user_preferences", "pin_app_rail", "INTEGER");
+  addColumnIfNotExists(
+    "user_preferences",
+    "expand_app_rail_on_hover",
+    "INTEGER",
+  );
   addColumnIfNotExists("user_preferences", "folders_collapsed", "INTEGER");
   addColumnIfNotExists("user_preferences", "confirm_snippet_execution", "INTEGER");
   addColumnIfNotExists("user_preferences", "disable_update_check", "INTEGER");

--- a/src/backend/database/db/schema.ts
+++ b/src/backend/database/db/schema.ts
@@ -774,6 +774,9 @@ export const userPreferences = sqliteTable("user_preferences", {
   showHostTags: integer("show_host_tags", { mode: "boolean" }),
   hostTrayOnClick: integer("host_tray_on_click", { mode: "boolean" }),
   pinAppRail: integer("pin_app_rail", { mode: "boolean" }),
+  expandAppRailOnHover: integer("expand_app_rail_on_hover", {
+    mode: "boolean",
+  }),
   foldersCollapsed: integer("folders_collapsed", { mode: "boolean" }),
   confirmSnippetExecution: integer("confirm_snippet_execution", { mode: "boolean" }),
   disableUpdateCheck: integer("disable_update_check", { mode: "boolean" }),

--- a/src/backend/database/routes/user-preferences.ts
+++ b/src/backend/database/routes/user-preferences.ts
@@ -23,6 +23,7 @@ const pickPreferences = (row?: typeof userPreferences.$inferSelect) => ({
   showHostTags: row?.showHostTags ?? null,
   hostTrayOnClick: row?.hostTrayOnClick ?? null,
   pinAppRail: row?.pinAppRail ?? null,
+  expandAppRailOnHover: row?.expandAppRailOnHover ?? null,
   foldersCollapsed: row?.foldersCollapsed ?? null,
   confirmSnippetExecution: row?.confirmSnippetExecution ?? null,
   disableUpdateCheck: row?.disableUpdateCheck ?? null,
@@ -77,6 +78,9 @@ const pickPreferences = (row?: typeof userPreferences.$inferSelect) => ({
  *                   type: boolean
  *                   nullable: true
  *                 pinAppRail:
+ *                   type: boolean
+ *                   nullable: true
+ *                 expandAppRailOnHover:
  *                   type: boolean
  *                   nullable: true
  *                 foldersCollapsed:
@@ -156,6 +160,8 @@ router.get("/", authenticateJWT, (req: Request, res: Response) => {
  *                 type: boolean
  *               pinAppRail:
  *                 type: boolean
+ *               expandAppRailOnHover:
+ *                 type: boolean
  *               foldersCollapsed:
  *                 type: boolean
  *               confirmSnippetExecution:
@@ -188,6 +194,7 @@ router.put("/", authenticateJWT, (req: Request, res: Response) => {
     showHostTags,
     hostTrayOnClick,
     pinAppRail,
+    expandAppRailOnHover,
     foldersCollapsed,
     confirmSnippetExecution,
     disableUpdateCheck,
@@ -207,6 +214,7 @@ router.put("/", authenticateJWT, (req: Request, res: Response) => {
     showHostTags?: boolean | null;
     hostTrayOnClick?: boolean | null;
     pinAppRail?: boolean | null;
+    expandAppRailOnHover?: boolean | null;
     foldersCollapsed?: boolean | null;
     confirmSnippetExecution?: boolean | null;
     disableUpdateCheck?: boolean | null;
@@ -249,6 +257,7 @@ router.put("/", authenticateJWT, (req: Request, res: Response) => {
     showHostTags,
     hostTrayOnClick,
     pinAppRail,
+    expandAppRailOnHover,
     foldersCollapsed,
     confirmSnippetExecution,
     disableUpdateCheck,
@@ -274,6 +283,8 @@ router.put("/", authenticateJWT, (req: Request, res: Response) => {
   if (showHostTags !== undefined) updates.showHostTags = showHostTags;
   if (hostTrayOnClick !== undefined) updates.hostTrayOnClick = hostTrayOnClick;
   if (pinAppRail !== undefined) updates.pinAppRail = pinAppRail;
+  if (expandAppRailOnHover !== undefined)
+    updates.expandAppRailOnHover = expandAppRailOnHover;
   if (foldersCollapsed !== undefined)
     updates.foldersCollapsed = foldersCollapsed;
   if (confirmSnippetExecution !== undefined)

--- a/src/ui/AppShell.tsx
+++ b/src/ui/AppShell.tsx
@@ -558,6 +558,7 @@ export function AppShell({
               "showHostTags",
               "hostTrayOnClick",
               "pinAppRail",
+              "expandAppRailOnHover",
               "defaultSnippetFoldersCollapsed",
               "confirmSnippetExecution",
               "disableUpdateCheck",
@@ -609,8 +610,20 @@ export function AppShell({
               "hostTrayOnClick",
               String(prefs.hostTrayOnClick),
             );
-          if (prefs.pinAppRail !== null && prefs.pinAppRail !== undefined)
+          if (prefs.pinAppRail !== null && prefs.pinAppRail !== undefined) {
             localStorage.setItem("pinAppRail", String(prefs.pinAppRail));
+            window.dispatchEvent(new Event("pinAppRailChanged"));
+          }
+          if (
+            prefs.expandAppRailOnHover !== null &&
+            prefs.expandAppRailOnHover !== undefined
+          ) {
+            localStorage.setItem(
+              "expandAppRailOnHover",
+              String(prefs.expandAppRailOnHover),
+            );
+            window.dispatchEvent(new Event("expandAppRailOnHoverChanged"));
+          }
           if (
             prefs.foldersCollapsed !== null &&
             prefs.foldersCollapsed !== undefined

--- a/src/ui/api/open-tabs-api.ts
+++ b/src/ui/api/open-tabs-api.ts
@@ -89,6 +89,7 @@ export interface UserPreferences {
   showHostTags?: boolean | null;
   hostTrayOnClick?: boolean | null;
   pinAppRail?: boolean | null;
+  expandAppRailOnHover?: boolean | null;
   foldersCollapsed?: boolean | null;
   confirmSnippetExecution?: boolean | null;
   disableUpdateCheck?: boolean | null;

--- a/src/ui/locales/en.json
+++ b/src/ui/locales/en.json
@@ -2767,6 +2767,8 @@
         "statusColorsDesc": "Use green/red for online/offline status instead of the accent color",
         "pinAppRail": "Pin App Rail",
         "pinAppRailDesc": "Keep the left sidebar app rail always expanded instead of expanding on hover",
+        "expandAppRailOnHover": "Expand App Rail on Hover",
+        "expandAppRailOnHoverDesc": "Allow the left sidebar app rail to expand when the pointer moves over it",
         "settingsNavigation": "Navigation",
         "navigationTabsDesc": "Choose which tabs appear in the app rail",
         "settingsSnippets": "Snippets",

--- a/src/ui/locales/translated/zh_CN.json
+++ b/src/ui/locales/translated/zh_CN.json
@@ -2593,6 +2593,8 @@
         "statusColorsDesc": "Use green/red for online/offline status instead of the accent color",
         "pinAppRail": "Pin App Rail",
         "pinAppRailDesc": "保持左侧边栏应用导轨始终展开，而不是鼠标悬停时才展开。",
+        "expandAppRailOnHover": "悬停时展开应用导轨",
+        "expandAppRailOnHoverDesc": "鼠标移入左侧应用导轨时允许自动展开。",
         "settingsNavigation": "Navigation",
         "navigationTabsDesc": "Choose which tabs appear in the app rail",
         "settingsSnippets": "片段",

--- a/src/ui/locales/translated/zh_TW.json
+++ b/src/ui/locales/translated/zh_TW.json
@@ -2593,6 +2593,8 @@
         "statusColorsDesc": "Use green/red for online/offline status instead of the accent color",
         "pinAppRail": "Pin App Rail",
         "pinAppRailDesc": "保持左側邊欄應用導軌始終展開，而不是滑鼠懸停時才展開。",
+        "expandAppRailOnHover": "懸停時展開應用導軌",
+        "expandAppRailOnHoverDesc": "滑鼠移入左側應用導軌時允許自動展開。",
         "settingsNavigation": "Navigation",
         "navigationTabsDesc": "Choose which tabs appear in the app rail",
         "settingsSnippets": "Snippets",

--- a/src/ui/sidebar/AppRail.tsx
+++ b/src/ui/sidebar/AppRail.tsx
@@ -164,6 +164,9 @@ export function AppRail({
   const [pinned, setPinned] = useState(
     () => localStorage.getItem("pinAppRail") === "true",
   );
+  const [expandOnHover, setExpandOnHover] = useState(
+    () => localStorage.getItem("expandAppRailOnHover") !== "false",
+  );
   const [unreadAlerts, setUnreadAlerts] = useState(0);
 
   useEffect(() => {
@@ -192,10 +195,18 @@ export function AppRail({
   });
 
   useEffect(() => {
-    const handler = () =>
+    const pinHandler = () =>
       setPinned(localStorage.getItem("pinAppRail") === "true");
-    window.addEventListener("pinAppRailChanged", handler);
-    return () => window.removeEventListener("pinAppRailChanged", handler);
+    const hoverHandler = () =>
+      setExpandOnHover(
+        localStorage.getItem("expandAppRailOnHover") !== "false",
+      );
+    window.addEventListener("pinAppRailChanged", pinHandler);
+    window.addEventListener("expandAppRailOnHoverChanged", hoverHandler);
+    return () => {
+      window.removeEventListener("pinAppRailChanged", pinHandler);
+      window.removeEventListener("expandAppRailOnHoverChanged", hoverHandler);
+    };
   }, []);
 
   useEffect(() => {
@@ -211,7 +222,7 @@ export function AppRail({
     return () => window.removeEventListener("hiddenRailTabsChanged", handler);
   }, []);
 
-  const railExpanded = pinned || hovered;
+  const railExpanded = pinned || (expandOnHover && hovered);
   const railButtons = buildRailButtons(splitMode, t, hiddenTabs);
 
   return (

--- a/src/ui/sidebar/UserProfilePanel.tsx
+++ b/src/ui/sidebar/UserProfilePanel.tsx
@@ -430,6 +430,7 @@ export function UserProfilePanel({
     hostTrayOnClick?: boolean | null;
     compactHostView?: boolean | null;
     pinAppRail?: boolean | null;
+    expandAppRailOnHover?: boolean | null;
     foldersCollapsed?: boolean | null;
     confirmSnippetExecution?: boolean | null;
     disableUpdateCheck?: boolean | null;
@@ -536,6 +537,9 @@ export function UserProfilePanel({
   const [pinAppRail, setPinAppRail] = useState(
     () => localStorage.getItem("pinAppRail") === "true",
   );
+  const [expandAppRailOnHover, setExpandAppRailOnHover] = useState(
+    () => localStorage.getItem("expandAppRailOnHover") !== "false",
+  );
   const [foldersCollapsed, setFoldersCollapsed] = useState(
     () => localStorage.getItem("defaultSnippetFoldersCollapsed") !== "false",
   );
@@ -616,6 +620,7 @@ export function UserProfilePanel({
         "hostTrayOnClick",
         "compactHostView",
         "pinAppRail",
+        "expandAppRailOnHover",
         "defaultSnippetFoldersCollapsed",
         "confirmSnippetExecution",
         "disableUpdateCheck",
@@ -683,6 +688,15 @@ export function UserProfilePanel({
         if (prefs.pinAppRail != null) {
           setPinAppRail(prefs.pinAppRail);
           localStorage.setItem("pinAppRail", String(prefs.pinAppRail));
+          window.dispatchEvent(new Event("pinAppRailChanged"));
+        }
+        if (prefs.expandAppRailOnHover != null) {
+          setExpandAppRailOnHover(prefs.expandAppRailOnHover);
+          localStorage.setItem(
+            "expandAppRailOnHover",
+            String(prefs.expandAppRailOnHover),
+          );
+          window.dispatchEvent(new Event("expandAppRailOnHoverChanged"));
         }
         if (prefs.foldersCollapsed != null) {
           setFoldersCollapsed(prefs.foldersCollapsed);
@@ -759,6 +773,10 @@ export function UserProfilePanel({
     window.dispatchEvent(new CustomEvent("compactHostViewChanged"));
     setPinAppRail(false);
     localStorage.setItem("pinAppRail", "false");
+    window.dispatchEvent(new Event("pinAppRailChanged"));
+    setExpandAppRailOnHover(true);
+    localStorage.setItem("expandAppRailOnHover", "true");
+    window.dispatchEvent(new Event("expandAppRailOnHoverChanged"));
     setFoldersCollapsed(true);
     localStorage.removeItem("defaultSnippetFoldersCollapsed");
     setConfirmSnippetExecution(false);
@@ -785,6 +803,7 @@ export function UserProfilePanel({
         hostTrayOnClick: false,
         compactHostView: false,
         pinAppRail: false,
+        expandAppRailOnHover: true,
         foldersCollapsed: true,
         confirmSnippetExecution: false,
         disableUpdateCheck: false,
@@ -864,6 +883,16 @@ export function UserProfilePanel({
     const restoredPinRail = restore("pinAppRail", "false") === "true";
     setPinAppRail(restoredPinRail);
     localStorage.setItem("pinAppRail", String(restoredPinRail));
+    window.dispatchEvent(new Event("pinAppRailChanged"));
+
+    const restoredExpandRailOnHover =
+      restore("expandAppRailOnHover", "true") !== "false";
+    setExpandAppRailOnHover(restoredExpandRailOnHover);
+    localStorage.setItem(
+      "expandAppRailOnHover",
+      String(restoredExpandRailOnHover),
+    );
+    window.dispatchEvent(new Event("expandAppRailOnHoverChanged"));
 
     const restoredFolders =
       restore("defaultSnippetFoldersCollapsed", null) !== "false";
@@ -1544,6 +1573,25 @@ export function UserProfilePanel({
                   localStorage.setItem("pinAppRail", v.toString());
                   window.dispatchEvent(new Event("pinAppRailChanged"));
                   if (storageMode === "cloud") saveToCloud({ pinAppRail: v });
+                }}
+              />
+            </SettingRow>
+            <SettingRow
+              label={t("newUi.sidebar.userProfile.expandAppRailOnHover")}
+              description={t(
+                "newUi.sidebar.userProfile.expandAppRailOnHoverDesc",
+              )}
+            >
+              <FakeSwitch
+                checked={expandAppRailOnHover}
+                onChange={(v) => {
+                  setExpandAppRailOnHover(v);
+                  localStorage.setItem("expandAppRailOnHover", v.toString());
+                  window.dispatchEvent(
+                    new Event("expandAppRailOnHoverChanged"),
+                  );
+                  if (storageMode === "cloud")
+                    saveToCloud({ expandAppRailOnHover: v });
                 }}
               />
             </SettingRow>


### PR DESCRIPTION
## Summary
- add a sidebar preference to disable app rail hover expansion
- keep the existing pin-open behavior intact and default hover expansion on for existing users
- sync the new preference through cloud user settings and migrate existing databases safely

## Verification
- npx prettier --check .
- npx tsc --noEmit
- npm run lint
- npm run build
- git diff --check

Fixes Termix-SSH/Support#887