### PR TITLE
fix: recognize Windows terminal Tab events

### DIFF
--- a/src/ui/features/terminal/Terminal.tsx
+++ b/src/ui/features/terminal/Terminal.tsx
@@ -65,6 +65,7 @@ import {
   getNextTerminalFontSize,
   getTerminalFontZoomDirection,
 } from "./terminal-font-zoom.ts";
+import { isTabKeyEvent } from "./terminal-key-event.ts";
 import {
   getUserPreferences,
   parseCustomKeybindings,
@@ -2328,7 +2329,7 @@ const TerminalInner = forwardRef<TerminalHandle, SSHTerminalProps>(
       // the capture phase blocks that traversal while still allowing the event to
       // reach xterm.js's internal handler (which fires our attachCustomKeyEventHandler).
       const handleTabCapture = (e: KeyboardEvent) => {
-        if (e.key === "Tab") {
+        if (isTabKeyEvent(e)) {
           e.preventDefault();
         }
       };
@@ -2678,7 +2679,7 @@ const TerminalInner = forwardRef<TerminalHandle, SSHTerminalProps>(
           }
 
           if (
-            e.key === "Tab" &&
+            isTabKeyEvent(e) &&
             !e.ctrlKey &&
             !e.altKey &&
             !e.metaKey &&
@@ -2701,7 +2702,7 @@ const TerminalInner = forwardRef<TerminalHandle, SSHTerminalProps>(
         }
 
         if (
-          e.key === "Tab" &&
+          isTabKeyEvent(e) &&
           e.shiftKey &&
           !e.ctrlKey &&
           !e.altKey &&
@@ -2718,7 +2719,7 @@ const TerminalInner = forwardRef<TerminalHandle, SSHTerminalProps>(
         }
 
         if (
-          e.key === "Tab" &&
+          isTabKeyEvent(e) &&
           !e.ctrlKey &&
           !e.altKey &&
           !e.metaKey &&

--- a/src/ui/features/terminal/terminal-key-event.ts
+++ b/src/ui/features/terminal/terminal-key-event.ts
@@ -1,0 +1,3 @@
+export function isTabKeyEvent(event: KeyboardEvent): boolean {
+  return event.key === "Tab" || event.code === "Tab" || event.keyCode === 9;
+}

--- a/src/ui/tests/features/terminal/terminal-key-event.test.ts
+++ b/src/ui/tests/features/terminal/terminal-key-event.test.ts
@@ -1,0 +1,21 @@
+import { describe, expect, it } from "vitest";
+import { isTabKeyEvent } from "@/features/terminal/terminal-key-event";
+
+describe("isTabKeyEvent", () => {
+  it.each([
+    ["key", new KeyboardEvent("keydown", { key: "Tab" })],
+    ["code", new KeyboardEvent("keydown", { code: "Tab" })],
+    [
+      "legacy keyCode",
+      new KeyboardEvent("keydown", { keyCode: 9 } as KeyboardEventInit),
+    ],
+  ])("recognizes Tab from %s", (_source, event) => {
+    expect(isTabKeyEvent(event)).toBe(true);
+  });
+
+  it("does not treat another key as Tab", () => {
+    expect(
+      isTabKeyEvent(new KeyboardEvent("keydown", { key: "Enter" })),
+    ).toBe(false);
+  });
+});

--- a/src/ui/tests/features/terminal/terminal-key-event.test.ts
+++ b/src/ui/tests/features/terminal/terminal-key-event.test.ts
@@ -14,8 +14,8 @@ describe("isTabKeyEvent", () => {
   });
 
   it("does not treat another key as Tab", () => {
-    expect(
-      isTabKeyEvent(new KeyboardEvent("keydown", { key: "Enter" })),
-    ).toBe(false);
+    expect(isTabKeyEvent(new KeyboardEvent("keydown", { key: "Enter" }))).toBe(
+      false,
+    );
   });
 });


### PR DESCRIPTION
## Summary
- recognize terminal Tab input from `key`, `code`, or the Windows Electron legacy key code
- apply the shared detection to capture, autocomplete, Tab, and Shift+Tab paths
- add regression coverage for all supported event shapes

## Validation
- `npm test -- --run src/ui/tests/features/terminal/terminal-key-event.test.ts` (4 tests)
- `npm run type-check`
- `npx eslint src/ui/features/terminal/Terminal.tsx src/ui/features/terminal/terminal-key-event.ts src/ui/tests/features/terminal/terminal-key-event.test.ts`
- `npm run build`

Closes Termix-SSH/Support#1014