### PR TITLE
Fix tmux detection for non-POSIX shells

### DIFF
--- a/src/backend/ssh/tmux-helper.test.ts
+++ b/src/backend/ssh/tmux-helper.test.ts
@@ -1,20 +1,52 @@
+import { EventEmitter } from "node:events";
+import type { Client } from "ssh2";
 import { describe, expect, it } from "vitest";
-import { tmuxCommand, withTmuxPath } from "./tmux-helper.js";
+import { detectTmux, tmuxCommand, withTmuxPath } from "./tmux-helper.js";
 
 describe("tmux command path handling", () => {
   it("adds common non-login shell tmux paths", () => {
     const command = withTmuxPath("command -v tmux");
 
+    expect(command).toMatch(/^\/bin\/sh -c '/);
     expect(command).toContain("/opt/homebrew/bin");
     expect(command).toContain("/usr/local/bin");
     expect(command).toContain("/opt/bin");
     expect(command).toContain("/usr/pkg/bin");
-    expect(command).toContain(":$PATH; command -v tmux");
+    expect(command).toContain(":$PATH; export PATH; command -v tmux");
   });
 
   it("wraps tmux invocations with the same path", () => {
     expect(tmuxCommand("list-sessions")).toMatch(
-      /^PATH=.*:\$PATH; tmux list-sessions$/,
+      /^\/bin\/sh -c 'PATH=.*:\$PATH; export PATH; tmux list-sessions'$/,
     );
+  });
+
+  it("detects suffixed tmux versions without parsing the version number", async () => {
+    const commands: string[] = [];
+    const conn = {
+      exec(command: string, callback: (error: null, stream: never) => void) {
+        commands.push(command);
+        const stream = new EventEmitter() as EventEmitter & {
+          stderr: EventEmitter;
+        };
+        stream.stderr = new EventEmitter();
+        callback(null, stream as never);
+
+        queueMicrotask(() => {
+          if (commands.length === 1) {
+            stream.emit("data", Buffer.from("tmux 3.7b\n"));
+            stream.emit("close", 0);
+            return;
+          }
+          stream.emit("close", 1);
+        });
+      },
+    } as unknown as Client;
+
+    await expect(detectTmux(conn)).resolves.toEqual({
+      available: true,
+      sessions: [],
+    });
+    expect(commands[0]).toContain("tmux -V");
   });
 });

--- a/src/backend/ssh/tmux-helper.ts
+++ b/src/backend/ssh/tmux-helper.ts
@@ -22,7 +22,8 @@ const TMUX_PATH_DIRS = [
 ];
 
 export function withTmuxPath(command: string): string {
-  return `PATH=${TMUX_PATH_DIRS.join(":")}:$PATH; ${command}`;
+  const script = `PATH=${TMUX_PATH_DIRS.join(":")}:$PATH; export PATH; ${command}`;
+  return `/bin/sh -c ${shellEscape(script)}`;
 }
 
 export function tmuxCommand(args: string): string {
@@ -69,7 +70,7 @@ export function execCommand(conn: Client, command: string): Promise<string> {
  */
 export async function detectTmux(conn: Client): Promise<TmuxDetectionResult> {
   try {
-    await execCommand(conn, withTmuxPath("command -v tmux"));
+    await execCommand(conn, tmuxCommand("-V"));
   } catch {
     return { available: false, sessions: [] };
   }

--- a/src/backend/ssh/tmux-monitor.ts
+++ b/src/backend/ssh/tmux-monitor.ts
@@ -21,7 +21,7 @@ import {
 } from "../utils/socks5-helper.js";
 import { withConnection } from "./ssh-connection-pool.js";
 import { resolveSshConnectConfigHost } from "./ssh-dns.js";
-import { execCommand, tmuxCommand, withTmuxPath } from "./tmux-helper.js";
+import { execCommand, tmuxCommand } from "./tmux-helper.js";
 import {
   SEP,
   parseSessions,
@@ -246,7 +246,7 @@ async function withHostConnection<T>(
 
 async function tmuxAvailable(conn: Client): Promise<boolean> {
   try {
-    await execCommand(conn, withTmuxPath("command -v tmux"));
+    await execCommand(conn, tmuxCommand("-V"));
     return true;
   } catch {
     return false;


### PR DESCRIPTION
## Summary
- execute tmux helper commands through `/bin/sh -c` so remote login shells such as fish do not reject the PATH setup syntax
- detect tmux by running `tmux -V` in both terminal auto-tmux and Tmux Monitor flows
- accept suffixed versions such as `tmux 3.7b` without parsing or constraining the version string
- add regression coverage for the shell wrapper and the 3.7b detection result

## Root cause
The failure was not version parsing. Termix prefixed detection with a standalone POSIX-style `PATH=...;` assignment. Non-POSIX login shells can reject that statement before `command -v tmux` runs, and the error was then reported as tmux being unavailable.

## Validation
- `npm test -- src/backend/ssh/tmux-helper.test.ts`
- `npm run type-check`
- `npm run lint`
- `npm run build`
- targeted ESLint and Prettier checks

Fixes Termix-SSH/Support#953

Issue: https://github.com/Termix-SSH/Support/issues/953