### PR TITLE
Fix release artifact checkout ref

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -14,6 +14,10 @@ on:
         options:
           - Development
           - Production
+      source_ref:
+        description: "Git ref/SHA to build (defaults to the workflow ref)"
+        required: false
+        default: ""
   workflow_call:
     inputs:
       version:
@@ -29,6 +33,11 @@ on:
         required: false
         type: boolean
         default: false
+      source_ref:
+        description: "Git ref/SHA to build"
+        required: false
+        type: string
+        default: ""
 
 jobs:
   build:
@@ -37,7 +46,11 @@ jobs:
       - name: Checkout repository
         uses: actions/checkout@v7
         with:
+          ref: ${{ inputs.source_ref || github.ref }}
           fetch-depth: 1
+
+      - name: Resolve source revision
+        run: echo "SOURCE_SHA=$(git rev-parse HEAD)" >> "$GITHUB_ENV"
 
       - name: Set up QEMU
         uses: docker/setup-qemu-action@v4
@@ -98,7 +111,7 @@ jobs:
             BUILDKIT_CONTEXT_KEEP_GIT_DIR=1
           labels: |
             org.opencontainers.image.source=https://github.com/${{ github.repository }}
-            org.opencontainers.image.revision=${{ github.sha }}
+            org.opencontainers.image.revision=${{ env.SOURCE_SHA }}
             org.opencontainers.image.created=${{ github.run_id }}
           cache-from: type=gha
           cache-to: type=gha,mode=max

--- a/.github/workflows/electron.yml
+++ b/.github/workflows/electron.yml
@@ -23,6 +23,10 @@ on:
           - file
           - release
           - submit
+      source_ref:
+        description: "Git ref/SHA to build (defaults to the workflow ref)"
+        required: false
+        default: ""
   workflow_call:
     inputs:
       build_type:
@@ -35,6 +39,11 @@ on:
         type: string
       release_tag:
         description: "Explicit release tag to upload assets to (defaults to latest release when empty)"
+        required: false
+        type: string
+        default: ""
+      source_ref:
+        description: "Git ref/SHA to build"
         required: false
         type: string
         default: ""
@@ -54,6 +63,7 @@ jobs:
       - name: Checkout repository
         uses: actions/checkout@v7
         with:
+          ref: ${{ inputs.source_ref || github.ref }}
           fetch-depth: 1
 
       - name: Setup Node.js
@@ -144,6 +154,7 @@ jobs:
       - name: Checkout repository
         uses: actions/checkout@v7
         with:
+          ref: ${{ inputs.source_ref || github.ref }}
           fetch-depth: 1
 
       - name: Setup Node.js
@@ -354,6 +365,7 @@ jobs:
       - name: Checkout repository
         uses: actions/checkout@v7
         with:
+          ref: ${{ inputs.source_ref || github.ref }}
           fetch-depth: 1
 
       - name: Setup Node.js
@@ -580,6 +592,7 @@ jobs:
       - name: Checkout repository
         uses: actions/checkout@v7
         with:
+          ref: ${{ inputs.source_ref || github.ref }}
           fetch-depth: 1
 
       - name: Get version from package.json
@@ -686,6 +699,7 @@ jobs:
       - name: Checkout repository
         uses: actions/checkout@v7
         with:
+          ref: ${{ inputs.source_ref || github.ref }}
           fetch-depth: 1
 
       - name: Get version from package.json
@@ -823,6 +837,7 @@ jobs:
       - name: Checkout repository
         uses: actions/checkout@v7
         with:
+          ref: ${{ inputs.source_ref || github.ref }}
           fetch-depth: 1
 
       - name: Get version from package.json
@@ -933,6 +948,7 @@ jobs:
       - name: Checkout repository
         uses: actions/checkout@v7
         with:
+          ref: ${{ inputs.source_ref || github.ref }}
           fetch-depth: 1
 
       - name: Setup Node.js

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -278,7 +278,7 @@ jobs:
 
           MAIN_SHA=$(gh api repos/${{ github.repository }}/commits/main -q .sha)
           echo "main_sha=$MAIN_SHA" >> "$GITHUB_OUTPUT"
-          echo "build_ref=main" >> "$GITHUB_OUTPUT"
+          echo "build_ref=$MAIN_SHA" >> "$GITHUB_OUTPUT"
 
   docker:
     needs: [prep, merge-to-main]
@@ -287,6 +287,7 @@ jobs:
       version: ${{ needs.prep.outputs.version }}
       build_type: Production
       dry_run: ${{ inputs.mode == 'Dry run' }}
+      source_ref: ${{ needs.merge-to-main.outputs.build_ref }}
     secrets: inherit
 
   create-release:
@@ -351,15 +352,17 @@ jobs:
       build_type: all
       artifact_destination: ${{ inputs.mode == 'Dry run' && 'file' || 'release' }}
       release_tag: ${{ needs.prep.outputs.release_tag }}
+      source_ref: ${{ needs.merge-to-main.outputs.build_ref }}
     secrets: inherit
 
   electron-submit:
-    needs: [prep, electron-release]
+    needs: [prep, merge-to-main, electron-release]
     if: ${{ inputs.mode != 'Dry run' && inputs.mode != 'Skip submit' }}
     uses: ./.github/workflows/electron.yml
     with:
       build_type: all
       artifact_destination: submit
+      source_ref: ${{ needs.merge-to-main.outputs.build_ref }}
     secrets: inherit
 
   cask-commit-back:


### PR DESCRIPTION
## Summary
- pass the post-merge release ref into Docker and Electron reusable workflows
- checkout the requested source ref/SHA when building release artifacts
- label Docker images with the actual checked-out source revision

Fixes Termix-SSH/Support#936

## Why
The release workflow syncs translations and merges the dev branch to main before building artifacts, but the reusable Docker/Electron workflows did not checkout that post-merge ref. This can produce release images from the workflow's original SHA, leaving Docker locale chunks behind the translated source files.

## Verification
- npm run build
- inspected dist/assets/ru_RU-*.js for Russian nav strings instead of English fallback strings
- npx prettier --check .github/workflows/docker.yml .github/workflows/release.yml .github/workflows/electron.yml
- actionlint -ignore 'label ".+" is unknown' -ignore '"needs" section should not be empty' .github/workflows/docker.yml .github/workflows/release.yml .github/workflows/electron.yml
- git diff --check