### PR TITLE
fix terminal font selection

### DIFF
--- a/src/ui/features/terminal/TerminalPreview.tsx
+++ b/src/ui/features/terminal/TerminalPreview.tsx
@@ -45,7 +45,7 @@ export function TerminalPreview({
   return (
     <div className="border border-input overflow-hidden">
       <div
-        className="p-3 font-mono"
+        className="p-3"
         style={{
           fontSize: `${fontSize}px`,
           fontFamily: fontFallback,

--- a/src/ui/features/terminal/terminal-global-styles.ts
+++ b/src/ui/features/terminal/terminal-global-styles.ts
@@ -66,7 +66,6 @@ style.innerHTML = `
 }
 
 .xterm .xterm-screen {
-  font-family: 'Caskaydia Cove Nerd Font Mono', 'SF Mono', Monaco, Consolas, 'Liberation Mono', 'Courier New', monospace !important;
   font-variant-ligatures: none;
 }
 


### PR DESCRIPTION
## Summary
- remove the global xterm font-family override so selected terminal fonts can apply
- remove the preview font-mono class so the preview uses the selected font fallback directly

## Validation
- npm run type-check
- npx eslint src/ui/features/terminal/terminal-global-styles.ts src/ui/features/terminal/TerminalPreview.tsx
- npx prettier --check src/ui/features/terminal/terminal-global-styles.ts src/ui/features/terminal/TerminalPreview.tsx
- git diff --check
- npm run build

Refs Termix-SSH/Support#944