### PR TITLE
Resolve client tunnel source credentials

### DIFF
--- a/src/backend/ssh/tunnel.ts
+++ b/src/backend/ssh/tunnel.ts
@@ -1937,6 +1937,7 @@ app.post(
     }
 
     const tunnelName = tunnelConfig.name;
+    tunnelConfig.requestingUserId = userId;
 
     try {
       if (!validateTunnelConfig(tunnelName, tunnelConfig)) {
@@ -1966,10 +1967,6 @@ app.post(
             tunnelName,
           });
           return res.status(403).json({ error: "Access denied to this host" });
-        }
-
-        if (accessInfo.isShared && !accessInfo.isOwner) {
-          tunnelConfig.requestingUserId = userId;
         }
       }
 


### PR DESCRIPTION
## Summary
- always attach the requesting user to manual tunnel connect requests
- allow server-side source host credential resolution for owner-started client tunnels
- keep shared-host tunnel credential resolution behavior unchanged

## Validation
- npx prettier --check src/backend/ssh/tunnel.ts
- npx eslint src/backend/ssh/tunnel.ts
- npm run type-check
- git diff --check
- npm run build

Fixes Termix-SSH/Support#937