### PR TITLE
fix: sync cloud preference storage mode

### DIFF
--- a/src/ui/AppShell.tsx
+++ b/src/ui/AppShell.tsx
@@ -1666,7 +1666,9 @@ export function AppShell({
               onLogout={onLogout}
               onChangeServer={onChangeServer}
               userPrefs={userPrefs}
-              onPrefsChange={setUserPrefs}
+              onPrefsChange={(updates) =>
+                setUserPrefs((current) => ({ ...current, ...updates }))
+              }
             />
           </div>
         )}

--- a/src/ui/sidebar/UserProfilePanel.tsx
+++ b/src/ui/sidebar/UserProfilePanel.tsx
@@ -445,7 +445,10 @@ export function UserProfilePanel({
     hiddenRailTabs?: string | null;
     statusColorScheme?: string | null;
   };
-  onPrefsChange?: (prefs: { reopenTabsOnLogin: boolean }) => void;
+  onPrefsChange?: (prefs: {
+    reopenTabsOnLogin?: boolean;
+    storageMode?: "local" | "cloud";
+  }) => void;
 }) {
   const { t } = useTranslation();
   const themeLabel: Record<ThemeId, string> = {
@@ -521,6 +524,12 @@ export function UserProfilePanel({
   const [storageMode, setStorageMode] = useState<"local" | "cloud">(() =>
     userPrefs?.storageMode === "cloud" ? "cloud" : "local",
   );
+
+  useEffect(() => {
+    if (userPrefs?.storageMode) {
+      setStorageMode(userPrefs.storageMode === "cloud" ? "cloud" : "local");
+    }
+  }, [userPrefs?.storageMode]);
 
   // Settings toggles — all backed by localStorage
   const [commandAutocomplete, setCommandAutocomplete] = useState(
@@ -623,6 +632,7 @@ export function UserProfilePanel({
 
   async function handleStorageModeChange(mode: "local" | "cloud") {
     setStorageMode(mode);
+    onPrefsChange?.({ storageMode: mode });
     if (mode === "cloud") {
       // Snapshot current browser localStorage values so any tab can restore them later
       const SNAPSHOT_KEYS = [


### PR DESCRIPTION
## Summary
- sync the User Profile storage selector after server preferences load
- keep AppShell preference state updated when switching between Browser and Database
- prevent the selector from reverting to Browser after reload or panel remount

## Root cause
The storage mode state was initialized before the asynchronous user-preferences request completed and never updated when the `storageMode` prop changed. Switching modes also updated only local component state, leaving AppShell with the stale mode.

## Verification
- touched-file Prettier
- touched-file ESLint
- `npm run type-check`
- `npm run build`

Closes Termix-SSH/Support#539