### PR TITLE
fix: allow sharing empty folders

### DIFF
--- a/src/backend/database/routes/rbac.ts
+++ b/src/backend/database/routes/rbac.ts
@@ -352,8 +352,6 @@ router.post(
  *         description: Folder shared successfully.
  *       400:
  *         description: Invalid request body.
- *       404:
- *         description: Folder has no hosts.
  *       500:
  *         description: Failed to share folder.
  */
@@ -415,9 +413,6 @@ router.post(
           userId,
           folder,
         );
-      if (hostsInFolder.length === 0) {
-        return res.status(404).json({ error: "Folder has no hosts" });
-      }
 
       const expiresAt = expiryFromDuration(durationHours);
       const rbacAccessRepository = createCurrentRbacAccessRepository();


### PR DESCRIPTION
## Summary
- treat folder sharing as a successful no-op when the folder contains no hosts
- return the existing `0/0` share summary instead of an HTTP 404
- remove the obsolete empty-folder 404 from the OpenAPI response documentation

## Validation
- `npm run type-check`
- `npx eslint src/backend/database/routes/rbac.ts`
- `npm run lint` (0 errors; existing warnings only)
- `npm run build`
- `git diff --check`

Closes Termix-SSH/Support#1032