### PR TITLE
fix: add Swiss German server layout

### DIFF
--- a/src/ui/sidebar/HostEditorGuacamoleTabs.tsx
+++ b/src/ui/sidebar/HostEditorGuacamoleTabs.tsx
@@ -676,6 +676,7 @@ export function HostEditorRdpTab({
               <option>en-us-qwerty</option>
               <option>en-gb-qwerty</option>
               <option>de-de-qwertz</option>
+              <option>de-ch-qwertz</option>
               <option>fr-fr-azerty</option>
               <option>it-it-qwerty</option>
               <option>sv-se-qwerty</option>
@@ -1332,6 +1333,7 @@ export function HostEditorVncTab({
               <option>en-us-qwerty</option>
               <option>en-gb-qwerty</option>
               <option>de-de-qwertz</option>
+              <option>de-ch-qwertz</option>
               <option>fr-fr-azerty</option>
               <option>it-it-qwerty</option>
               <option>sv-se-qwerty</option>


### PR DESCRIPTION
## Summary

- add the Guacamole `de-ch-qwertz` server layout to RDP host settings
- expose the same supported layout in VNC host settings for consistency

Fixes Termix-SSH/Support#1017

## Validation

- `npm run type-check`
- `npm run lint -- --quiet`
- `npm test -- --run src/ui/tests/sidebar/HostEditorData.test.ts` (15 tests passed)
- `git diff --check`