### PR TITLE
Skip metrics start for non-SSH hosts

### DIFF
--- a/src/backend/ssh/host-metrics-helpers.test.ts
+++ b/src/backend/ssh/host-metrics-helpers.test.ts
@@ -19,6 +19,7 @@ describe("supportsMetrics", () => {
   it("rejects non-ssh connection types", () => {
     expect(supportsMetrics({ connectionType: "rdp" })).toBe(false);
     expect(supportsMetrics({ connectionType: "vnc" })).toBe(false);
+    expect(supportsMetrics({ connectionType: "telnet" })).toBe(false);
   });
 
   it("rejects ssh hosts that cannot run shell commands", () => {

--- a/src/backend/ssh/host-metrics.ts
+++ b/src/backend/ssh/host-metrics.ts
@@ -1952,6 +1952,20 @@ app.post("/metrics/start/:id", validateHostId, async (req, res) => {
       return res.status(404).json({ error: "Host not found", connectionLogs });
     }
 
+    if (!supportsMetrics(host)) {
+      connectionLogs.push(
+        createConnectionLog(
+          "info",
+          "stats_connecting",
+          "Metrics collection is only supported for SSH hosts",
+          {
+            connectionType: host.connectionType || "ssh",
+          },
+        ),
+      );
+      return res.json({ success: true, skipped: true, connectionLogs });
+    }
+
     connectionLogs.push(
       createConnectionLog(
         "info",


### PR DESCRIPTION
## Summary
- prevent manual metrics startup from opening SSH handshakes for RDP/VNC/Telnet hosts
- return a skipped metrics response before jump-host SSH setup for non-SSH hosts
- cover Telnet in the existing metrics support helper tests

## Verification
- npm run test -- src/backend/ssh/host-metrics-helpers.test.ts
- npx tsc --noEmit
- npm run lint
- npm run build
- git diff --check

Fixes Termix-SSH/Support#904