### PR TITLE
Fix host metrics startup polling

### DIFF
--- a/src/backend/ssh/host-metrics.ts
+++ b/src/backend/ssh/host-metrics.ts
@@ -297,6 +297,8 @@ class PollingManager {
       viewerUserId,
     };
 
+    this.pollingConfigs.set(host.id, config);
+
     if (isTcpPingEnabled(statsConfig)) {
       const intervalMs = statsConfig.statusCheckInterval * 1000;
 
@@ -338,8 +340,6 @@ class PollingManager {
     } else {
       this.metricsStore.delete(host.id);
     }
-
-    this.pollingConfigs.set(host.id, config);
   }
 
   private async pollHostStatus(
@@ -1997,7 +1997,11 @@ app.post("/metrics/start/:id", validateHostId, async (req, res) => {
           "Using existing metrics session",
         ),
       );
-      return res.json({ success: true, connectionLogs });
+
+      const viewerSessionId = `viewer-${Date.now()}-${Math.random().toString(36).substr(2, 9)}`;
+      pollingManager.registerViewer(host.id, viewerSessionId, userId);
+
+      return res.json({ success: true, viewerSessionId, connectionLogs });
     }
 
     const config = await buildSshConfig(host);

--- a/src/backend/ssh/managers/wireguard.ts
+++ b/src/backend/ssh/managers/wireguard.ts
@@ -1,5 +1,4 @@
 import type { Express } from "express";
-import { execCommand } from "../widgets/common-utils.js";
 import { execElevated } from "./exec-elevated.js";
 import { managerHandler } from "./route-helpers.js";
 import { ManagerInputError } from "./route-helpers.js";


### PR DESCRIPTION
## Summary
- register host metrics polling config before the initial metrics collection runs
- return a viewer session when reusing an existing metrics SSH session
- remove an unused WireGuard import that blocked full lint

## Validation
- npm run type-check
- npm run test -- src/backend/ssh/host-metrics-helpers.test.ts src/backend/ssh/host-metrics-preferences.test.ts
- npm run lint
- npm run build

Fixes Termix-SSH/Support#912