### PR TITLE
Persist dashboard service link changes

### DIFF
--- a/src/backend/database/routes/dashboard-service-links-routes.ts
+++ b/src/backend/database/routes/dashboard-service-links-routes.ts
@@ -2,7 +2,7 @@ import type { AuthenticatedRequest } from "../../../types/index.js";
 import type { Request, Response } from "express";
 import { and, asc, eq } from "drizzle-orm";
 import { dashboardLogger } from "../../utils/logger.js";
-import { db } from "../db/index.js";
+import { db, DatabaseSaveTrigger } from "../db/index.js";
 import { dashboardServiceLinks } from "../db/schema.js";
 import { isNonEmptyString } from "./host-normalizers.js";
 import {
@@ -107,6 +107,7 @@ dashboardServiceLinksRouter.post("/", async (req: Request, res: Response) => {
       })
       .returning();
 
+    DatabaseSaveTrigger.triggerSave("dashboard_service_link_created");
     res.status(201).json(created);
   } catch (err) {
     dashboardLogger.error("Failed to create service link", err);
@@ -175,6 +176,7 @@ dashboardServiceLinksRouter.delete(
           ),
         );
 
+      DatabaseSaveTrigger.triggerSave("dashboard_service_link_deleted");
       res.json({ message: "Service link deleted" });
     } catch (err) {
       dashboardLogger.error("Failed to delete service link", err);
@@ -272,6 +274,7 @@ dashboardServiceLinksRouter.put("/:id", async (req: Request, res: Response) => {
       )
       .returning();
 
+    DatabaseSaveTrigger.triggerSave("dashboard_service_link_updated");
     res.json(updated);
   } catch (err) {
     dashboardLogger.error("Failed to update service link", err);


### PR DESCRIPTION
## Summary
- trigger database persistence after creating dashboard service links
- trigger persistence after updating or deleting dashboard service links
- keep service link writes consistent with homepage and alert configuration routes

## Validation
- npx prettier --check src/backend/database/routes/dashboard-service-links-routes.ts
- npm run type-check
- npx eslint src/backend/database/routes/dashboard-service-links-routes.ts

Fixes Termix-SSH/Support#923