### PR TITLE
fix: preserve architecture in unpacked ASAR path

### DIFF
--- a/electron/backend-paths.cjs
+++ b/electron/backend-paths.cjs
@@ -1,0 +1,8 @@
+function getUnpackedAppRoot(appRoot) {
+  return appRoot.replace(
+    /app(-[a-z0-9]+)?\.asar(?!\.unpacked)/,
+    "app$1.asar.unpacked",
+  );
+}
+
+module.exports = { getUnpackedAppRoot };

--- a/electron/main.cjs
+++ b/electron/main.cjs
@@ -12,6 +12,7 @@ const {
   nativeImage,
 } = require("electron");
 const path = require("path");
+const { getUnpackedAppRoot } = require("./backend-paths.cjs");
 const fs = require("fs");
 const os = require("os");
 const https = require("https");
@@ -800,10 +801,7 @@ function getBackendPaths() {
   // fork() does not go through Electron's asar redirector — use the unpacked path.
   // On macOS multi-arch builds (mergeASARs: false), electron-builder names the ASAR
   // app-arm64.asar / app-x64.asar instead of app.asar, so match all variants.
-  const unpackedRoot = appRoot.replace(
-    /app(-[a-z0-9]+)?\.asar(?!\.unpacked)/,
-    "app.asar.unpacked",
-  );
+  const unpackedRoot = getUnpackedAppRoot(appRoot);
   const backendDir = path.join(unpackedRoot, "dist", "backend", "backend");
   return {
     entryPath: path.join(backendDir, "starter.js"),

--- a/src/backend/tests/electron/backend-paths.test.ts
+++ b/src/backend/tests/electron/backend-paths.test.ts
@@ -1,0 +1,33 @@
+import { createRequire } from "node:module";
+import { describe, expect, it } from "vitest";
+
+const require = createRequire(import.meta.url);
+const { getUnpackedAppRoot } =
+  require("../../../../electron/backend-paths.cjs") as {
+    getUnpackedAppRoot: (appRoot: string) => string;
+  };
+
+describe("getUnpackedAppRoot", () => {
+  it.each([
+    [
+      "/Applications/Termix.app/Contents/Resources/app.asar",
+      "/Applications/Termix.app/Contents/Resources/app.asar.unpacked",
+    ],
+    [
+      "/Applications/Termix.app/Contents/Resources/app-arm64.asar",
+      "/Applications/Termix.app/Contents/Resources/app-arm64.asar.unpacked",
+    ],
+    [
+      "/Applications/Termix.app/Contents/Resources/app-x64.asar",
+      "/Applications/Termix.app/Contents/Resources/app-x64.asar.unpacked",
+    ],
+  ])("maps %s to its matching unpacked directory", (appRoot, expected) => {
+    expect(getUnpackedAppRoot(appRoot)).toBe(expected);
+  });
+
+  it("does not append the suffix twice", () => {
+    const appRoot =
+      "/Applications/Termix.app/Contents/Resources/app-arm64.asar.unpacked";
+    expect(getUnpackedAppRoot(appRoot)).toBe(appRoot);
+  });
+});


### PR DESCRIPTION
## Summary
- preserve the architecture suffix when resolving universal macOS ASAR paths
- keep single-architecture and already-unpacked paths unchanged
- add regression coverage for standard, arm64, and x64 layouts

## Validation
- `npm test -- --run src/backend/tests/electron/backend-paths.test.ts`
- `npm run type-check`
- `npm run lint` (0 errors; existing warnings only)
- `npm run build`
- `git diff --check`

Closes Termix-SSH/Support#1036