### PR TITLE
Fix Proxmox discovery over HTTPS

### DIFF
--- a/docker/nginx-https.conf
+++ b/docker/nginx-https.conf
@@ -235,6 +235,18 @@ http {
             proxy_set_header X-Forwarded-Proto $scheme;
         }
 
+        location ~ ^/proxmox(/.*)?$ {
+            proxy_pass http://127.0.0.1:30001;
+            proxy_http_version 1.1;
+            proxy_set_header Host $http_host;
+            proxy_set_header X-Real-IP $remote_addr;
+            proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+            proxy_set_header X-Forwarded-Proto $proxy_x_forwarded_proto;
+            proxy_connect_timeout 60s;
+            proxy_send_timeout 120s;
+            proxy_read_timeout 120s;
+        }
+
         location ~ ^/c2s-tunnel-presets(/.*)?$ {
             proxy_pass http://127.0.0.1:30001;
             proxy_http_version 1.1;


### PR DESCRIPTION
## Summary
- proxy `/proxmox` requests in the HTTPS nginx configuration
- keep the HTTPS route aligned with the existing HTTP configuration and backend timeouts
- prevent discovery POST requests from falling through to the static frontend and returning 405

## Validation
- `git diff --check`
- `npm run format:check -- docker/nginx-https.conf`
- generated the HTTPS nginx config with `envsubst` and verified it with `nginx -t` using `nginx:alpine`

Fixes Termix-SSH/Support#975