### PR TITLE
Fix MC syntax highlighting artifacts

### DIFF
--- a/src/ui/lib/terminal-syntax-highlighter.test.ts
+++ b/src/ui/lib/terminal-syntax-highlighter.test.ts
@@ -66,6 +66,16 @@ describe("highlightTerminalOutput", () => {
     expect(highlightTerminalOutput(chunk)).toBe(chunk);
   });
 
+  it("skips TUI frames with box-drawing characters", () => {
+    const chunk = `┌─ /var/log ─┐\n│ ERROR file │`;
+    expect(highlightTerminalOutput(chunk)).toBe(chunk);
+  });
+
+  it("skips DEC line-drawing charset frames", () => {
+    const chunk = `${ESC}(0lqq /var/log qk${ESC}(B`;
+    expect(highlightTerminalOutput(chunk)).toBe(chunk);
+  });
+
   it("highlights text that already has ANSI codes", () => {
     let heavy = "";
     for (let i = 0; i < 12; i++) heavy += `${ESC}[32mgreen${ESC}[0m `;

--- a/src/ui/lib/terminal-syntax-highlighter.ts
+++ b/src/ui/lib/terminal-syntax-highlighter.ts
@@ -61,6 +61,7 @@ const MAX_LINE_LENGTH = 2000;
 // (mc, nano, vim, htop). If a chunk contains these, highlighting can inject
 // extra SGR bytes into a full-screen redraw and corrupt xterm's cursor state.
 const TUI_SEQUENCE = /\x1b\[(?:[\d;]*[ABCDEFGHJKST]|\?[\d;]*[hl])/;
+const TUI_FRAME_SEQUENCE = /[\u2500-\u257f]|\x1b[()][0B]|\x1b\[[0-9;]*[~`]/;
 
 // A bare \r (not immediately followed by \n) means the terminal is overwriting
 // the current line (shell prompts, progress bars). Highlighting mid-rewrite
@@ -398,6 +399,7 @@ export function highlightTerminalOutput(
   if (hasIncompleteAnsiSequence(text)) return text;
 
   if (TUI_SEQUENCE.test(text)) return text;
+  if (TUI_FRAME_SEQUENCE.test(text)) return text;
   if (MID_LINE_CR.test(text)) return text;
 
   const activePatterns = buildActivePatterns(options);


### PR DESCRIPTION
## Summary
- skip syntax highlighting for TUI frame chunks that contain box-drawing glyphs
- skip DEC line-drawing charset frames before injecting highlight SGR codes
- add regression coverage for Midnight Commander-style frames

## Validation
- npm test -- src/ui/lib/terminal-syntax-highlighter.test.ts
- npm run type-check

Fixes Termix-SSH/Support#910