### PR TITLE
feat: add Open File Manager to tab right-click menu

### DIFF
--- a/src/ui/AppShell.tsx
+++ b/src/ui/AppShell.tsx
@@ -1713,6 +1713,10 @@ export function AppShell({
               onAddToSplit={addTabToSplit}
               onRemoveFromSplit={removeTabFromSplit}
               onRenameTab={renameTab}
+              onOpenFileManager={(tabId) => {
+                const targetTab = tabs.find((t) => t.id === tabId);
+                if (targetTab?.host) openTab(targetTab.host, "files");
+              }}
               isAppFullscreen={isAppFullscreen}
               onToggleAppFullscreen={toggleAppFullscreen}
             />

--- a/src/ui/shell/TabBar.tsx
+++ b/src/ui/shell/TabBar.tsx
@@ -18,6 +18,7 @@ import {
   Pencil,
   Maximize2,
   Minimize2,
+  FolderOpen,
 } from "lucide-react";
 import { tabIcon } from "@/shell/tabUtils";
 import { isElectron } from "@/lib/electron";
@@ -40,6 +41,7 @@ export function TabBar({
   onAddToSplit,
   onRemoveFromSplit,
   onRenameTab,
+  onOpenFileManager,
   isAppFullscreen,
   onToggleAppFullscreen,
 }: {
@@ -56,6 +58,7 @@ export function TabBar({
   onAddToSplit: (tabId: string) => void;
   onRemoveFromSplit: (tabId: string) => void;
   onRenameTab?: (tabId: string, newLabel: string) => void;
+  onOpenFileManager?: (tabId: string) => void;
   isAppFullscreen: boolean;
   onToggleAppFullscreen: () => void;
 }) {
@@ -527,6 +530,20 @@ export function TabBar({
                   {t("nav.refreshTab")}
                 </button>
               )}
+              {ctxTab.type === "terminal" &&
+                ctxTab.host &&
+                onOpenFileManager && (
+                  <button
+                    className="flex items-center gap-2 w-full px-3 py-1.5 text-xs text-left hover:bg-accent hover:text-accent-foreground"
+                    onClick={() => {
+                      onOpenFileManager(contextTabId);
+                      setContextTabId(null);
+                    }}
+                  >
+                    <FolderOpen className="size-3" />
+                    {t("nav.openFileManager")}
+                  </button>
+                )}
               <button
                 className="flex items-center gap-2 w-full px-3 py-1.5 text-xs text-left hover:bg-accent hover:text-accent-foreground"
                 onClick={() => {


### PR DESCRIPTION
# Overview
_Short summary of what this PR does_
- [x] Added: "Open File Manager" option to the terminal tab right-click context menu
- [x] Updated: `TabBar.tsx` context menu and `AppShell.tsx` tab handling to support opening a file browser tab directly from a terminal tab
- [ ] Removed: ...
- [ ] Fixed: ...

# Changes Made
_Detailed explanation of changes (if needed)_
- `TabBar.tsx`: added a new `onOpenFileManager` prop and rendered an "Open File Manager" button (with `FolderOpen` icon) in the tab context menu. The option is only shown for tabs where `type === "terminal"` and a `host` is present.
- `AppShell.tsx`: wired up the new prop — resolves the target tab by id and opens a new `files` tab pointed at that tab's host.
- No new i18n key was needed; `nav.openFileManager` already existed in `en.json`.

# Related Issues
_Link any issues this PR addresses_
- Closes #974

# Screenshots / Demos
_(Optional: add before/after screenshots, GIFs, or console output)_

**Context menu showing the new "Open File Manager" option on a terminal tab:**

![Context menu with Open File Manager option]

<img width="728" height="491" alt="context-menu-screenshot" src="https://github.com/user-attachments/assets/819388c7-098d-4fd4-bfe9-53be84e6f982" />

- Resulting file-manager (SFTP) tab opened for the same host, confirmed via connection log showing an SFTP connection attempt to the correct host/port

# Checklist
- [x] Code follows project style guidelines
- [ ] Supports mobile and desktop UI/app (if applicable)
- [x] I have read [Contributing.md](https://github.com/Termix-SSH/Termix/blob/main/CONTRIBUTING.md)
- [x] This is not a translation request. See [docs](https://docs.termix.site/translations)

---

### Testing done
- Verified the patch applies cleanly against `main`.
- `npm run build` — succeeds.
- `npm run type-check` — 0 errors.
- `npm run lint` — 0 errors, no new warnings introduced (44 pre-existing warnings unrelated to these files).
- Manual test: right-clicked a terminal tab, confirmed "Open File Manager" appears with correct label/icon; clicking it opens a new file-browser (SFTP) tab correctly targeted at the same host.

### Notes for reviewers
- The option only appears for `ctxTab.type === "terminal"`. Extending this to other tab types with a `host` (e.g. RDP/VNC) could be a natural follow-up, but is out of scope here.
- Split-tab pane behavior (2-way, 3-way, etc.) was not explicitly exercised in testing — flagging as a possible follow-up check.
