### PR TITLE
Fix command palette Escape in fullscreen

### DIFF
--- a/src/ui/shell/CommandPalette.tsx
+++ b/src/ui/shell/CommandPalette.tsx
@@ -126,14 +126,18 @@ export function CommandPalette({
   }, [isOpen]);
 
   useEffect(() => {
+    if (!isOpen) return;
+
     const handleKeyDown = (e: KeyboardEvent) => {
       if (e.key === "Escape") {
+        e.preventDefault();
+        e.stopPropagation();
         setIsOpen(false);
       }
     };
-    window.addEventListener("keydown", handleKeyDown);
-    return () => window.removeEventListener("keydown", handleKeyDown);
-  }, [setIsOpen]);
+    window.addEventListener("keydown", handleKeyDown, true);
+    return () => window.removeEventListener("keydown", handleKeyDown, true);
+  }, [isOpen, setIsOpen]);
 
   const filteredHosts = hosts.filter(
     (h) =>


### PR DESCRIPTION
## Summary
- only register the command palette Escape handler while the palette is open
- handle Escape in the capture phase and consume it before browser fullscreen exits
- keep the next Escape press available for leaving fullscreen after the palette closes

Fixes Termix-SSH/Support#929

## Tests
- npx prettier --check src/ui/shell/CommandPalette.tsx
- npx eslint src/ui/shell/CommandPalette.tsx
- npm run type-check
- git diff --check
- npm run build