### PR TITLE
Fix Tailscale authentication in tmux monitor

### DIFF
--- a/src/backend/hosts/tmux/auth-utils.ts
+++ b/src/backend/hosts/tmux/auth-utils.ts
@@ -1,0 +1,11 @@
+import type { SSHHost } from "../../../types/index.js";
+
+export function getTmuxAuthBehavior(authType: SSHHost["authType"]): {
+  credentialless: boolean;
+  tryKeyboard: boolean;
+} {
+  return {
+    credentialless: authType === "none" || authType === "tailscale",
+    tryKeyboard: authType !== "tailscale",
+  };
+}

--- a/src/backend/hosts/tmux/index.ts
+++ b/src/backend/hosts/tmux/index.ts
@@ -40,6 +40,7 @@ import {
   type PaneMetrics,
 } from "./monitor-helpers.js";
 import type { SSHHost, AuthenticatedRequest } from "../../../types/index.js";
+import { getTmuxAuthBehavior } from "./auth-utils.js";
 
 const PANE_ID_RE = /^%\d+$/;
 // tmux session names cannot contain ":" or "."; keep to a conservative
@@ -59,11 +60,12 @@ interface TmuxSessionOverview extends TmuxSessionSummary {
 // and docker; jump hosts and SOCKS5 reuse the shared helpers)
 
 async function buildSshConfig(host: SSHHost): Promise<ConnectConfig> {
+  const authBehavior = getTmuxAuthBehavior(host.authType);
   const base: ConnectConfig = {
     host: (host.ip || "").replace(/^\[|\]$/g, ""),
     port: host.port,
     username: host.username,
-    tryKeyboard: true,
+    tryKeyboard: authBehavior.tryKeyboard,
     keepaliveInterval: 30000,
     keepaliveCountMax: 3,
     readyTimeout: 60000,
@@ -94,7 +96,7 @@ async function buildSshConfig(host: SSHHost): Promise<ConnectConfig> {
     if (host.keyPassword) {
       (base as Record<string, unknown>).passphrase = host.keyPassword;
     }
-  } else if (host.authType === "none") {
+  } else if (authBehavior.credentialless) {
     // no credentials needed
   } else if (host.authType === "vault") {
     // cert auth setup happens in connectToHost (needs client instance)

--- a/src/backend/tests/hosts/tmux/auth-utils.test.ts
+++ b/src/backend/tests/hosts/tmux/auth-utils.test.ts
@@ -1,0 +1,25 @@
+import { describe, expect, it } from "vitest";
+import { getTmuxAuthBehavior } from "../../../hosts/tmux/auth-utils.js";
+
+describe("getTmuxAuthBehavior", () => {
+  it("uses credentialless non-interactive authentication for Tailscale SSH", () => {
+    expect(getTmuxAuthBehavior("tailscale")).toEqual({
+      credentialless: true,
+      tryKeyboard: false,
+    });
+  });
+
+  it("preserves keyboard-interactive fallback for none authentication", () => {
+    expect(getTmuxAuthBehavior("none")).toEqual({
+      credentialless: true,
+      tryKeyboard: true,
+    });
+  });
+
+  it("does not treat password authentication as credentialless", () => {
+    expect(getTmuxAuthBehavior("password")).toEqual({
+      credentialless: false,
+      tryKeyboard: true,
+    });
+  });
+});


### PR DESCRIPTION
## Summary
- support Tailscale SSH as a credentialless authentication mode in the tmux monitor backend
- disable keyboard-interactive negotiation for Tailscale connections, matching the terminal connection path
- add regression coverage for Tailscale, none, and password authentication behavior

## Root cause
The earlier pane-preview change preserved `authType: tailscale` in the frontend, but the tmux monitor backend still rejected that auth type as unsupported. As a result, monitor operations opened through the backend could not establish their Tailscale SSH connection.

## Validation
- npm exec vitest run src/backend/tests/hosts/tmux/auth-utils.test.ts
- npm run type-check
- npm exec eslint src/backend/hosts/tmux/auth-utils.ts src/backend/hosts/tmux/index.ts src/backend/tests/hosts/tmux/auth-utils.test.ts
- npm exec prettier -- --check src/backend/hosts/tmux/auth-utils.ts src/backend/hosts/tmux/index.ts src/backend/tests/hosts/tmux/auth-utils.test.ts
- npm run build

Closes Termix-SSH/Support#1019