### PR TITLE
fix: export repository user record

### DIFF
--- a/src/backend/database/database.ts
+++ b/src/backend/database/database.ts
@@ -713,7 +713,7 @@ app.post("/database/export", authenticateJWT, async (req, res) => {
     }
 
     const timestamp = new Date().toISOString().replace(/[:.]/g, "-");
-    const filename = `termix-export-${user[0].username}-${timestamp}.sqlite`;
+    const filename = `termix-export-${user.username}-${timestamp}.sqlite`;
     const tempPath = path.join(tempDir, filename);
 
     apiLogger.info("Creating export database", {
@@ -882,7 +882,7 @@ app.post("/database/export", authenticateJWT, async (req, res) => {
         );
       `);
 
-      const userRecord = user[0];
+      const userRecord = user;
       const insertUser = exportDb.prepare(`
         INSERT INTO users (id, username, password_hash, is_admin, is_oidc, oidc_identifier, client_id, client_secret, issuer_url, authorization_url, token_url, identifier_path, name_path, scopes, totp_secret, totp_enabled, totp_backup_codes)
         VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)


### PR DESCRIPTION
## Summary
- use the user object returned by the current repository when building the export filename
- insert that same record into the exported SQLite database instead of indexing it as a legacy query array

## Validation
- `npm test -- --run src/backend/tests/database/repositories/user-data-export-repository.test.ts`
- `npm run type-check`
- `npx eslint src/backend/database/database.ts`
- `npx prettier --check src/backend/database/database.ts`
- `npm run build:backend`

Closes Termix-SSH/Support#1020