### PR TITLE
fix(terminal): add keyboard font zoom shortcuts

### DIFF
--- a/src/ui/features/terminal/Terminal.tsx
+++ b/src/ui/features/terminal/Terminal.tsx
@@ -56,6 +56,10 @@ import { ConnectionLog } from "@/ssh/connection-log/ConnectionLog.tsx";
 import { toast } from "sonner";
 import { Button } from "@/components/button";
 import { resolveTermixThemeColors } from "./terminal-theme.ts";
+import {
+  clampTerminalFontSize,
+  getTerminalFontZoomDirection,
+} from "./terminal-font-zoom.ts";
 import type { TerminalHandle, TerminalHostConfig } from "./terminal-types.ts";
 export type { TerminalHandle, TerminalHostConfig } from "./terminal-types.ts";
 
@@ -83,8 +87,6 @@ interface SSHTerminalProps {
   disableAutoFocus?: boolean;
 }
 
-const TERMINAL_FONT_ZOOM_MIN = 8;
-const TERMINAL_FONT_ZOOM_MAX = 36;
 const ALTERNATE_SCREEN_SEQUENCE = /\x1b\[\?(47|1047|1049)([hl])/g;
 
 function updateAlternateScreenMode(output: string, currentMode: boolean) {
@@ -497,16 +499,12 @@ const TerminalInner = forwardRef<TerminalHandle, SSHTerminalProps>(
       }
     }
 
-    function zoomTerminalFont(deltaY: number) {
-      const direction = deltaY < 0 ? 1 : -1;
+    function zoomTerminalFont(direction: 1 | -1) {
       const currentFontSize =
         terminal.options.fontSize ??
         terminalFontSizeRef.current ??
         DEFAULT_TERMINAL_CONFIG.fontSize;
-      const nextFontSize = Math.min(
-        TERMINAL_FONT_ZOOM_MAX,
-        Math.max(TERMINAL_FONT_ZOOM_MIN, currentFontSize + direction),
-      );
+      const nextFontSize = clampTerminalFontSize(currentFontSize, direction);
 
       if (nextFontSize === currentFontSize) {
         return;
@@ -2167,7 +2165,7 @@ const TerminalInner = forwardRef<TerminalHandle, SSHTerminalProps>(
 
       terminal.attachCustomWheelEventHandler((ev) => {
         if (ev.ctrlKey || ev.metaKey) {
-          zoomTerminalFont(ev.deltaY);
+          zoomTerminalFont(ev.deltaY < 0 ? 1 : -1);
           return false;
         }
 
@@ -2365,6 +2363,14 @@ const TerminalInner = forwardRef<TerminalHandle, SSHTerminalProps>(
       const handleCustomKey = (e: KeyboardEvent): boolean => {
         if (e.type !== "keydown") {
           return true;
+        }
+
+        const fontZoomDirection = getTerminalFontZoomDirection(e);
+        if (fontZoomDirection) {
+          e.preventDefault();
+          e.stopPropagation();
+          zoomTerminalFont(fontZoomDirection);
+          return false;
         }
 
         // Forward global app shortcuts to AppShell directly — xterm swallows

--- a/src/ui/features/terminal/terminal-font-zoom.test.ts
+++ b/src/ui/features/terminal/terminal-font-zoom.test.ts
@@ -1,0 +1,41 @@
+import { describe, expect, it } from "vitest";
+import {
+  clampTerminalFontSize,
+  getTerminalFontZoomDirection,
+} from "./terminal-font-zoom";
+
+function keyboardEvent(key: string, overrides: Partial<KeyboardEvent> = {}) {
+  return new KeyboardEvent("keydown", {
+    key,
+    code: key === "+" ? "Equal" : key === "-" ? "Minus" : "KeyA",
+    ctrlKey: true,
+    ...overrides,
+  });
+}
+
+describe("terminal font zoom", () => {
+  it("recognizes Ctrl/Cmd plus and minus shortcuts", () => {
+    expect(getTerminalFontZoomDirection(keyboardEvent("+"))).toBe(1);
+    expect(getTerminalFontZoomDirection(keyboardEvent("-"))).toBe(-1);
+    expect(
+      getTerminalFontZoomDirection(
+        keyboardEvent("+", { ctrlKey: false, metaKey: true }),
+      ),
+    ).toBe(1);
+  });
+
+  it("ignores unmodified and Alt-modified keys", () => {
+    expect(
+      getTerminalFontZoomDirection(keyboardEvent("+", { ctrlKey: false })),
+    ).toBeNull();
+    expect(
+      getTerminalFontZoomDirection(keyboardEvent("+", { altKey: true })),
+    ).toBeNull();
+  });
+
+  it("keeps the font size within terminal limits", () => {
+    expect(clampTerminalFontSize(14, 1)).toBe(15);
+    expect(clampTerminalFontSize(36, 1)).toBe(36);
+    expect(clampTerminalFontSize(8, -1)).toBe(8);
+  });
+});

--- a/src/ui/features/terminal/terminal-font-zoom.ts
+++ b/src/ui/features/terminal/terminal-font-zoom.ts
@@ -1,0 +1,20 @@
+export const TERMINAL_FONT_ZOOM_MIN = 8;
+export const TERMINAL_FONT_ZOOM_MAX = 36;
+
+export function clampTerminalFontSize(fontSize: number, direction: 1 | -1) {
+  return Math.min(
+    TERMINAL_FONT_ZOOM_MAX,
+    Math.max(TERMINAL_FONT_ZOOM_MIN, fontSize + direction),
+  );
+}
+
+export function getTerminalFontZoomDirection(
+  event: Pick<KeyboardEvent, "altKey" | "code" | "ctrlKey" | "key" | "metaKey">,
+): 1 | -1 | null {
+  if ((!event.ctrlKey && !event.metaKey) || event.altKey) return null;
+
+  if (event.key === "+" || event.code === "NumpadAdd") return 1;
+  if (event.key === "-" || event.code === "NumpadSubtract") return -1;
+
+  return null;
+}


### PR DESCRIPTION
## Summary
- add Ctrl/Cmd + `+` and Ctrl/Cmd + `-` shortcuts to adjust SSH terminal font size
- reuse the existing terminal-only zoom behavior and 8–36 font-size limits
- support numpad add/subtract and prevent browser zoom while the terminal handles the shortcut

## Verification
- `npx vitest run src/ui/features/terminal/terminal-font-zoom.test.ts`
- `npm run type-check`
- targeted ESLint
- `npm run build`

Closes Termix-SSH/Support#963