### PR TITLE
Add app fullscreen mode

### DIFF
--- a/src/backend/ssh/managers/wireguard.ts
+++ b/src/backend/ssh/managers/wireguard.ts
@@ -1,5 +1,4 @@
 import type { Express } from "express";
-import { execCommand } from "../widgets/common-utils.js";
 import { execElevated } from "./exec-elevated.js";
 import { managerHandler } from "./route-helpers.js";
 import { ManagerInputError } from "./route-helpers.js";

--- a/src/ui/AppShell.tsx
+++ b/src/ui/AppShell.tsx
@@ -169,6 +169,9 @@ export function AppShell({
   });
   const [sidebarDragging, setSidebarDragging] = useState(false);
   const [sidebarEditing, setSidebarEditing] = useState(false);
+  const [isAppFullscreen, setIsAppFullscreen] = useState(
+    () => !!document.fullscreenElement,
+  );
 
   useEffect(() => {
     localStorage.setItem("termix_sidebarWidth", String(sidebarWidth));
@@ -201,6 +204,34 @@ export function AppShell({
         setUserId(info.userId);
       })
       .catch(() => setIsAdmin(false));
+  }, []);
+
+  const toggleAppFullscreen = useCallback(async () => {
+    try {
+      if (document.fullscreenElement) {
+        await document.exitFullscreen();
+        return;
+      }
+
+      if (!document.fullscreenEnabled) {
+        toast.error("Fullscreen is not supported by this browser");
+        return;
+      }
+
+      await document.documentElement.requestFullscreen();
+    } catch {
+      toast.error("Unable to toggle fullscreen mode");
+    }
+  }, []);
+
+  useEffect(() => {
+    const handleFullscreenChange = () => {
+      setIsAppFullscreen(!!document.fullscreenElement);
+    };
+
+    document.addEventListener("fullscreenchange", handleFullscreenChange);
+    return () =>
+      document.removeEventListener("fullscreenchange", handleFullscreenChange);
   }, []);
 
   const lastShiftTime = useRef(0);
@@ -306,6 +337,14 @@ export function AppShell({
   // without going through synthetic DOM events (which are unreliable).
   useEffect(() => {
     const handleKeyDown = (e: KeyboardEvent) => {
+      if (e.ctrlKey && e.shiftKey && !e.altKey && !e.metaKey) {
+        if (e.code === "KeyF") {
+          e.preventDefault();
+          toggleAppFullscreen();
+          return;
+        }
+      }
+
       // Ctrl+Shift+\ — toggle 2-way split (side by side)
       if (e.ctrlKey && e.shiftKey && !e.altKey && e.code === "Backslash") {
         e.preventDefault();
@@ -1661,6 +1700,8 @@ export function AppShell({
               onAddToSplit={addTabToSplit}
               onRemoveFromSplit={removeTabFromSplit}
               onRenameTab={renameTab}
+              isAppFullscreen={isAppFullscreen}
+              onToggleAppFullscreen={toggleAppFullscreen}
             />
             <div className="relative flex flex-col flex-1 min-h-0 overflow-hidden">
               {/* Split view — always mounted when not mobile, hidden via CSS when inactive */}

--- a/src/ui/shell/TabBar.tsx
+++ b/src/ui/shell/TabBar.tsx
@@ -16,6 +16,8 @@ import {
   Plus,
   Minus,
   Pencil,
+  Maximize2,
+  Minimize2,
 } from "lucide-react";
 import { tabIcon } from "@/shell/tabUtils";
 import type { Tab, TabType, SplitMode } from "@/types/ui-types";
@@ -37,6 +39,8 @@ export function TabBar({
   onAddToSplit,
   onRemoveFromSplit,
   onRenameTab,
+  isAppFullscreen,
+  onToggleAppFullscreen,
 }: {
   tabs: Tab[];
   activeTabId: string;
@@ -51,6 +55,8 @@ export function TabBar({
   onAddToSplit: (tabId: string) => void;
   onRemoveFromSplit: (tabId: string) => void;
   onRenameTab?: (tabId: string, newLabel: string) => void;
+  isAppFullscreen: boolean;
+  onToggleAppFullscreen: () => void;
 }) {
   const { t } = useTranslation();
   const [open, setOpen] = useState(true);
@@ -437,6 +443,27 @@ export function TabBar({
               ))}
             </DropdownMenuContent>
           </DropdownMenu>
+          <Separator orientation="vertical" />
+          <Button
+            variant="ghost"
+            size="icon"
+            className="h-full w-12.5 rounded-none border-y-0 border-border text-muted-foreground hover:text-foreground"
+            title={
+              isAppFullscreen
+                ? "Exit fullscreen (Ctrl+Shift+F)"
+                : "Enter fullscreen (Ctrl+Shift+F)"
+            }
+            aria-label={
+              isAppFullscreen ? "Exit fullscreen" : "Enter fullscreen"
+            }
+            onClick={onToggleAppFullscreen}
+          >
+            {isAppFullscreen ? (
+              <Minimize2 className="size-4" />
+            ) : (
+              <Maximize2 className="size-4" />
+            )}
+          </Button>
           <Separator orientation="vertical" />
           <Button
             variant="ghost"


### PR DESCRIPTION
## Summary
- add an app-wide fullscreen toggle using the browser Fullscreen API
- expose the toggle from the tab bar with enter/exit icons
- add Ctrl+Shift+F as the app-level fullscreen shortcut, including terminal-focused sessions through the existing global shortcut handler
- remove an unused WireGuard import that blocks full lint on the current base

## Validation
- npm run type-check
- npm run lint
- npm run build

Closes Termix-SSH/Support#913