### PR TITLE
Fix hidden external editor actions in file preview

### DIFF
--- a/src/ui/features/file-manager/components/FileViewer.tsx
+++ b/src/ui/features/file-manager/components/FileViewer.tsx
@@ -407,7 +407,7 @@ export function FileViewer({
   return (
     <div className="h-full flex flex-col bg-background">
       <div className="flex-shrink-0 bg-card border-b border-border p-4">
-        <div className="flex items-center justify-between">
+        <div className="flex flex-wrap items-center justify-between gap-3">
           <div className="flex items-center gap-3">
             <div className={cn("p-2 rounded-lg bg-muted", fileTypeInfo.color)}>
               {fileTypeInfo.icon}
@@ -434,7 +434,7 @@ export function FileViewer({
             </div>
           </div>
 
-          <div className="flex items-center gap-2">
+          <div className="ml-auto flex min-w-0 max-w-full flex-wrap items-center justify-end gap-2">
             {isEditable && (
               <Button
                 variant="ghost"


### PR DESCRIPTION
## Summary
- allow the file preview header and action toolbar to wrap within narrow windows
- keep external editor and editor-selection actions visible at the default 800px file window width
- preserve all existing file preview actions instead of clipping the actions after Download

## Root cause
The external editor controls were rendered after the Download action in a non-wrapping header. The file window uses an 800px default width and `overflow-hidden`, so the controls existed but were clipped outside the visible window.

## Validation
- `git diff --check`
- `npx prettier --check src/ui/features/file-manager/components/FileViewer.tsx`
- `npx eslint src/ui/features/file-manager/components/FileViewer.tsx`
- `npm run type-check`
- `npm run build`

Fixes Termix-SSH/Support#972