### PR TITLE
Allow custom SSH tunnel endpoint hosts

### DIFF
--- a/src/ui/locales/en.json
+++ b/src/ui/locales/en.json
@@ -567,6 +567,7 @@
     "tunnelModeDynamicDesc": "Create a SOCKS5 proxy on a local port for dynamic port forwarding.",
     "sameHost": "This host (direct tunnel)",
     "endpointHost": "Endpoint Host",
+    "endpointHostPlaceholder": "Same host, SSH host, or reachable host/IP",
     "endpointPort": "Endpoint Port",
     "bindHost": "Bind Host",
     "sourcePort": "Source Port",

--- a/src/ui/locales/translated/zh_CN.json
+++ b/src/ui/locales/translated/zh_CN.json
@@ -440,6 +440,7 @@
     "tunnelModeDynamicDesc": "Create a SOCKS5 proxy on a local port for dynamic port forwarding.",
     "sameHost": "此主机（直接隧道）",
     "endpointHost": "Endpoint Host",
+    "endpointHostPlaceholder": "同一主机、SSH 主机，或可访问的主机/IP",
     "endpointPort": "Endpoint Port",
     "bindHost": "Bind Host",
     "sourcePort": "Source Port",

--- a/src/ui/locales/translated/zh_TW.json
+++ b/src/ui/locales/translated/zh_TW.json
@@ -440,6 +440,7 @@
     "tunnelModeDynamicDesc": "在本機連接埠上建立 SOCKS5 代理，用於動態連接埠轉送。",
     "sameHost": "此主機（直接隧道）",
     "endpointHost": "端點主機",
+    "endpointHostPlaceholder": "同一主機、SSH 主機，或可存取的主機/IP",
     "endpointPort": "Endpoint Port",
     "bindHost": "綁定主機",
     "sourcePort": "Source Port",

--- a/src/ui/sidebar/HostEditor.tsx
+++ b/src/ui/sidebar/HostEditor.tsx
@@ -1594,18 +1594,20 @@ export function HostEditor({
                   </p>
                 )}
                 {form.serverTunnels.map((tun, i) => {
+                  const endpointValue = (tun.endpointHost ?? "").trim();
                   const selectedEndpointHost = findHostByTunnelEndpoint(
                     hosts,
-                    tun.endpointHost,
+                    endpointValue,
                   );
                   const directEndpoint =
-                    !tun.endpointHost ||
-                    tun.endpointHost === "127.0.0.1" ||
-                    tun.endpointHost === "localhost";
+                    !endpointValue ||
+                    endpointValue === "127.0.0.1" ||
+                    endpointValue === "localhost";
+                  const endpointInputId = `server-tunnel-endpoint-${host?.id ?? "new"}-${i}`;
                   const hostLabel =
                     host?.name ||
                     (host ? `${host.username}@${host.ip}` : "new");
-                  const tunnelName = `${host?.id ?? "new"}::${i}::${hostLabel}::${tun.sourcePort}::${tun.endpointHost ?? ""}::${tun.endpointPort}`;
+                  const tunnelName = `${host?.id ?? "new"}::${i}::${hostLabel}::${tun.sourcePort}::${endpointValue}::${tun.endpointPort}`;
                   const tunnelStatus = tunnelStatuses[tunnelName]?.status as
                     | string
                     | undefined;
@@ -1666,14 +1668,16 @@ export function HostEditor({
                                       endpointIP: directEndpoint
                                         ? host.ip
                                         : (selectedEndpointHost?.ip ??
-                                          tun.endpointHost ??
-                                          ""),
-                                      endpointSSHPort: directEndpoint
-                                        ? (host.sshPort ?? host.port)
-                                        : (selectedEndpointHost?.sshPort ??
-                                          selectedEndpointHost?.port ??
-                                          22),
-                                      endpointHost: tun.endpointHost ?? "",
+                                          endpointValue),
+                                      endpointSSHPort:
+                                        directEndpoint || selectedEndpointHost
+                                          ? directEndpoint
+                                            ? (host.sshPort ?? host.port)
+                                            : (selectedEndpointHost?.sshPort ??
+                                              selectedEndpointHost?.port ??
+                                              22)
+                                          : 22,
+                                      endpointHost: endpointValue,
                                       endpointUsername: directEndpoint
                                         ? form.username
                                         : (selectedEndpointHost?.username ??
@@ -1765,8 +1769,10 @@ export function HostEditor({
                             <label className="text-[10px] font-bold text-muted-foreground">
                               {t("hosts.endpointHost")}
                             </label>
-                            <select
+                            <Input
                               className="h-7 text-xs border border-border bg-background px-2 outline-none focus:ring-1 focus:ring-ring"
+                              list={endpointInputId}
+                              placeholder={t("hosts.endpointHostPlaceholder")}
                               value={tun.endpointHost ?? ""}
                               onChange={(e) => {
                                 const updated = [...form.serverTunnels];
@@ -1776,8 +1782,8 @@ export function HostEditor({
                                 };
                                 setField("serverTunnels", updated);
                               }}
-                            >
-                              <option value="">{t("hosts.sameHost")}</option>
+                            />
+                            <datalist id={endpointInputId}>
                               {hosts
                                 .filter((h) => h.enableSsh)
                                 .map((h) => (
@@ -1785,7 +1791,7 @@ export function HostEditor({
                                     {h.name || h.ip} ({h.ip})
                                   </option>
                                 ))}
-                            </select>
+                            </datalist>
                           </div>
                         )}
                         {tun.mode !== "dynamic" && (


### PR DESCRIPTION
## Summary
- let server tunnel endpoint hosts be typed directly instead of limited to SSH-host selections
- keep existing SSH host suggestions so managed S2S tunnels still work when a saved SSH host is selected
- trim custom endpoint values before connecting so direct source-host forwarding reaches arbitrary hosts/IPs behind the bastion

## Verification
- npx tsc --noEmit
- npm run lint
- npm run build
- npx prettier --check .
- git diff --check

Fixes Termix-SSH/Support#889