### PR TITLE
Support Vault auth for monitors

### DIFF
--- a/src/backend/ssh/host-metrics.ts
+++ b/src/backend/ssh/host-metrics.ts
@@ -104,6 +104,7 @@ interface SSHHostWithCredentials {
   rdpPort?: number;
   vncPort?: number;
   telnetPort?: number;
+  vaultProfile?: { id?: number | null } | null;
 }
 
 type StatusEntry = {
@@ -1128,6 +1129,8 @@ async function buildSshConfig(
     // no credentials needed
   } else if (host.authType === "opkssh") {
     // cert auth setup happens in createSshFactory (needs client instance)
+  } else if (host.authType === "vault") {
+    // cert auth setup happens in createSshFactory (needs client instance)
   } else if (host.authType === "credential") {
     if (host.password) {
       base.password = host.password;
@@ -1186,6 +1189,10 @@ function createSshFactory(host: SSHHostWithCredentials): () => Promise<Client> {
       }
       const { setupOPKSSHCertAuth } = await import("./opkssh-cert-auth.js");
       await setupOPKSSHCertAuth(config, client, token, host.username);
+    } else if (host.authType === "vault") {
+      const { setupVaultSshSignerAuth } =
+        await import("./vault-ssh-connect.js");
+      await setupVaultSshSignerAuth(config, client, host);
     }
 
     const proxyConfig: SOCKS5Config | null =
@@ -2070,6 +2077,10 @@ app.post("/metrics/start/:id", validateHostId, async (req, res) => {
       }
       const { setupOPKSSHCertAuth } = await import("./opkssh-cert-auth.js");
       await setupOPKSSHCertAuth(config, client, token, host.username);
+    } else if (host.authType === "vault") {
+      const { setupVaultSshSignerAuth } =
+        await import("./vault-ssh-connect.js");
+      await setupVaultSshSignerAuth(config, client, host);
     }
 
     const connectionPromise = new Promise<{

--- a/src/backend/ssh/tmux-monitor.ts
+++ b/src/backend/ssh/tmux-monitor.ts
@@ -95,6 +95,8 @@ async function buildSshConfig(host: SSHHost): Promise<ConnectConfig> {
     }
   } else if (host.authType === "none") {
     // no credentials needed
+  } else if (host.authType === "vault") {
+    // cert auth setup happens in connectToHost (needs client instance)
   } else if (host.authType === "agent") {
     const result = await applyAgentAuth(
       base as Record<string, unknown>,
@@ -117,6 +119,12 @@ export function connectToHost(host: SSHHost): () => Promise<Client> {
   return async () => {
     const config = await buildSshConfig(host);
     const client = new Client();
+
+    if (host.authType === "vault") {
+      const { setupVaultSshSignerAuth } =
+        await import("./vault-ssh-connect.js");
+      await setupVaultSshSignerAuth(config, client, host);
+    }
 
     const proxyConfig: SOCKS5Config | null =
       host.useSocks5 &&

--- a/src/backend/ssh/vault-ssh-connect.ts
+++ b/src/backend/ssh/vault-ssh-connect.ts
@@ -1,0 +1,39 @@
+import type { Client, ConnectConfig } from "ssh2";
+
+type VaultAuthHost = {
+  id: number;
+  username: string;
+  userId?: string | null;
+  vaultProfile?: { id?: number | null } | null;
+};
+
+export async function setupVaultSshSignerAuth(
+  config: ConnectConfig,
+  client: Client,
+  host: VaultAuthHost,
+): Promise<void> {
+  if (!host.userId) {
+    throw new Error("Vault SSH signer authentication requires a user session");
+  }
+
+  const vaultProfileId = host.vaultProfile?.id;
+  if (!vaultProfileId) {
+    throw new Error("Host has no Vault signer profile configured");
+  }
+
+  const { getVaultCert } = await import("./vault-signer-auth.js");
+  const cert = await getVaultCert(host.userId, vaultProfileId);
+  if (!cert) {
+    throw new Error(
+      "Vault SSH signer authentication required. Please open a Terminal connection first.",
+    );
+  }
+
+  const { setupOPKSSHCertAuth } = await import("./opkssh-cert-auth.js");
+  await setupOPKSSHCertAuth(
+    config,
+    client,
+    { privateKey: cert.privateKey, sshCert: cert.sshCert },
+    host.username,
+  );
+}

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -109,7 +109,8 @@ export interface Host {
     | "none"
     | "opkssh"
     | "tailscale"
-    | "agent";
+    | "agent"
+    | "vault";
   useWarpgate?: boolean;
   password?: string;
   key?: string;
@@ -123,6 +124,8 @@ export interface Host {
   autostartKeyPassword?: string;
 
   credentialId?: number;
+  vaultProfileId?: number | null;
+  vaultProfile?: { id?: number | null };
   overrideCredentialUsername?: boolean;
   userId?: string;
   enableTerminal: boolean;


### PR DESCRIPTION
## Summary
- add shared Vault SSH signer setup for non-terminal SSH clients
- allow Host Metrics and Tmux Monitor to use cached Vault-signed certificates
- keep the existing Terminal-first Vault OIDC flow requirement when no cached cert is available
- include Vault auth in the shared host auth type

## Validation
- npx prettier --check src/backend/ssh/vault-ssh-connect.ts src/backend/ssh/host-metrics.ts src/backend/ssh/tmux-monitor.ts src/types/index.ts
- npx eslint src/backend/ssh/vault-ssh-connect.ts src/backend/ssh/host-metrics.ts src/backend/ssh/tmux-monitor.ts src/types/index.ts
- npm run type-check
- git diff --check
- npm run build

Fixes Termix-SSH/Support#933