### PR TITLE
fix(net): correct SSRF blocklist false-positive blocking all outbound IPv4

### DIFF
--- a/src/backend/tests/utils/safe-outbound-fetch.test.ts
+++ b/src/backend/tests/utils/safe-outbound-fetch.test.ts
@@ -1,0 +1,44 @@
+import { describe, expect, it } from "vitest";
+import { isBlockedAddress } from "../../utils/safe-outbound-fetch.js";
+
+describe("isBlockedAddress", () => {
+  it("allows public IPv4 addresses", () => {
+    expect(isBlockedAddress("8.8.8.8")).toBe(false);
+    expect(isBlockedAddress("104.21.52.150")).toBe(false);
+  });
+
+  it("blocks private/reserved IPv4 ranges", () => {
+    expect(isBlockedAddress("10.0.0.1")).toBe(true);
+    expect(isBlockedAddress("172.16.0.1")).toBe(true);
+    expect(isBlockedAddress("192.168.1.1")).toBe(true);
+    expect(isBlockedAddress("127.0.0.1")).toBe(true);
+    expect(isBlockedAddress("169.254.1.1")).toBe(true);
+    expect(isBlockedAddress("100.64.0.1")).toBe(true);
+  });
+
+  it("allows public IPv6 addresses", () => {
+    expect(isBlockedAddress("2606:4700:3034::ac43:c88d")).toBe(false);
+    expect(isBlockedAddress("2001:4860:4860::8888")).toBe(false);
+  });
+
+  it("blocks private/reserved IPv6 ranges", () => {
+    expect(isBlockedAddress("::1")).toBe(true);
+    expect(isBlockedAddress("fc00::1")).toBe(true);
+    expect(isBlockedAddress("fe80::1")).toBe(true);
+  });
+
+  it("blocks IPv4-mapped-IPv6 spoofing of private addresses", () => {
+    expect(isBlockedAddress("::ffff:127.0.0.1")).toBe(true);
+    expect(isBlockedAddress("::ffff:192.168.1.1")).toBe(true);
+    expect(isBlockedAddress("::ffff:10.0.0.1")).toBe(true);
+  });
+
+  it("does not block IPv4-mapped-IPv6 form of public addresses", () => {
+    expect(isBlockedAddress("::ffff:104.21.52.150")).toBe(false);
+    expect(isBlockedAddress("::ffff:8.8.8.8")).toBe(false);
+  });
+
+  it("blocks unparseable input", () => {
+    expect(isBlockedAddress("not-an-ip")).toBe(true);
+  });
+});

