### PR TITLE
Fix Android hardware keyboard special keys

### DIFF
--- a/src/ui/features/terminal/Terminal.tsx
+++ b/src/ui/features/terminal/Terminal.tsx
@@ -47,6 +47,7 @@ import { globalShortcutHandler } from "@/lib/global-shortcut-handler";
 import { useCommandTracker } from "@/features/terminal/command-history/useCommandTracker.ts";
 import { highlightTerminalOutput } from "@/lib/terminal-syntax-highlighter.ts";
 import { useCommandHistory } from "@/features/terminal/command-history/CommandHistoryContext.tsx";
+import { getAndroidHardwareKeySequence } from "@/features/terminal/android-hardware-keyboard.ts";
 import { CommandAutocomplete } from "./command-history/CommandAutocomplete.tsx";
 import { SimpleLoader } from "@/lib/SimpleLoader.tsx";
 import { useConfirmation } from "@/hooks/use-confirmation.ts";
@@ -2474,6 +2475,24 @@ const TerminalInner = forwardRef<TerminalHandle, SSHTerminalProps>(
               readTextFromClipboard,
               getSnippetById,
             });
+            return false;
+          }
+        }
+
+        if (navigator.userAgent.includes("Android")) {
+          const sequence = getAndroidHardwareKeySequence(
+            e,
+            terminal.modes.applicationCursorKeysMode,
+            hostConfig.terminalConfig?.backspaceMode,
+          );
+          if (sequence) {
+            e.preventDefault();
+            e.stopPropagation();
+            if (webSocketRef.current?.readyState === WebSocket.OPEN) {
+              webSocketRef.current.send(
+                JSON.stringify({ type: "input", data: sequence }),
+              );
+            }
             return false;
           }
         }

--- a/src/ui/features/terminal/android-hardware-keyboard.ts
+++ b/src/ui/features/terminal/android-hardware-keyboard.ts
@@ -1,0 +1,30 @@
+import type { HostBackspaceMode } from "@/sidebar/HostEditorData";
+
+const CURSOR_SEQUENCES: Record<string, [normal: string, application: string]> =
+  {
+    ArrowUp: ["\x1b[A", "\x1bOA"],
+    ArrowDown: ["\x1b[B", "\x1bOB"],
+    ArrowRight: ["\x1b[C", "\x1bOC"],
+    ArrowLeft: ["\x1b[D", "\x1bOD"],
+  };
+
+export function getAndroidHardwareKeySequence(
+  event: Pick<
+    KeyboardEvent,
+    "key" | "ctrlKey" | "altKey" | "metaKey" | "shiftKey"
+  >,
+  applicationCursorKeys: boolean,
+  backspaceMode: HostBackspaceMode | undefined,
+): string | null {
+  if (event.ctrlKey || event.altKey || event.metaKey || event.shiftKey) {
+    return null;
+  }
+
+  const cursor = CURSOR_SEQUENCES[event.key];
+  if (cursor) return cursor[applicationCursorKeys ? 1 : 0];
+  if (event.key === "Delete") return "\x1b[3~";
+  if (event.key === "Backspace" && backspaceMode !== "control-h") {
+    return "\x7f";
+  }
+  return null;
+}

--- a/src/ui/tests/features/terminal/android-hardware-keyboard.test.ts
+++ b/src/ui/tests/features/terminal/android-hardware-keyboard.test.ts
@@ -1,0 +1,50 @@
+import { describe, expect, it } from "vitest";
+import { getAndroidHardwareKeySequence } from "@/features/terminal/android-hardware-keyboard";
+
+const key = (
+  value: string,
+  modifiers: Partial<KeyboardEvent> = {},
+): Pick<
+  KeyboardEvent,
+  "key" | "ctrlKey" | "altKey" | "metaKey" | "shiftKey"
+> => ({
+  key: value,
+  ctrlKey: false,
+  altKey: false,
+  metaKey: false,
+  shiftKey: false,
+  ...modifiers,
+});
+
+describe("getAndroidHardwareKeySequence", () => {
+  it("maps cursor keys in normal and application modes", () => {
+    expect(
+      getAndroidHardwareKeySequence(key("ArrowUp"), false, undefined),
+    ).toBe("\x1b[A");
+    expect(getAndroidHardwareKeySequence(key("ArrowUp"), true, undefined)).toBe(
+      "\x1bOA",
+    );
+  });
+
+  it("maps Delete and the default Backspace mode", () => {
+    expect(getAndroidHardwareKeySequence(key("Delete"), false, undefined)).toBe(
+      "\x1b[3~",
+    );
+    expect(
+      getAndroidHardwareKeySequence(key("Backspace"), false, undefined),
+    ).toBe("\x7f");
+  });
+
+  it("leaves control-h Backspace and modified keys to existing handlers", () => {
+    expect(
+      getAndroidHardwareKeySequence(key("Backspace"), false, "control-h"),
+    ).toBeNull();
+    expect(
+      getAndroidHardwareKeySequence(
+        key("ArrowLeft", { ctrlKey: true }),
+        false,
+        undefined,
+      ),
+    ).toBeNull();
+  });
+});


### PR DESCRIPTION
## Summary
- forward Android hardware keyboard cursor, Delete, and Backspace keys directly from xterm
- preserve normal/application cursor mode and configured Backspace behavior
- leave modified key combinations and existing control-h handling unchanged
- add regression coverage for the generated terminal sequences

## Root cause
Some Android WebViews expose a valid `KeyboardEvent.key` for external keyboard special keys while reporting key codes that xterm cannot translate. Text input still works through the textarea/IME path, but cursor and editing keys produce no terminal data.

## Validation
- npm exec vitest run src/ui/tests/features/terminal/android-hardware-keyboard.test.ts
- npm run type-check
- npm exec eslint src/ui/features/terminal/android-hardware-keyboard.ts src/ui/features/terminal/Terminal.tsx src/ui/tests/features/terminal/android-hardware-keyboard.test.ts
- npm exec prettier -- --check src/ui/features/terminal/android-hardware-keyboard.ts src/ui/features/terminal/Terminal.tsx src/ui/tests/features/terminal/android-hardware-keyboard.test.ts
- npm run build

Closes Termix-SSH/Support#915