### PR TITLE
Fix runtime base path for auth callbacks

### DIFF
--- a/src/backend/database/routes/users.ts
+++ b/src/backend/database/routes/users.ts
@@ -14,7 +14,10 @@ import {
   generateDeviceFingerprint,
 } from "../../utils/user-agent-parser.js";
 import { loginRateLimiter } from "../../utils/login-rate-limiter.js";
-import { getRequestOriginWithForceHTTPS } from "../../utils/request-origin.js";
+import {
+  getRequestBasePath,
+  getRequestBaseUrlWithForceHTTPS,
+} from "../../utils/request-origin.js";
 import { deleteUserAndRelatedData } from "./delete-user-data.js";
 import {
   getOIDCConfigFromEnv,
@@ -630,9 +633,8 @@ router.get("/oidc/authorize", async (req, res) => {
       appCallbackUrl,
       providerId: providerIdStr,
     } = req.query;
-    const origin = getRequestOriginWithForceHTTPS(req);
-    const basePath = (process.env.BASE_PATH || "").replace(/\/+$/, "");
-    const backendCallbackUri = `${origin}${basePath}/users/oidc/callback`;
+    const publicBaseUrl = getRequestBaseUrlWithForceHTTPS(req);
+    const backendCallbackUri = `${publicBaseUrl}/users/oidc/callback`;
 
     const resolvedProviderId = providerIdStr
       ? parseInt(providerIdStr as string, 10)
@@ -664,9 +666,9 @@ router.get("/oidc/authorize", async (req, res) => {
       frontendOrigin = callbackUrl.toString();
     } else if (referer) {
       const refererUrl = new URL(referer);
-      frontendOrigin = `${refererUrl.protocol}//${refererUrl.host}`;
+      frontendOrigin = `${refererUrl.protocol}//${refererUrl.host}${getRequestBasePath(req)}`;
     } else {
-      frontendOrigin = origin;
+      frontendOrigin = publicBaseUrl;
     }
 
     db.$client

--- a/src/backend/ssh/terminal.ts
+++ b/src/backend/ssh/terminal.ts
@@ -780,7 +780,7 @@ wss.on("connection", async (ws: WebSocket, req) => {
         const opksshData = data as { hostId: number };
         try {
           const { startOPKSSHAuth } = await import("./opkssh-auth.js");
-          const { getRequestOrigin } =
+          const { getRequestBaseUrl } =
             await import("../utils/request-origin.js");
           const db = getDb();
           const hostRow = await db
@@ -807,7 +807,7 @@ wss.on("connection", async (ws: WebSocket, req) => {
             break;
           }
           const hostname = hostRow[0].name || hostRow[0].ip;
-          const requestOrigin = getRequestOrigin(req);
+          const requestOrigin = getRequestBaseUrl(req);
           await startOPKSSHAuth(
             userId,
             opksshData.hostId,
@@ -898,7 +898,7 @@ wss.on("connection", async (ws: WebSocket, req) => {
         try {
           const { loadVaultProfileForHost, startVaultAuth } =
             await import("./vault-oidc-auth.js");
-          const { getRequestOrigin } =
+          const { getRequestBaseUrl } =
             await import("../utils/request-origin.js");
           const profile = await loadVaultProfileForHost(vaultData.hostId);
           if (!profile) {
@@ -911,7 +911,7 @@ wss.on("connection", async (ws: WebSocket, req) => {
             );
             break;
           }
-          const requestOrigin = getRequestOrigin(req);
+          const requestOrigin = getRequestBaseUrl(req);
           await startVaultAuth(
             userId,
             vaultData.hostId,

--- a/src/backend/utils/request-origin.test.ts
+++ b/src/backend/utils/request-origin.test.ts
@@ -1,0 +1,108 @@
+import { afterEach, describe, expect, it } from "vitest";
+import {
+  getRequestBasePath,
+  getRequestBaseUrl,
+  getRequestBaseUrlWithForceHTTPS,
+  normalizeBasePath,
+} from "./request-origin.js";
+
+function request(headers: Record<string, string | string[] | undefined>) {
+  return {
+    headers,
+    socket: {},
+  } as Parameters<typeof getRequestBasePath>[0];
+}
+
+function restoreEnv(name: string, value: string | undefined) {
+  if (value === undefined) {
+    delete process.env[name];
+  } else {
+    process.env[name] = value;
+  }
+}
+
+describe("normalizeBasePath", () => {
+  it("normalizes empty and root paths", () => {
+    expect(normalizeBasePath("")).toBe("");
+    expect(normalizeBasePath("/")).toBe("");
+    expect(normalizeBasePath(" / ")).toBe("");
+  });
+
+  it("normalizes configured base paths", () => {
+    expect(normalizeBasePath("termix")).toBe("/termix");
+    expect(normalizeBasePath("/termix/")).toBe("/termix");
+    expect(normalizeBasePath("/termix, /other")).toBe("/termix");
+  });
+
+  it("accepts forwarded prefix values that include a URL", () => {
+    expect(normalizeBasePath("https://example.com/termix/")).toBe("/termix");
+  });
+});
+
+describe("getRequestBasePath", () => {
+  const previousBasePath = process.env.BASE_PATH;
+  const previousViteBasePath = process.env.VITE_BASE_PATH;
+  const previousForceHttps = process.env.OIDC_FORCE_HTTPS;
+
+  afterEach(() => {
+    restoreEnv("BASE_PATH", previousBasePath);
+    restoreEnv("VITE_BASE_PATH", previousViteBasePath);
+    restoreEnv("OIDC_FORCE_HTTPS", previousForceHttps);
+  });
+
+  it("uses BASE_PATH before forwarded headers", () => {
+    process.env.BASE_PATH = "/admin/";
+    process.env.VITE_BASE_PATH = "";
+
+    expect(
+      getRequestBasePath(request({ "x-forwarded-prefix": "/termix" })),
+    ).toBe("/admin");
+  });
+
+  it("falls back to VITE_BASE_PATH for deployments that already set it", () => {
+    process.env.BASE_PATH = "";
+    process.env.VITE_BASE_PATH = "/termix/";
+
+    expect(getRequestBasePath(request({}))).toBe("/termix");
+  });
+
+  it("uses X-Forwarded-Prefix when no env base path is set", () => {
+    process.env.BASE_PATH = "";
+    process.env.VITE_BASE_PATH = "";
+
+    expect(
+      getRequestBasePath(request({ "x-forwarded-prefix": "/termix/" })),
+    ).toBe("/termix");
+  });
+
+  it("builds a public base URL with forwarded origin and prefix", () => {
+    process.env.BASE_PATH = "";
+    process.env.VITE_BASE_PATH = "";
+
+    expect(
+      getRequestBaseUrl(
+        request({
+          "x-forwarded-proto": "https",
+          "x-forwarded-host": "example.com",
+          "x-forwarded-prefix": "/termix",
+        }),
+      ),
+    ).toBe("https://example.com/termix");
+  });
+
+  it("applies OIDC_FORCE_HTTPS to public base URLs", () => {
+    process.env.BASE_PATH = "";
+    process.env.VITE_BASE_PATH = "";
+    process.env.OIDC_FORCE_HTTPS = "true";
+
+    expect(
+      getRequestBaseUrlWithForceHTTPS(
+        request({
+          "x-forwarded-proto": "http",
+          "x-forwarded-host": "example.com",
+          "x-forwarded-prefix": "/termix",
+        }),
+      ),
+    ).toBe("https://example.com/termix");
+  });
+});

--- a/src/backend/utils/request-origin.ts
+++ b/src/backend/utils/request-origin.ts
@@ -1,6 +1,31 @@
 import type { Request } from "express";
 import type { IncomingMessage } from "http";
 
+function firstHeaderValue(value: string | string[] | undefined): string {
+  if (!value) return "";
+  const raw = Array.isArray(value) ? value[0] : value;
+  return raw.split(",")[0].trim();
+}
+
+export function normalizeBasePath(value: unknown): string {
+  if (typeof value !== "string") return "";
+  let basePath = value.split(",")[0].trim();
+  if (!basePath) return "";
+
+  try {
+    if (/^https?:\/\//i.test(basePath)) {
+      basePath = new URL(basePath).pathname;
+    }
+  } catch {
+    return "";
+  }
+
+  basePath = basePath.split("?")[0].split("#")[0].trim();
+  if (!basePath || basePath === "/") return "";
+  if (!basePath.startsWith("/")) basePath = `/${basePath}`;
+  return basePath.replace(/\/+$/, "");
+}
+
 export function getRequestOrigin(req: Request | IncomingMessage): string {
   let protocol: string;
   const protoHeader = req.headers["x-forwarded-proto"];
@@ -62,4 +87,27 @@ export function getRequestOriginWithForceHTTPS(
     return origin.replace(/^http:/, "https:");
   }
   return getRequestOrigin(req);
+}
+
+export function getRequestBasePath(req: Request | IncomingMessage): string {
+  const envBasePath = normalizeBasePath(
+    process.env.BASE_PATH || process.env.VITE_BASE_PATH,
+  );
+  if (envBasePath) return envBasePath;
+
+  return (
+    normalizeBasePath(firstHeaderValue(req.headers["x-forwarded-prefix"])) ||
+    normalizeBasePath(firstHeaderValue(req.headers["x-script-name"])) ||
+    normalizeBasePath(firstHeaderValue(req.headers["x-original-prefix"]))
+  );
+}
+
+export function getRequestBaseUrl(req: Request | IncomingMessage): string {
+  return `${getRequestOrigin(req)}${getRequestBasePath(req)}`;
+}
+
+export function getRequestBaseUrlWithForceHTTPS(
+  req: Request | IncomingMessage,
+): string {
+  return `${getRequestOriginWithForceHTTPS(req)}${getRequestBasePath(req)}`;
 }


### PR DESCRIPTION
## Summary
- resolve backend public base paths from BASE_PATH/VITE_BASE_PATH and forwarded prefix headers at runtime
- include the runtime base path in OIDC callback URLs and post-login redirects
- include the runtime base path in OPKSSH and Vault auth callback URLs started from terminal WebSockets
- add request-origin tests for env and proxy-prefix base path handling

## Testing
- npm run test -- src/backend/utils/request-origin.test.ts
- npm run type-check
- npm run lint
- npm run format:check
- npm run biome:check
- npm run build

Fixes Termix-SSH/Support#666