--- a/src/backend/tests/utils/safe-outbound-fetch.test.ts
+++ b/src/backend/tests/utils/safe-outbound-fetch.test.ts
@@ -1,5 +1,9 @@
-import { describe, expect, it } from "vitest";
-import { isBlockedAddress } from "../../utils/safe-outbound-fetch.js";
+import { describe, expect, it, vi } from "vitest";
+import type { LookupAddress, LookupAllOptions } from "dns";
+import {
+  createDnsLookupHook,
+  isBlockedAddress,
+} from "../../utils/safe-outbound-fetch.js";
 
 describe("isBlockedAddress", () => {
   it("allows public IPv4 addresses", () => {
@@ -40,5 +44,62 @@ describe("isBlockedAddress", () => {
 
   it("blocks unparseable input", () => {
     expect(isBlockedAddress("not-an-ip")).toBe(true);
+  });
+});
+
+// These exercise createDnsLookupHook directly against a fake resolver,
+// bypassing fetch()/undici entirely. That's the actual code path the
+// original bug lived in — a public IPv4 address getting misclassified as
+// private — and testing it through a real Agent/fetch call would only
+// add flakiness (real TCP connects, undici's own quirks) without adding
+// coverage of the logic that actually broke.
+function runHook(
+  addresses: LookupAddress[],
+  error: NodeJS.ErrnoException | null = null,
+) {
+  const fakeLookup = (
+    _host: string,
+    _opts: LookupAllOptions,
+    cb: (err: NodeJS.ErrnoException | null, addrs: LookupAddress[]) => void,
+  ) => cb(error, addresses);
+
+  const hook = createDnsLookupHook(fakeLookup);
+  const callback = vi.fn();
+  hook("example.invalid", { all: true }, callback);
+  return callback;
+}
+
+describe("createDnsLookupHook", () => {
+  it("allows a public IPv4 address through", () => {
+    const callback = runHook([{ address: "104.21.52.150", family: 4 }]);
+    expect(callback).toHaveBeenCalledWith(null, "104.21.52.150", 4);
+  });
+
+  it("rejects a private address with the private-destination error", () => {
+    const callback = runHook([{ address: "192.168.1.1", family: 4 }]);
+    expect(callback).toHaveBeenCalledWith(
+      expect.objectContaining({ message: "Private destinations are not allowed" }),
+      "",
+      0,
+    );
+  });
+
+  it("rejects with a distinct error when DNS returns no addresses", () => {
+    const callback = runHook([]);
+    expect(callback).toHaveBeenCalledWith(
+      expect.objectContaining({
+        message: "DNS resolution returned no addresses",
+      }),
+      "",
+      0,
+    );
+  });
+
+  it("propagates a real DNS lookup error untouched", () => {
+    const dnsError = Object.assign(new Error("getaddrinfo ENOTFOUND"), {
+      code: "ENOTFOUND",
+    });
+    const callback = runHook([], dnsError);
+    expect(callback).toHaveBeenCalledWith(dnsError, "", 0);
   });
 });

--- a/src/backend/utils/safe-outbound-fetch.ts
+++ b/src/backend/utils/safe-outbound-fetch.ts
@@ -22,21 +22,27 @@ for (const [network, prefix] of [
 for (const [network, prefix] of [
   ["::", 128],
   ["::1", 128],
-  // IPv4-mapped equivalents of the blocked IPv4 ranges above, expressed
-  // individually rather than as a blanket "::ffff:0:0/96": Node's BlockList
-  // compares IPv4 addresses against their mapped-IPv6 form internally, so a
-  // full "::ffff:0:0/96" entry matches every IPv4 address, not just spoofed
-  // ones passed as literal IPv6 strings.
-  ["::ffff:0.0.0.0", 104],
-  ["::ffff:10.0.0.0", 104],
-  ["::ffff:100.64.0.0", 106],
-  ["::ffff:127.0.0.0", 104],
-  ["::ffff:169.254.0.0", 112],
-  ["::ffff:172.16.0.0", 108],
-  ["::ffff:192.168.0.0", 112],
-  ["::ffff:198.18.0.0", 111],
-  ["::ffff:224.0.0.0", 100],
-  ["::ffff:240.0.0.0", 100],
+  // These mirror the IPv4 ranges above, just written as their
+  // IPv4-mapped-IPv6 form (prefix = 96 + the IPv4 prefix), so that a
+  // spoofed literal like "::ffff:127.0.0.1" gets caught too. We list
+  // them individually instead of one "::ffff:0:0/96" catch-all because
+  // Node's BlockList matches across families through this mapped form
+  // regardless of which `type` you pass to check() — see the
+  // addAddress('123.123.123.123') / check('::ffff:123.123.123.123')
+  // example on https://nodejs.org/api/net.html#class-netblocklist for
+  // the same thing from the other direction. A blanket ::ffff:0:0/96
+  // covers the entire IPv4 space in mapped form, so it silently blocks
+  // every plain IPv4 address too, not just spoofed ones.
+  ["::ffff:0.0.0.0", 104], // 0.0.0.0/8
+  ["::ffff:10.0.0.0", 104], // 10.0.0.0/8
+  ["::ffff:100.64.0.0", 106], // 100.64.0.0/10 (CGNAT)
+  ["::ffff:127.0.0.0", 104], // 127.0.0.0/8
+  ["::ffff:169.254.0.0", 112], // 169.254.0.0/16 (link-local)
+  ["::ffff:172.16.0.0", 108], // 172.16.0.0/12
+  ["::ffff:192.168.0.0", 112], // 192.168.0.0/16
+  ["::ffff:198.18.0.0", 111], // 198.18.0.0/15 (benchmarking)
+  ["::ffff:224.0.0.0", 100], // 224.0.0.0/4 (multicast)
+  ["::ffff:240.0.0.0", 100], // 240.0.0.0/4 (reserved)
   ["fc00::", 7],
   ["fe80::", 10],
   ["ff00::", 8],
@@ -44,7 +50,7 @@ for (const [network, prefix] of [
   blockedAddresses.addSubnet(network, prefix, "ipv6");
 }
 
-function isBlockedAddress(address: string): boolean {
+export function isBlockedAddress(address: string): boolean {
   const family = isIP(address);
   return (
     family === 0 ||

--- a/src/backend/utils/safe-outbound-fetch.ts
+++ b/src/backend/utils/safe-outbound-fetch.ts
@@ -1,48 +1,51 @@
-import { lookup } from "dns";
+import { lookup, type LookupAddress, type LookupAllOptions } from "dns";
 import { BlockList, isIP } from "net";
 import { Agent } from "undici";
 
+type DnsLookupFn = (
+  hostname: string,
+  options: LookupAllOptions,
+  callback: (err: NodeJS.ErrnoException | null, addresses: LookupAddress[]) => void,
+) => void;
+
+type LookupHookCallback = (
+  error: NodeJS.ErrnoException | Error | null,
+  address: string,
+  family: number,
+) => void;
+
 const blockedAddresses = new BlockList();
 
-for (const [network, prefix] of [
+// Derived, not hand-duplicated: Node's BlockList matches addresses across
+// families through their IPv4-mapped-IPv6 form regardless of which `type`
+// you pass to check()/addSubnet() (see the addAddress('123.123.123.123') /
+// check('::ffff:123.123.123.123') example on
+// https://nodejs.org/api/net.html#class-netblocklist). So every IPv4 range
+// below needs an "::ffff:<net>" mirror in the IPv6 list, or a spoofed
+// literal like "::ffff:127.0.0.1" slips through unblocked. Generating the
+// mirror from this list instead of maintaining two lists by hand means the
+// two can't drift out of sync the way they did before.
+const blockedIpv4Ranges = [
   ["0.0.0.0", 8],
   ["10.0.0.0", 8],
-  ["100.64.0.0", 10],
+  ["100.64.0.0", 10], // CGNAT
   ["127.0.0.0", 8],
-  ["169.254.0.0", 16],
+  ["169.254.0.0", 16], // link-local
   ["172.16.0.0", 12],
   ["192.168.0.0", 16],
-  ["198.18.0.0", 15],
-  ["224.0.0.0", 4],
-  ["240.0.0.0", 4],
-] as const) {
+  ["198.18.0.0", 15], // benchmarking
+  ["224.0.0.0", 4], // multicast
+  ["240.0.0.0", 4], // reserved
+] as const;
+
+for (const [network, prefix] of blockedIpv4Ranges) {
   blockedAddresses.addSubnet(network, prefix, "ipv4");
+  blockedAddresses.addSubnet(`::ffff:${network}`, prefix + 96, "ipv6");
 }
 
 for (const [network, prefix] of [
   ["::", 128],
   ["::1", 128],
-  // These mirror the IPv4 ranges above, just written as their
-  // IPv4-mapped-IPv6 form (prefix = 96 + the IPv4 prefix), so that a
-  // spoofed literal like "::ffff:127.0.0.1" gets caught too. We list
-  // them individually instead of one "::ffff:0:0/96" catch-all because
-  // Node's BlockList matches across families through this mapped form
-  // regardless of which `type` you pass to check() — see the
-  // addAddress('123.123.123.123') / check('::ffff:123.123.123.123')
-  // example on https://nodejs.org/api/net.html#class-netblocklist for
-  // the same thing from the other direction. A blanket ::ffff:0:0/96
-  // covers the entire IPv4 space in mapped form, so it silently blocks
-  // every plain IPv4 address too, not just spoofed ones.
-  ["::ffff:0.0.0.0", 104], // 0.0.0.0/8
-  ["::ffff:10.0.0.0", 104], // 10.0.0.0/8
-  ["::ffff:100.64.0.0", 106], // 100.64.0.0/10 (CGNAT)
-  ["::ffff:127.0.0.0", 104], // 127.0.0.0/8
-  ["::ffff:169.254.0.0", 112], // 169.254.0.0/16 (link-local)
-  ["::ffff:172.16.0.0", 108], // 172.16.0.0/12
-  ["::ffff:192.168.0.0", 112], // 192.168.0.0/16
-  ["::ffff:198.18.0.0", 111], // 198.18.0.0/15 (benchmarking)
-  ["::ffff:224.0.0.0", 100], // 224.0.0.0/4 (multicast)
-  ["::ffff:240.0.0.0", 100], // 240.0.0.0/4 (reserved)
   ["fc00::", 7],
   ["fe80::", 10],
   ["ff00::", 8],
@@ -56,6 +59,42 @@ export function isBlockedAddress(address: string): boolean {
     family === 0 ||
     blockedAddresses.check(address, family === 4 ? "ipv4" : "ipv6")
   );
+}
+
+// Extracted so the blocklist decision can be tested directly against a
+// fake DNS resolver, instead of only through a real fetch()/Agent call —
+// the actual bug here lived entirely in this callback, several layers
+// below where undici's own "fetch failed" wrapping would otherwise hide it.
+export function createDnsLookupHook(dnsLookup: DnsLookupFn = lookup) {
+  return function lookupHook(
+    host: string,
+    lookupOptions: LookupAllOptions,
+    callback: LookupHookCallback,
+  ): void {
+    dnsLookup(
+      host,
+      { ...lookupOptions, all: true, verbatim: true },
+      (error, addresses) => {
+        if (error) return callback(error, "", 0);
+        if (!addresses.length) {
+          return callback(
+            new Error("DNS resolution returned no addresses"),
+            "",
+            0,
+          );
+        }
+        if (addresses.some(({ address }) => isBlockedAddress(address))) {
+          return callback(
+            new Error("Private destinations are not allowed"),
+            "",
+            0,
+          );
+        }
+        const selected = addresses[0];
+        callback(null, selected.address, selected.family);
+      },
+    );
+  };
 }
 
 export async function safeOutboundFetch(
@@ -78,27 +117,7 @@ export async function safeOutboundFetch(
 
   const dispatcher = new Agent({
     connect: {
-      lookup(host, lookupOptions, callback) {
-        lookup(
-          host,
-          { ...lookupOptions, all: true, verbatim: true },
-          (error, addresses) => {
-            if (error) return callback(error, "", 0);
-            if (
-              !addresses.length ||
-              addresses.some(({ address }) => isBlockedAddress(address))
-            ) {
-              return callback(
-                new Error("Private destinations are not allowed"),
-                "",
-                0,
-              );
-            }
-            const selected = addresses[0];
-            callback(null, selected.address, selected.family);
-          },
-        );
-      },
+      lookup: createDnsLookupHook(),
     },
   });
 

--- a/src/backend/utils/safe-outbound-fetch.ts
+++ b/src/backend/utils/safe-outbound-fetch.ts
@@ -22,7 +22,21 @@ for (const [network, prefix] of [
 for (const [network, prefix] of [
   ["::", 128],
   ["::1", 128],
-  ["::ffff:0:0", 96],
+  // IPv4-mapped equivalents of the blocked IPv4 ranges above, expressed
+  // individually rather than as a blanket "::ffff:0:0/96": Node's BlockList
+  // compares IPv4 addresses against their mapped-IPv6 form internally, so a
+  // full "::ffff:0:0/96" entry matches every IPv4 address, not just spoofed
+  // ones passed as literal IPv6 strings.
+  ["::ffff:0.0.0.0", 104],
+  ["::ffff:10.0.0.0", 104],
+  ["::ffff:100.64.0.0", 106],
+  ["::ffff:127.0.0.0", 104],
+  ["::ffff:169.254.0.0", 112],
+  ["::ffff:172.16.0.0", 108],
+  ["::ffff:192.168.0.0", 112],
+  ["::ffff:198.18.0.0", 111],
+  ["::ffff:224.0.0.0", 100],
+  ["::ffff:240.0.0.0", 100],
   ["fc00::", 7],
   ["fe80::", 10],
   ["ff00::", 8],


### PR DESCRIPTION
Fixes [#1024](https://github.com/Termix-SSH/Support/issues/1024)

## Summary

`safeOutboundFetch` was rejecting every outbound IPv4 destination as private, not just the ones that actually are. I hit this through ntfy notification delivery, but it affects anything that goes through `safeOutboundFetch`.

## Root cause

The IPv6 half of the SSRF blocklist has one entry, `["::ffff:0:0", 96]`, meant to catch someone spoofing a private address as an IPv6 literal (a URL containing `::ffff:127.0.0.1`, say, trying to sneak past the plain-IPv4 checks). Node's `BlockList` doesn't respect the family boundary the way you'd expect: it compares addresses through their IPv4-mapped-IPv6 form no matter what `type` you pass to `check()`. That's documented, just easy to miss ([BlockList docs](https://nodejs.org/api/net.html#class-netblocklist) show the mirror case, an IPv4 rule catching an IPv6-literal check). `::ffff:0:0/96` is the entire IPv4 address space once mapped, so that one entry was blocking every IPv4 address, including ones checked with `type: "ipv4"` directly.

I found this by patching a running container to log the raw addresses being checked. The failure itself, `"Private destinations are not allowed"` on a plain public Cloudflare IP, gave no hint the bug was in the blocklist rather than DNS, SSRF logic, or the request itself.

## Changes

- Replaced the blanket `::ffff:0:0/96` with individual mapped ranges, one per existing IPv4 CIDR, generated from the same list the IPv4 rules come from. The two lists can't drift apart again the way they did here.
- The lookup hook threw the same `"Private destinations are not allowed"` for two different situations: DNS returning zero addresses, and DNS returning an address that's actually private. Only one of those is a privacy decision. Split into separate error messages.
- Pulled the `connect.lookup` hook out into its own function (`createDnsLookupHook`) so it can be tested against a fake resolver directly, instead of only through a real `fetch()`/`Agent` call.

## User impact

Any notification channel or webhook that resolves to a plain IPv4 address should now go through, instead of failing with a "private destination" error that has nothing to do with the actual destination.

## Testing

Added `src/backend/tests/utils/safe-outbound-fetch.test.ts`:

- `isBlockedAddress`: public/private IPv4, public/private IPv6, IPv4-mapped spoofing of private ranges, IPv4-mapped form of public addresses
- `createDnsLookupHook`: allows a public address through, blocks a private one, distinct error on empty DNS result, real DNS errors pass through untouched
- 11/11 passing, `tsc --noEmit` clean

## Notes

Scoped to the blocklist bug only. While chasing the original notification failure I also found the `connect.lookup` hook doesn't handle `lookupOptions.all`: Node's happy-eyeballs (`autoSelectFamily`) expects the full address array back, not a single address, and this hook always returns a single address. That's a separate bug in the same file. I'll send it as its own PR instead of bundling it here.