### PR TITLE
fix(alerts): send channel config as object payload instead of JSON st…

### DIFF
--- a/src/ui/sidebar/NotificationChannelDialog.tsx
+++ b/src/ui/sidebar/NotificationChannelDialog.tsx
@@ -84,15 +84,15 @@ export function NotificationChannelDialog({
       toast.error(t("alerts.channelNameRequired", "Name is required"));
       return;
     }
-    let config: string;
+    let config: WebhookConfig | NtfyConfig;
     if (type === "webhook") {
       if (!webhookUrl.trim()) {
         toast.error(t("alerts.webhookUrlRequired", "Webhook URL is required"));
         return;
       }
-      config = JSON.stringify({
+      config = {
         url: webhookUrl.trim(),
-      } satisfies WebhookConfig);
+      } satisfies WebhookConfig;
     } else {
       if (!ntfyTopic.trim()) {
         toast.error(t("alerts.ntfyTopicRequired", "Topic is required"));
@@ -100,7 +100,7 @@ export function NotificationChannelDialog({
       }
       const cfg: NtfyConfig = { url: ntfyUrl.trim(), topic: ntfyTopic.trim() };
       if (ntfyToken.trim()) cfg.token = ntfyToken.trim();
-      config = JSON.stringify(cfg);
+      config = cfg;
     }
 
     setSaving(true);
@@ -154,7 +154,7 @@ export function NotificationChannelDialog({
                 <button
                   key={ct}
                   onClick={() => setType(ct)}
-                  className={`px-3 py-1 text-xs font-semibold border transition-colors ${type === ct ? "border-accent-brand/40 bg-accent-brand/10 text-accent-brand" : "border-border text-muted-foreground hover:text-foreground"}`}
+                  className={`px-3 py-1 text-xs font-semibold border transition-colors ${type === ct ? "border-accent-brand/40 bg-accent-brand/10 text-accent-brand" : "border-border text-muted-foreground hover:border-accent-brand/30"}`}
                 >
                   {ct === "webhook" ? "Webhook" : "ntfy"}
                 </button>


### PR DESCRIPTION
## Summary

Fixes the alert notification channel save flow for both **Webhook** and **ntfy** by sending `config` as an object instead of a JSON string.

The backend `/notification-channels` route expects:

```json
{
  "name": "...",
  "type": "webhook" | "ntfy",
  "config": { ... }
}
```

but the frontend dialog was sending `config` as a stringified JSON value, which caused the backend validation to reject the request with:

```json
{"error":"config is required"}
```

## Root cause

In `src/ui/sidebar/NotificationChannelDialog.tsx`, the dialog built `config` with `JSON.stringify(...)` before calling:

- `createNotificationChannel()`
- `updateNotificationChannel()`

In `src/backend/database/routes/alert-rules-routes.ts`, the backend checks that `config` is an object and returns HTTP 400 otherwise.

## Changes

- Update notification channel save logic to send `config` as a plain object
- Fix both create and update paths
- Preserve existing backend behavior, where config is stringified when persisted

## User impact

This fixes the bug where adding or editing **Webhook** and **ntfy** alert channels fails with:

```json
{"error":"config is required"}
```

## Related issue

- Fixes https://github.com/Termix-SSH/Support/issues/1008

## Testing

Recommended manual verification:

1. Go to **Alerts → Channels → Add**
2. Create a **Webhook** channel with a valid name and URL
3. Confirm the channel saves successfully
4. Create an **ntfy** channel with a valid name, server URL, and topic
5. Confirm the channel saves successfully
6. Edit both channel types and confirm updates also save successfully