### PR TITLE
Fix Firefox desktop OIDC callback

### DIFF
--- a/electron/main.cjs
+++ b/electron/main.cjs
@@ -1397,7 +1397,7 @@ ipcMain.handle(
 
       server.once("error", fail);
 
-      server.listen(callbackPort, "127.0.0.1", async () => {
+      server.listen(callbackPort, "localhost", async () => {
         try {
           await shell.openExternal(authUrl);
         } catch (error) {

--- a/src/backend/database/routes/users.ts
+++ b/src/backend/database/routes/users.ts
@@ -18,6 +18,10 @@ import {
   getRequestBasePath,
   getRequestBaseUrlWithForceHTTPS,
 } from "../../utils/request-origin.js";
+import {
+  getDesktopOidcCallbackUrl,
+  isOidcTokenCallback,
+} from "../../utils/oidc-desktop-callback.js";
 import { deleteUserAndRelatedData } from "./delete-user-data.js";
 import {
   getOIDCConfigFromEnv,
@@ -654,7 +658,10 @@ router.get("/oidc/authorize", async (req, res) => {
     const referer = req.get("Referer");
     let frontendOrigin;
     if (desktopCallbackPort) {
-      frontendOrigin = `http://127.0.0.1:${desktopCallbackPort}/oidc-callback`;
+      frontendOrigin = getDesktopOidcCallbackUrl(desktopCallbackPort);
+      if (!frontendOrigin) {
+        return res.status(400).json({ error: "Invalid desktop callback port" });
+      }
     } else if (typeof appCallbackUrl === "string" && appCallbackUrl) {
       let callbackUrl: URL;
       try {
@@ -1001,9 +1008,7 @@ router.get("/oidc/callback", async (req, res) => {
       });
       const ghRedirectUrl = new URL(frontendOrigin);
       ghRedirectUrl.searchParams.set("success", "true");
-      const ghIsTokenCallback =
-        frontendOrigin.startsWith("http://127.0.0.1:") ||
-        frontendOrigin.startsWith("termix-mobile:");
+      const ghIsTokenCallback = isOidcTokenCallback(frontendOrigin);
       const ghMaxAge =
         deviceInfo.type === "desktop" || deviceInfo.type === "mobile"
           ? 30 * 24 * 60 * 60 * 1000
@@ -1487,9 +1492,7 @@ router.get("/oidc/callback", async (req, res) => {
     const redirectUrl = new URL(frontendOrigin);
     redirectUrl.searchParams.set("success", "true");
 
-    const isTokenCallback =
-      frontendOrigin.startsWith("http://127.0.0.1:") ||
-      frontendOrigin.startsWith("termix-mobile:");
+    const isTokenCallback = isOidcTokenCallback(frontendOrigin);
 
     const maxAge =
       deviceInfo.type === "desktop" || deviceInfo.type === "mobile"

--- a/src/backend/utils/oidc-desktop-callback.test.ts
+++ b/src/backend/utils/oidc-desktop-callback.test.ts
@@ -1,0 +1,38 @@
+import { describe, expect, it } from "vitest";
+import {
+  getDesktopOidcCallbackUrl,
+  isOidcTokenCallback,
+} from "./oidc-desktop-callback";
+
+describe("getDesktopOidcCallbackUrl", () => {
+  it("uses localhost so browsers do not upgrade the loopback callback", () => {
+    expect(getDesktopOidcCallbackUrl("17850")).toBe(
+      "http://localhost:17850/oidc-callback",
+    );
+  });
+
+  it.each(["", "0", "65536", "17850/path", ["17850"]])(
+    "rejects invalid callback port %j",
+    (port) => {
+      expect(getDesktopOidcCallbackUrl(port)).toBeNull();
+    },
+  );
+});
+
+describe("isOidcTokenCallback", () => {
+  it.each([
+    "http://localhost:17850/oidc-callback",
+    "http://127.0.0.1:17850/oidc-callback",
+    "termix-mobile://oidc-callback",
+  ])("recognizes app callback %s", (url) => {
+    expect(isOidcTokenCallback(url)).toBe(true);
+  });
+
+  it.each([
+    "https://localhost:17850/oidc-callback",
+    "http://example.com:17850/oidc-callback",
+    "http://localhost:17850/other",
+  ])("rejects non-app callback %s", (url) => {
+    expect(isOidcTokenCallback(url)).toBe(false);
+  });
+});

--- a/src/backend/utils/oidc-desktop-callback.ts
+++ b/src/backend/utils/oidc-desktop-callback.ts
@@ -1,0 +1,25 @@
+const CALLBACK_PATH = "/oidc-callback";
+
+export function getDesktopOidcCallbackUrl(value: unknown): string | null {
+  if (typeof value !== "string" || !/^\d+$/.test(value)) return null;
+
+  const port = Number(value);
+  if (!Number.isInteger(port) || port < 1 || port > 65535) return null;
+
+  return `http://localhost:${port}${CALLBACK_PATH}`;
+}
+
+export function isOidcTokenCallback(value: string): boolean {
+  if (value.startsWith("termix-mobile:")) return true;
+
+  try {
+    const url = new URL(value);
+    return (
+      url.protocol === "http:" &&
+      (url.hostname === "localhost" || url.hostname === "127.0.0.1") &&
+      url.pathname === CALLBACK_PATH
+    );
+  } catch {
+    return false;
+  }
+}


### PR DESCRIPTION
## Summary
- use `localhost` for the desktop OIDC loopback callback so Firefox does not upgrade it to HTTPS
- bind the Electron callback listener to the same hostname
- preserve token delivery for both standard and GitHub OIDC providers
- validate the desktop callback port before storing the redirect target

## Root cause
The desktop callback used `http://127.0.0.1:<port>`. In the reported Firefox setup this was upgraded to HTTPS, but Electron serves a plain HTTP loopback listener, producing an SSL protocol error and leaving the app waiting until timeout. Firefox always exempts `localhost` from HTTPS-Only upgrades.

## Validation
- `npm test -- --run src/backend/utils/oidc-desktop-callback.test.ts` (12 tests)
- `npx eslint src/backend/utils/oidc-desktop-callback.ts src/backend/utils/oidc-desktop-callback.test.ts src/backend/database/routes/users.ts`
- `npm run type-check`
- `npm run build`
- `git diff --check`

Fixes Termix-SSH/Support#968