### PR TITLE
fix(ssh): do not offer chacha20-poly1305 without the native ssh2 binding

### DIFF
--- a/src/backend/utils/ssh-algorithms.ts
+++ b/src/backend/utils/ssh-algorithms.ts
@@ -31,13 +31,13 @@ try {
   nativeRequire("ssh2/lib/protocol/crypto/build/Release/sshcrypto.node");
   ssh2BindingAvailable = true;
 } catch {
-  try {
-    // ESM fallback: check if chacha20 works via OpenSSL createCipheriv
-    crypto.createCipheriv("chacha20", Buffer.alloc(32), Buffer.alloc(16));
-    ssh2BindingAvailable = true;
-  } catch {
-    ssh2BindingAvailable = false;
-  }
+  // The pure-JS fallback in ssh2 for chacha20-poly1305@openssh.com is broken and
+  // corrupts the transport: the target sshd aborts the KEX with
+  // "ssh_dispatch_run_fatal: ... incomplete message [preauth]" and the client times out.
+  // A working OpenSSL "chacha20" cipher is NOT sufficient here — only the native
+  // binding (sshcrypto.node) makes chacha20-poly1305 usable. Keep it disabled otherwise
+  // so filterCiphers() drops it and the connection negotiates AES-GCM instead.
+  ssh2BindingAvailable = false;
 }
 
 function filterCiphers(list: CipherAlgorithm[]): CipherAlgorithm[] {


### PR DESCRIPTION
### What
Do not advertise `chacha20-poly1305@openssh.com` when the native ssh2 crypto binding (`sshcrypto.node`) is unavailable.

### Why
`ssh-algorithms.ts` treated a working OpenSSL raw-`chacha20` cipher as proof that ssh2's `chacha20-poly1305@openssh.com` is usable. It is not — ssh2's pure-JS ChaChaPoly implementation corrupts the transport. The peer then aborts the handshake in pre-auth:
```
ssh_dispatch_run_fatal: Connection from <ip> port <p>: incomplete message [preauth]
```
and the client runs into a connection timeout. This is easy to trigger on jump-host connections whose target sshd negotiates `chacha20-poly1305` first (plain OpenSSH over the same path is unaffected).

### Change
The ESM fallback that set `ssh2BindingAvailable = true` based solely on `crypto.createCipheriv("chacha20", ...)` is removed. When the native binding is missing, `ssh2BindingAvailable` stays `false`, so `filterCiphers()` drops `chacha20-poly1305@openssh.com` and the connection negotiates AES-GCM/CTR instead.

### Testing
Repro: Termix v2.5.1, bare Node (no `sshcrypto.node`), ssh2 1.17.0, connecting through a jump host to a target whose sshd offers `chacha20-poly1305` first.
- Before: target sshd logs `incomplete message [preauth]`; client times out.
- After: target sshd logs `Accepted publickey`; terminal opens normally.

Fixes #1080
