### PR TITLE
Prevent Electron modifier wheel zoom

### DIFF
--- a/src/main.tsx
+++ b/src/main.tsx
@@ -10,6 +10,7 @@ import { Toaster } from "@/components/sonner";
 import { Auth, getStoredAuth, clearStoredAuth } from "@/auth/Auth";
 import { getUserInfo, getCurrentToken, appReadyPromise } from "@/main-axios";
 import { applyAccentColor, applyFontSize } from "@/lib/theme";
+import { installElectronWheelZoomGuard } from "@/lib/electron-wheel-zoom";
 import type { FontSizeId } from "@/types/ui-types";
 import { useServiceWorker } from "@/hooks/use-service-worker";
 import { useTranslation } from "react-i18next";
@@ -339,6 +340,8 @@ function RootApp() {
 
   return <App />;
 }
+
+installElectronWheelZoomGuard();
 
 prepareClientCacheVersion().finally(() => {
   createRoot(document.getElementById("root")!).render(

--- a/src/ui/lib/electron-wheel-zoom.test.ts
+++ b/src/ui/lib/electron-wheel-zoom.test.ts
@@ -1,0 +1,39 @@
+import { afterEach, describe, expect, it } from "vitest";
+import { installElectronWheelZoomGuard } from "./electron-wheel-zoom";
+
+const win = window as unknown as Record<string, unknown>;
+let cleanup: (() => void) | undefined;
+
+afterEach(() => {
+  cleanup?.();
+  cleanup = undefined;
+  delete win.IS_ELECTRON;
+  delete win.electronAPI;
+});
+
+function dispatchWheel(init?: WheelEventInit): WheelEvent {
+  const event = new WheelEvent("wheel", {
+    bubbles: true,
+    cancelable: true,
+    ...init,
+  });
+  window.dispatchEvent(event);
+  return event;
+}
+
+describe("installElectronWheelZoomGuard", () => {
+  it("does not block ordinary browser wheel events", () => {
+    cleanup = installElectronWheelZoomGuard();
+
+    expect(dispatchWheel({ ctrlKey: true }).defaultPrevented).toBe(false);
+  });
+
+  it("blocks modifier wheel zoom in Electron", () => {
+    win.electronAPI = { isElectron: true };
+    cleanup = installElectronWheelZoomGuard();
+
+    expect(dispatchWheel({ metaKey: true }).defaultPrevented).toBe(true);
+    expect(dispatchWheel({ ctrlKey: true }).defaultPrevented).toBe(true);
+    expect(dispatchWheel().defaultPrevented).toBe(false);
+  });
+});

--- a/src/ui/lib/electron-wheel-zoom.ts
+++ b/src/ui/lib/electron-wheel-zoom.ts
@@ -1,0 +1,20 @@
+import { isElectron } from "./electron";
+
+export function installElectronWheelZoomGuard(): () => void {
+  if (!isElectron()) return () => {};
+
+  const preventModifierWheelZoom = (event: WheelEvent) => {
+    if (!event.metaKey && !event.ctrlKey) return;
+    event.preventDefault();
+  };
+
+  window.addEventListener("wheel", preventModifierWheelZoom, {
+    capture: true,
+    passive: false,
+  });
+
+  return () =>
+    window.removeEventListener("wheel", preventModifierWheelZoom, {
+      capture: true,
+    });
+}


### PR DESCRIPTION
## Summary
- prevent Electron from treating Cmd/Ctrl + wheel as browser zoom
- keep ordinary wheel scrolling untouched
- cover the guard with a focused unit test

Fixes Termix-SSH/Support#942

Note: this fixes the reported macOS Cmd + two-finger scroll resize/zoom behavior. Shortcut customization is a separate feature request and is intentionally not included here.

## Verification
- npx vitest run src/ui/lib/electron-wheel-zoom.test.ts
- npm run type-check
- npx eslint src/main.tsx src/ui/lib/electron-wheel-zoom.ts src/ui/lib/electron-wheel-zoom.test.ts
- npx prettier --check src/main.tsx src/ui/lib/electron-wheel-zoom.ts src/ui/lib/electron-wheel-zoom.test.ts
- git diff --check
- npm run build