### PR TITLE
fix: preserve WoL broadcast address

### DIFF
--- a/src/ui/sidebar/HostManagerData.ts
+++ b/src/ui/sidebar/HostManagerData.ts
@@ -63,6 +63,7 @@ export function sshHostToHost(h: SSHHostWithStatus): Host {
     notes: h.notes,
     pin: h.pin ?? false,
     macAddress: h.macAddress,
+    wolBroadcastAddress: h.wolBroadcastAddress,
     enableSsh: h.enableSsh != null ? h.enableSsh : isSshHost,
     enableTerminal:
       h.enableTerminal ?? (h.enableSsh != null ? h.enableSsh : isSshHost),

--- a/src/ui/tests/sidebar/HostManagerData.test.ts
+++ b/src/ui/tests/sidebar/HostManagerData.test.ts
@@ -1,0 +1,18 @@
+import { describe, expect, it } from "vitest";
+import type { SSHHostWithStatus } from "@/main-axios";
+import { sshHostToHost } from "@/sidebar/HostManagerData";
+
+describe("sshHostToHost", () => {
+  it("preserves the Wake-on-LAN broadcast address for editing", () => {
+    const host = sshHostToHost({
+      id: 1,
+      name: "server",
+      ip: "192.168.0.10",
+      port: 22,
+      username: "root",
+      wolBroadcastAddress: "192.168.0.255",
+    } as SSHHostWithStatus);
+
+    expect(host.wolBroadcastAddress).toBe("192.168.0.255");
+  });
+});


### PR DESCRIPTION
## Summary
- preserve `wolBroadcastAddress` when mapping backend hosts into the host editor model
- add a regression test proving the saved directed broadcast address survives the mapping round trip

## Validation
- `npm test -- --run src/ui/tests/sidebar/HostManagerData.test.ts`
- `npm run type-check`
- `npx eslint src/ui/sidebar/HostManagerData.ts src/ui/tests/sidebar/HostManagerData.test.ts`
- `npm run lint` (0 errors; existing warnings only)
- `npm run build`
- `git diff --check`

Closes Termix-SSH/Support#1022