### PR TITLE
Fix OIDC login when the ID token is not a verifiable JWS

### DIFF
--- a/src/backend/database/routes/user-oidc-utils.ts
+++ b/src/backend/database/routes/user-oidc-utils.ts
@@ -10,6 +10,17 @@ import {
 const BACKCHANNEL_LOGOUT_EVENT =
   "http://schemas.openid.net/event/backchannel-logout";
 
+/**
+ * Raised when a token cannot be verified because it is not a compact JWS,
+ * as opposed to a signature or claim check that actually failed.
+ */
+export class OIDCTokenFormatError extends Error {
+  constructor(message: string) {
+    super(message);
+    this.name = "OIDCTokenFormatError";
+  }
+}
+
 function normalizeIssuer(url: string): string {
   return url.trim().replace(/\/+$/, "");
 }
@@ -149,6 +160,15 @@ export async function verifyOIDCToken(
   clientId: string,
   caCert?: string,
 ): Promise<Record<string, unknown>> {
+  const segments = idToken.split(".");
+  if (segments.length !== 3) {
+    throw new OIDCTokenFormatError(
+      segments.length === 5
+        ? "Token is a JWE (encrypted). Termix cannot verify encrypted tokens; disable token encryption for this client in your OIDC provider."
+        : `Token is not a compact JWS: expected 3 segments, got ${segments.length}.`,
+    );
+  }
+
   const fetchOptions = buildFetchOptions(caCert);
   const normalizedIssuerUrl = issuerUrl.endsWith("/")
     ? issuerUrl.slice(0, -1)

--- a/src/backend/database/routes/users.ts
+++ b/src/backend/database/routes/users.ts
@@ -27,6 +27,7 @@ import { shouldShowDonationModal } from "./donation-modal-utils.js";
 import {
   getOIDCConfigFromEnv,
   isOIDCUserAllowed,
+  OIDCTokenFormatError,
   verifyOIDCToken,
   extractOidcGroups,
   loadProviderConfig,
@@ -1049,20 +1050,37 @@ router.get("/oidc/callback", async (req, res) => {
     );
 
     if (tokenData.id_token) {
-      userInfo = await verifyOIDCToken(
-        tokenData.id_token as string,
-        config.issuer_url,
-        config.client_id,
-        caCert,
-      );
+      try {
+        userInfo = await verifyOIDCToken(
+          tokenData.id_token as string,
+          config.issuer_url,
+          config.client_id,
+          caCert,
+        );
 
-      const expectedNonce = storedNonce;
-      if (userInfo.nonce !== expectedNonce) {
-        authLogger.warn("OIDC ID token nonce mismatch", {
-          operation: "oidc_nonce_mismatch",
-          providerId: callbackProviderId,
-        });
-        return res.status(401).json({ error: "Invalid OIDC token nonce" });
+        const expectedNonce = storedNonce;
+        if (userInfo.nonce !== expectedNonce) {
+          authLogger.warn("OIDC ID token nonce mismatch", {
+            operation: "oidc_nonce_mismatch",
+            providerId: callbackProviderId,
+          });
+          return res.status(401).json({ error: "Invalid OIDC token nonce" });
+        }
+      } catch (error) {
+        // A token we cannot parse as a JWS carries no claims we could trust, so
+        // fall through to the userinfo endpoint instead of failing the login.
+        // Signature and claim failures still reject: those are real rejections.
+        if (!(error instanceof OIDCTokenFormatError)) throw error;
+
+        userInfo = null;
+        authLogger.warn(
+          "OIDC ID token cannot be verified, falling back to userinfo endpoint",
+          {
+            operation: "oidc_id_token_unverifiable",
+            providerId: callbackProviderId,
+            reason: error.message,
+          },
+        );
       }
     }
 

--- a/src/backend/tests/database/routes/user-oidc-utils.test.ts
+++ b/src/backend/tests/database/routes/user-oidc-utils.test.ts
@@ -251,3 +251,53 @@ describe("validateLogoutTokenClaims", () => {
     ).toThrow("must contain sub and/or sid");
   });
 });
+
+// Imported as a namespace rather than destructured into the shared block at the
+// top of the file, so this suite stays independent of what that block binds.
+const oidcUtils = await import("../../../database/routes/user-oidc-utils.js");
+
+describe("verifyOIDCToken token shape", () => {
+  const issuer = "https://idp.example.com/application/o/termix";
+
+  // The shape check runs before any network call, so no fetch stub is needed.
+  const fetchSpy = vi.fn();
+  beforeEach(() => {
+    vi.stubGlobal("fetch", fetchSpy);
+  });
+  afterEach(() => {
+    vi.unstubAllGlobals();
+    fetchSpy.mockReset();
+  });
+
+  it("reports an encrypted (JWE) token as a format error", async () => {
+    const jwe = ["header", "key", "iv", "ciphertext", "tag"].join(".");
+
+    await expect(
+      oidcUtils.verifyOIDCToken(jwe, issuer, "client"),
+    ).rejects.toThrow(oidcUtils.OIDCTokenFormatError);
+    await expect(
+      oidcUtils.verifyOIDCToken(jwe, issuer, "client"),
+    ).rejects.toThrow(/JWE \(encrypted\)/);
+    expect(fetchSpy).not.toHaveBeenCalled();
+  });
+
+  it("reports any other non-JWS segment count as a format error", async () => {
+    await expect(
+      oidcUtils.verifyOIDCToken("header.payload", issuer, "client"),
+    ).rejects.toThrow(/expected 3 segments, got 2/);
+    await expect(
+      oidcUtils.verifyOIDCToken("opaque", issuer, "client"),
+    ).rejects.toThrow(/expected 3 segments, got 1/);
+    expect(fetchSpy).not.toHaveBeenCalled();
+  });
+
+  it("lets a three-segment token through to key resolution", async () => {
+    fetchSpy.mockResolvedValue({ ok: false });
+
+    // Reaches JWKS fetching, so it fails on the key lookup rather than the shape.
+    await expect(
+      oidcUtils.verifyOIDCToken("header.payload.signature", issuer, "client"),
+    ).rejects.not.toThrow(oidcUtils.OIDCTokenFormatError);
+    expect(fetchSpy).toHaveBeenCalled();
+  });
+});


### PR DESCRIPTION
## Summary

- reject a non-JWS `id_token` with a distinct `OIDCTokenFormatError` before any JWKS lookup, so the shape check is separable from a real verification failure
- fall back to the userinfo endpoint when the ID token carries no verifiable claims, instead of failing the login with `JWSInvalid: Invalid Compact JWS`
- keep rejecting the login when signature or claim verification actually fails, and keep rejecting unverifiable back-channel logout tokens
- report an encrypted (JWE) ID token with an actionable message naming the provider setting to change
- add regression coverage for JWE and other malformed token shapes

`jwtVerify` throws `JWSInvalid` when a token does not split into exactly three
segments — a shape check, not a signature check. Authentik issues an encrypted
five-segment JWE `id_token` when the provider has an encryption key configured,
so verification never succeeded for those deployments. 2.5.0 hid this behind a
catch-all that decoded the unverified payload; for a JWE its `parts.length === 3`
guard was false, `userInfo` stayed null, and the login completed via userinfo.
Removing that fallback stopped Termix trusting unsigned claims, but also turned
the pre-existing failure into a hard login failure. This restores the 2.5.0
outcome without the unsigned-claim decode.

## Validation

- `npm test -- --run src/backend/tests/database/routes/user-oidc-utils.test.ts` (27 passed)
- `npm run type-check`
- `npm run lint` (0 errors; 44 existing warnings only)
- `npm run build`
- `git diff --check`

Closes Termix-SSH/Support#1016
Closes Termix-SSH/Support#1018