### PR TITLE
fix: restore sudo password autofill settings

### DIFF
--- a/src/ui/sidebar/HostEditor.tsx
+++ b/src/ui/sidebar/HostEditor.tsx
@@ -755,6 +755,28 @@ export function HostEditor({
                     onChange={(v) => setField("allowLegacyAlgorithms", v)}
                   />
                 </SettingRow>
+                <SettingRow
+                  label={t("hosts.sudoPasswordAutoFillLabel")}
+                  description={t("hosts.sudoPasswordAutoFillDesc")}
+                >
+                  <FakeSwitch
+                    checked={form.sudoPasswordAutoFill}
+                    onChange={(v) => setField("sudoPasswordAutoFill", v)}
+                  />
+                </SettingRow>
+                {form.sudoPasswordAutoFill && (
+                  <div className="flex flex-col gap-1.5">
+                    <label className="text-[10px] font-bold uppercase tracking-widest text-muted-foreground">
+                      {t("hosts.sudoPasswordLabel")}
+                    </label>
+                    <PasswordInput
+                      className="h-8 text-xs pr-8"
+                      placeholder="••••••••"
+                      value={form.sudoPassword}
+                      onChange={(e) => setField("sudoPassword", e.target.value)}
+                    />
+                  </div>
+                )}
               </div>
             </SectionCard>
           </>

--- a/src/ui/sidebar/HostEditorData.test.ts
+++ b/src/ui/sidebar/HostEditorData.test.ts
@@ -120,4 +120,18 @@ describe("buildHostEditorPayload auth field isolation", () => {
 
     expect(tc?.agentSocketPath).toBeNull();
   });
+
+  it("preserves sudo password autofill settings", () => {
+    const form = {
+      ...createHostEditorForm(null),
+      sudoPasswordAutoFill: true,
+      sudoPassword: "sudo-secret",
+    };
+
+    const payload = buildHostEditorPayload(form, sshOnly);
+    const tc = payload.terminalConfig as Record<string, unknown> | null;
+
+    expect(tc?.sudoPasswordAutoFill).toBe(true);
+    expect(tc?.sudoPassword).toBe("sudo-secret");
+  });
 });

--- a/src/ui/sidebar/HostEditorData.ts
+++ b/src/ui/sidebar/HostEditorData.ts
@@ -407,7 +407,7 @@ export function buildHostEditorPayload(
           agentForwarding: form.agentForwarding,
           autoMosh: form.autoMosh,
           autoTmux: form.autoTmux,
-          sudoPasswordAutoFill: false,
+          sudoPasswordAutoFill: form.sudoPasswordAutoFill,
           sudoPassword: form.sudoPassword || null,
           keepaliveInterval: Number(form.keepaliveInterval),
           keepaliveCountMax: Number(form.keepaliveCountMax),


### PR DESCRIPTION
## Summary
- restore the Sudo Password Auto Fill option in the SSH host editor
- allow users to enter a separate sudo password for new and existing hosts
- persist the selected autofill setting instead of forcing it off
- add regression coverage for the host editor payload

## Verification
- `npx vitest run src/ui/sidebar/HostEditorData.test.ts`
- touched-file ESLint
- `npm run type-check`
- `npm run build`

Closes Termix-SSH/Support#976