### PR TITLE
Fix OPKSSH startup with js-yaml v5

### DIFF
--- a/src/backend/ssh/opkssh-auth.ts
+++ b/src/backend/ssh/opkssh-auth.ts
@@ -11,7 +11,7 @@ import { FieldCrypto } from "../utils/field-crypto.js";
 import { promises as fs } from "fs";
 import path from "path";
 import axios from "axios";
-import yaml from "js-yaml";
+import { load as loadYaml } from "js-yaml";
 
 const AUTH_TIMEOUT = 60 * 1000;
 
@@ -131,7 +131,7 @@ async function checkOPKConfigExists(): Promise<{
 
     let providers: ProviderRedirectInfo[] = [];
     try {
-      const parsed = yaml.load(content) as {
+      const parsed = loadYaml(content) as {
         providers?: Array<{
           alias?: string;
           issuer?: string;


### PR DESCRIPTION
## Summary
- use the named `load` export provided by js-yaml v5
- restore OPKSSH module loading under Node ESM

## Root cause
Termix 2.5.0 upgraded js-yaml to v5, which no longer provides a default ESM export. The OPKSSH module still imported that removed default export, so Node failed while instantiating the module before authentication could start.

## Validation
- `npx prettier --check src/backend/ssh/opkssh-auth.ts`
- `npx eslint src/backend/ssh/opkssh-auth.ts`
- `npm run type-check`
- `npm run lint`
- `npm run build`
- native Node ESM import of `dist/backend/backend/ssh/opkssh-auth.js`

Fixes Termix-SSH/Support#958
https://github.com/Termix-SSH/Support/issues/958