### PR TITLE
fix: preserve file editor position on save

### DIFF
--- a/src/ui/features/file-manager/components/FileViewer.tsx
+++ b/src/ui/features/file-manager/components/FileViewer.tsx
@@ -88,6 +88,7 @@ interface FileViewerProps {
   content?: string;
   savedContent?: string;
   isLoading?: boolean;
+  isSaving?: boolean;
   isEditable?: boolean;
   resetKey?: number;
   onContentChange?: (content: string) => void;
@@ -271,6 +272,7 @@ export function FileViewer({
   content = "",
   savedContent = "",
   isLoading = false,
+  isSaving = false,
   isEditable = false,
   resetKey,
   onContentChange,
@@ -353,6 +355,7 @@ export function FileViewer({
   };
 
   const handleSave = () => {
+    if (isSaving) return;
     onSave?.(editedContent);
   };
 
@@ -490,6 +493,7 @@ export function FileViewer({
                   variant="outline"
                   size="sm"
                   onClick={handleRevert}
+                  disabled={isSaving}
                   className="flex items-center gap-2"
                 >
                   <RotateCcw className="w-4 h-4" />
@@ -499,6 +503,7 @@ export function FileViewer({
                   variant="default"
                   size="sm"
                   onClick={handleSave}
+                  disabled={isSaving}
                   className="flex items-center gap-2"
                 >
                   <Save className="w-4 h-4" />

--- a/src/ui/features/file-manager/components/FileWindow.tsx
+++ b/src/ui/features/file-manager/components/FileWindow.tsx
@@ -81,6 +81,7 @@ export function FileWindow({
 
   const [content, setContent] = useState<string>("");
   const [isLoading, setIsLoading] = useState(false);
+  const [isSaving, setIsSaving] = useState(false);
   const [isEditable, setIsEditable] = useState(false);
   const [pendingContent, setPendingContent] = useState<string>("");
   const [resetKey, setResetKey] = useState(0);
@@ -309,7 +310,7 @@ export function FileWindow({
 
   const handleSave = async (newContent: string) => {
     try {
-      setIsLoading(true);
+      setIsSaving(true);
 
       await ensureSSHConnection();
 
@@ -340,7 +341,7 @@ export function FileWindow({
         );
       }
     } finally {
-      setIsLoading(false);
+      setIsSaving(false);
     }
   };
 
@@ -553,6 +554,7 @@ export function FileWindow({
         content={pendingContent || content}
         savedContent={content}
         isLoading={isLoading}
+        isSaving={isSaving}
         resetKey={resetKey}
         onRevert={handleRevert}
         isEditable={isEditable}


### PR DESCRIPTION
## Summary
- keep the CodeMirror editor mounted while a file is being saved
- separate saving state from initial/reload loading state
- disable save and revert actions while the write is in progress
- preserve cursor, selection, scroll position, and editor history after save

## Root cause
Saving reused the full-view loading state, which unmounted FileViewer and CodeMirror. Remounting the editor reset its cursor and scroll context to the start of the file.

## Verification
- touched-file Prettier check
- touched-file ESLint
- `npm run type-check`
- `npm run build`

Closes Termix-SSH/Support#793