### PR TITLE
fix: centralize outbound address validation

### DIFF
--- a/src/backend/database/routes/homepage-proxy-routes.ts
+++ b/src/backend/database/routes/homepage-proxy-routes.ts
@@ -3,8 +3,9 @@ import express from "express";
 import https from "https";
 import http from "http";
 import { lookup } from "dns/promises";
-import { BlockList, isIP } from "net";
+import { isIP } from "net";
 import { homepageLogger } from "../../utils/logger.js";
+import { isBlockedAddress } from "../../utils/safe-outbound-fetch.js";
 
 export const homepageProxyRouter = express.Router();
 
@@ -16,40 +17,6 @@ interface ProxyCacheEntry {
 const proxyCache = new Map<string, ProxyCacheEntry>();
 const CACHE_SIZE = 50;
 const FETCH_TIMEOUT_MS = 8000;
-
-const blockedAddresses = new BlockList();
-for (const [network, prefix] of [
-  ["0.0.0.0", 8],
-  ["10.0.0.0", 8],
-  ["100.64.0.0", 10],
-  ["127.0.0.0", 8],
-  ["169.254.0.0", 16],
-  ["172.16.0.0", 12],
-  ["192.168.0.0", 16],
-  ["198.18.0.0", 15],
-  ["224.0.0.0", 4],
-  ["240.0.0.0", 4],
-] as const) {
-  blockedAddresses.addSubnet(network, prefix, "ipv4");
-}
-for (const [network, prefix] of [
-  ["::", 128],
-  ["::1", 128],
-  ["::ffff:0:0", 96],
-  ["fc00::", 7],
-  ["fe80::", 10],
-  ["ff00::", 8],
-] as const) {
-  blockedAddresses.addSubnet(network, prefix, "ipv6");
-}
-
-function isBlockedAddress(address: string): boolean {
-  const family = isIP(address);
-  return (
-    family === 0 ||
-    blockedAddresses.check(address, family === 4 ? "ipv4" : "ipv6")
-  );
-}
 
 async function resolvePublicUrl(rawUrl: string): Promise<{
   url: URL;

--- a/src/backend/utils/proxy-helper.ts
+++ b/src/backend/utils/proxy-helper.ts
@@ -3,22 +3,8 @@ import type { SocksClientOptions } from "socks";
 import net from "net";
 import dns from "dns/promises";
 import { sshLogger } from "./logger.js";
+import { isBlockedAddress } from "./safe-outbound-fetch.js";
 import type { ProxyNode } from "../../types/index.js";
-
-function isBlockedAddress(ip: string): boolean {
-  if (ip === "0.0.0.0" || ip === "::1" || ip === "::") return true;
-
-  const parts = ip.split(".").map(Number);
-  if (parts.length !== 4) return false;
-
-  if (parts[0] === 127) return true;
-  if (parts[0] === 10) return true;
-  if (parts[0] === 172 && parts[1] >= 16 && parts[1] <= 31) return true;
-  if (parts[0] === 192 && parts[1] === 168) return true;
-  if (parts[0] === 169 && parts[1] === 254) return true;
-
-  return false;
-}
 
 async function validateHost(host: string): Promise<void> {
   if (net.isIP(host)) {


### PR DESCRIPTION
## Summary
- remove the duplicate homepage proxy SSRF blocklist that rejected all IPv4 targets
- replace the incomplete SOCKS proxy address checks with the shared validated implementation
- keep private, reserved, IPv6, and IPv4-mapped IPv6 coverage in one place

## Validation
- `npm test -- --run src/backend/tests/utils/safe-outbound-fetch.test.ts`
- `npm run type-check`
- `npm run lint` (0 errors; existing warnings only)
- `npm run build`
- `git diff --check`

Closes Termix-SSH/Support#1029