### PR TITLE
Fix localhost database export routing

### DIFF
--- a/src/ui/lib/database-transfer-url.ts
+++ b/src/ui/lib/database-transfer-url.ts
@@ -20,10 +20,7 @@ export function getDatabaseTransferUrl(
     return `${serverUrl.replace(/\/$/, "")}/database/${operation}`;
   }
 
-  const development =
-    location.port === "5173" ||
-    location.hostname === "localhost" ||
-    location.hostname === "127.0.0.1";
+  const development = location.port === "5173";
 
   if (development) {
     return `http://localhost:30001/database/${operation}`;

--- a/src/ui/tests/lib/database-transfer-url.test.ts
+++ b/src/ui/tests/lib/database-transfer-url.test.ts
@@ -51,4 +51,21 @@ describe("getDatabaseTransferUrl", () => {
       }),
     ).toBe("http://localhost:30001/database/export");
   });
+
+  it.each(["localhost", "127.0.0.1"])(
+    "keeps Docker access through %s on the browser origin",
+    (hostname) => {
+      expect(
+        getDatabaseTransferUrl("export", {
+          electron: false,
+          location: {
+            protocol: "http:",
+            host: `${hostname}:8080`,
+            hostname,
+            port: "8080",
+          },
+        }),
+      ).toBe(`http://${hostname}:8080/database/export`);
+    },
+  );
 });


### PR DESCRIPTION
## Summary
- keep database import/export requests on the browser origin for Docker deployments opened via localhost or 127.0.0.1
- reserve the localhost:30001 backend route for the Vite development server on port 5173
- add regression coverage for both localhost addresses on port 8080

## Validation
- npm exec vitest run src/ui/tests/lib/database-transfer-url.test.ts
- npm run type-check
- npm exec eslint src/ui/lib/database-transfer-url.ts src/ui/tests/lib/database-transfer-url.test.ts
- npm exec prettier -- --check src/ui/lib/database-transfer-url.ts src/ui/tests/lib/database-transfer-url.test.ts
- npm run build

Closes Termix-SSH/Support#1002