### PR TITLE
feat: add Open File Manager to tab right-click menu

### DIFF
--- a/src/ui/AppShell.tsx
+++ b/src/ui/AppShell.tsx
@@ -1713,6 +1713,10 @@ export function AppShell({
               onAddToSplit={addTabToSplit}
               onRemoveFromSplit={removeTabFromSplit}
               onRenameTab={renameTab}
+              onOpenFileManager={(tabId) => {
+                const targetTab = tabs.find((t) => t.id === tabId);
+                if (targetTab?.host) openTab(targetTab.host, "files");
+              }}
               isAppFullscreen={isAppFullscreen}
               onToggleAppFullscreen={toggleAppFullscreen}
             />

--- a/src/ui/shell/TabBar.tsx
+++ b/src/ui/shell/TabBar.tsx
@@ -18,6 +18,7 @@ import {
   Pencil,
   Maximize2,
   Minimize2,
+  FolderOpen,
 } from "lucide-react";
 import { tabIcon } from "@/shell/tabUtils";
 import { isElectron } from "@/lib/electron";
@@ -40,6 +41,7 @@ export function TabBar({
   onAddToSplit,
   onRemoveFromSplit,
   onRenameTab,
+  onOpenFileManager,
   isAppFullscreen,
   onToggleAppFullscreen,
 }: {
@@ -56,6 +58,7 @@ export function TabBar({
   onAddToSplit: (tabId: string) => void;
   onRemoveFromSplit: (tabId: string) => void;
   onRenameTab?: (tabId: string, newLabel: string) => void;
+  onOpenFileManager?: (tabId: string) => void;
   isAppFullscreen: boolean;
   onToggleAppFullscreen: () => void;
 }) {
@@ -527,6 +530,20 @@ export function TabBar({
                   {t("nav.refreshTab")}
                 </button>
               )}
+              {ctxTab.type === "terminal" &&
+                ctxTab.host &&
+                onOpenFileManager && (
+                  <button
+                    className="flex items-center gap-2 w-full px-3 py-1.5 text-xs text-left hover:bg-accent hover:text-accent-foreground"
+                    onClick={() => {
+                      onOpenFileManager(contextTabId);
+                      setContextTabId(null);
+                    }}
+                  >
+                    <FolderOpen className="size-3" />
+                    {t("nav.openFileManager")}
+                  </button>
+                )}
               <button
                 className="flex items-center gap-2 w-full px-3 py-1.5 text-xs text-left hover:bg-accent hover:text-accent-foreground"
                 onClick={() => {


### PR DESCRIPTION
## Summary
- add an Open File Manager action to SSH terminal tab context menus
- open the file browser against the selected tab host
- move the reviewed contribution from #1046 onto the active `dev-2.5.1` line

Original implementation by @SankeerthNara in #1046.

## Verification
- `npm run type-check`
- targeted ESLint
- targeted Prettier check
- `npm run build`

Closes Termix-SSH/Support#974