### PR TITLE
Fix export user record handling and 500 error

### DIFF
--- a/src/backend/database/database.ts
+++ b/src/backend/database/database.ts
@@ -711,7 +711,7 @@ app.post("/database/export", authenticateJWT, async (req, res) => {
     }
 
     const timestamp = new Date().toISOString().replace(/[:.]/g, "-");
-    const filename = `termix-export-${user[0].username}-${timestamp}.sqlite`;
+    const filename = `termix-export-${user.username}-${timestamp}.sqlite`;
     const tempPath = path.join(tempDir, filename);
 
     apiLogger.info("Creating export database", {
@@ -880,7 +880,7 @@ app.post("/database/export", authenticateJWT, async (req, res) => {
         );
       `);
 
-      const userRecord = user[0];
+      const userRecord = user;
       const insertUser = exportDb.prepare(`
         INSERT INTO users (id, username, password_hash, is_admin, is_oidc, oidc_identifier, client_id, client_secret, issuer_url, authorization_url, token_url, identifier_path, name_path, scopes, totp_secret, totp_enabled, totp_backup_codes)
         VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)

--- a/src/ui/features/tmux-monitor/PanePreview.tsx
+++ b/src/ui/features/tmux-monitor/PanePreview.tsx
@@ -70,6 +70,15 @@ export function PanePreview({
     setAttachNonce((n) => n + 1);
   }
 
+  const resolvedPort = host.sshPort ?? host.port;
+  const terminalHostConfig = {
+    ...host,
+    port: resolvedPort,
+    sshPort: resolvedPort,
+    authType: host.authType,
+    instanceId: instanceIdRef.current,
+  } as TerminalHostConfig;
+
   return (
     <>
       <div className="flex items-center gap-3 border-b border-border px-3 py-1.5 text-xs text-muted-foreground">
@@ -147,13 +156,7 @@ export function PanePreview({
         <CommandHistoryProvider key={attachNonce}>
           <Terminal
             ref={terminalRef}
-            hostConfig={
-              {
-                ...host,
-                sshPort: host.port,
-                instanceId: instanceIdRef.current,
-              } as TerminalHostConfig
-            }
+            hostConfig={terminalHostConfig}
             isVisible={true}
             title={pane.sessionName}
             showTitle={false}

--- a/src/ui/features/tmux-monitor/PanePreview.tsx
+++ b/src/ui/features/tmux-monitor/PanePreview.tsx
@@ -70,14 +70,20 @@ export function PanePreview({
     setAttachNonce((n) => n + 1);
   }
 
-  const resolvedPort = host.sshPort ?? host.port;
-  const terminalHostConfig = {
-    ...host,
-    port: resolvedPort,
-    sshPort: resolvedPort,
-    authType: host.authType,
-    instanceId: instanceIdRef.current,
-  } as TerminalHostConfig;
+  const terminalHostConfig =
+    host.authType === "tailscale"
+      ? ({
+          ...host,
+          authType: "tailscale",
+          instanceId: instanceIdRef.current,
+        } as TerminalHostConfig)
+      : ({
+          ...host,
+          port: host.sshPort ?? host.port,
+          sshPort: host.sshPort ?? host.port,
+          authType: host.authType,
+          instanceId: instanceIdRef.current,
+        } as TerminalHostConfig);
 
   return (
     <>


### PR DESCRIPTION
This pull request makes small fixes to the user object handling in the `/database/export` API endpoint. The changes ensure that the code consistently uses the `user` object directly rather than treating it as an array.

* Fixed a bug where `user[0]` was incorrectly used instead of `user` for the username in the export filename, preventing potential runtime errors.
* Updated the assignment of `userRecord` to use the `user` object directly, ensuring correct insertion of user data into the export database.# Overview

Fixes: https://github.com/Termix-SSH/Support/issues/1020
