### PR TITLE
fix: stabilize Windows app icon

### DIFF
--- a/electron-builder.json
+++ b/electron-builder.json
@@ -28,11 +28,8 @@
     "!dist/icon-mac.png",
     "!public/icon-mac.png",
     "!dist/icon.ico",
-    "!public/icon.ico",
     "!dist/icon.icns",
-    "!public/icon.icns",
-    "!dist/icons/**/*",
-    "!public/icons/**/*"
+    "!public/icon.icns"
   ],
   "extraMetadata": {
     "main": "electron/main.cjs",
@@ -61,6 +58,8 @@
     "artifactName": "termix_windows_${arch}_nsis.${ext}",
     "createDesktopShortcut": true,
     "createStartMenuShortcut": true,
+    "installerIcon": "public/icon.ico",
+    "uninstallerIcon": "public/icon.ico",
     "shortcutName": "Termix",
     "uninstallDisplayName": "Termix"
   },

--- a/electron/main.cjs
+++ b/electron/main.cjs
@@ -531,6 +531,7 @@ let isQuitting = false;
 
 const isDev = process.env.NODE_ENV === "development" || !app.isPackaged;
 const appRoot = isDev ? process.cwd() : path.join(__dirname, "..");
+const windowsAppUserModelId = "com.karmaa.termix";
 const electronCacheBuildPath = path.join(
   app.getPath("userData"),
   "client-cache-build.json",
@@ -928,7 +929,11 @@ function createWindow() {
     minWidth: 800,
     minHeight: 600,
     title: "Termix",
-    icon: path.join(appRoot, "public", "icon.png"),
+    icon: path.join(
+      appRoot,
+      "public",
+      process.platform === "win32" ? "icon.ico" : "icon.png",
+    ),
     webPreferences: {
       nodeIntegration: false,
       contextIsolation: true,
@@ -2717,6 +2722,9 @@ app.whenReady().then(async () => {
     "arch:",
     process.arch,
   );
+  if (process.platform === "win32") {
+    app.setAppUserModelId(windowsAppUserModelId);
+  }
   createMenu();
   await clearElectronClientCacheIfBuildChanged();
   await clearElectronJwtCookiesAtStartup();


### PR DESCRIPTION
## Summary
- set the Windows AppUserModelID before creating Electron windows
- use the ICO file for Windows BrowserWindow icons
- keep packaged Windows icon assets available and set NSIS installer/uninstaller icons

Fixes Termix-SSH/Support#908

## Checks
- npm run biome:check
- npx eslint .
- npx prettier --check .
- npx tsc --noEmit
- npm run build