### PR TITLE
Stop read-only shared hosts from being dragged into folders

### DIFF
--- a/src/ui/sidebar/SidebarTree.tsx
+++ b/src/ui/sidebar/SidebarTree.tsx
@@ -2,6 +2,7 @@
 import {
   useState,
   useEffect,
+  useMemo,
   useRef,
   useLayoutEffect,
   type MouseEvent,
@@ -404,7 +405,7 @@ export function HostItem({
   if (compactHostView) {
     return (
       <div
-        draggable={!selectionMode && !isTouchOnly}
+        draggable={!selectionMode && !isTouchOnly && canEditHost(host)}
         onDragStart={(e) => {
           e.dataTransfer.effectAllowed = "move";
           onDragStart?.();
@@ -934,7 +935,7 @@ export function HostItem({
 
   return (
     <div
-      draggable={!selectionMode && !isTouchOnly}
+      draggable={!selectionMode && !isTouchOnly && canEditHost(host)}
       onDragStart={(e) => {
         e.dataTransfer.effectAllowed = "move";
         onDragStart?.();
@@ -1861,6 +1862,12 @@ export function SidebarTree({
     };
   }, []);
 
+  const hostsById = useMemo(() => {
+    const map = new Map<string, Host>();
+    for (const host of collectAllHosts(children)) map.set(host.id, host);
+    return map;
+  }, [children]);
+
   function handleDragHostStart(hostId: string) {
     // When the dragged host is part of an active selection, move the whole set.
     if (selectionMode && selectedHostIds.has(hostId)) {
@@ -1875,12 +1882,19 @@ export function SidebarTree({
     targetPath: string,
   ) {
     setDraggedHostIds(null);
+    // A selection can mix owned hosts with shared ones the recipient may not
+    // edit; moving those would fail server-side and take the whole batch down.
+    const movableIds = hostIds.filter((id) => {
+      const host = hostsById.get(id);
+      return !host || canEditHost(host);
+    });
+    if (movableIds.length === 0) return;
     try {
-      await bulkUpdateSSHHosts(hostIds.map(Number), { folder: targetPath });
+      await bulkUpdateSSHHosts(movableIds.map(Number), { folder: targetPath });
       window.dispatchEvent(new CustomEvent("termix:hosts-changed"));
       toast.success(
         t("hosts.movedToFolder", {
-          count: hostIds.length,
+          count: movableIds.length,
           folder: targetPath || t("hosts.folderPickerNone"),
         }),
       );

--- a/src/ui/tests/sidebar/host-permissions.test.ts
+++ b/src/ui/tests/sidebar/host-permissions.test.ts
@@ -1,0 +1,76 @@
+import { describe, expect, it } from "vitest";
+import type { Host, SharePermissionLevel } from "@/types/ui-types";
+import {
+  canDeleteHost,
+  canEditHost,
+  canShareHost,
+  canViewHostConfig,
+} from "../../sidebar/host-permissions";
+
+function ownHost(): Host {
+  return { id: "1", name: "own", isShared: false } as Host;
+}
+
+function sharedHost(permissionLevel?: SharePermissionLevel): Host {
+  return { id: "2", name: "shared", isShared: true, permissionLevel } as Host;
+}
+
+describe("host permissions", () => {
+  it("grants every action on a host you own", () => {
+    const host = ownHost();
+
+    expect(canViewHostConfig(host)).toBe(true);
+    expect(canEditHost(host)).toBe(true);
+    expect(canShareHost(host)).toBe(true);
+    expect(canDeleteHost(host)).toBe(true);
+  });
+
+  it("limits a connect-level recipient to connecting", () => {
+    const host = sharedHost("connect");
+
+    expect(canViewHostConfig(host)).toBe(false);
+    expect(canEditHost(host)).toBe(false);
+    expect(canShareHost(host)).toBe(false);
+  });
+
+  it("lets a view-level recipient read the config but not change it", () => {
+    const host = sharedHost("view");
+
+    expect(canViewHostConfig(host)).toBe(true);
+    expect(canEditHost(host)).toBe(false);
+    expect(canShareHost(host)).toBe(false);
+  });
+
+  it("lets an edit-level recipient edit but not re-share", () => {
+    const host = sharedHost("edit");
+
+    expect(canEditHost(host)).toBe(true);
+    expect(canShareHost(host)).toBe(false);
+  });
+
+  it("lets a manage-level recipient edit and re-share", () => {
+    const host = sharedHost("manage");
+
+    expect(canEditHost(host)).toBe(true);
+    expect(canShareHost(host)).toBe(true);
+  });
+
+  it("treats a shared host with no level as connect-only", () => {
+    const host = sharedHost(undefined);
+
+    expect(canViewHostConfig(host)).toBe(false);
+    expect(canEditHost(host)).toBe(false);
+    expect(canShareHost(host)).toBe(false);
+  });
+
+  it("never lets a recipient delete a shared host", () => {
+    for (const level of [
+      "connect",
+      "view",
+      "edit",
+      "manage",
+    ] as SharePermissionLevel[]) {
+      expect(canDeleteHost(sharedHost(level))).toBe(false);
+    }
+  });
+});


### PR DESCRIPTION
## Summary

- gate the sidebar row `draggable` flag on `canEditHost`, so a shared host the recipient cannot edit can no longer be dragged
- skip hosts the recipient cannot edit in `handleMoveHostsToFolder`, so a mixed selection moves what it can instead of failing as a whole
- add coverage for `host-permissions` across all four share levels

`HostItem` already hides edit, share and delete based on the recipient permission
level, and `HostEditor` disables its fieldset and hides the save button. The drag
handle was the one write path left ungated: `draggable={!selectionMode && !isTouchOnly}`
never consulted the permission level, so dropping a read-only shared host on a
folder called `bulkUpdateSSHHosts(..., { folder })`, which the server rejects. The
recipient gets `hosts.failedToMoveHosts` in the corner for an action the UI
offered them — the "edits that end up with an error" in the report.

## Not covered here

The second half of the report — per-recipient credentials on a shared host, so
two users can connect to the same host with their own logins — is a feature
rather than a fix, and changes the sharing model. Worth splitting into its own
request.

## Validation

- `npm test -- --run src/ui/tests/sidebar/host-permissions.test.ts` (7 passed)
- `npm test` (1089 passed, 1 skipped; the one failure, `scripts/patch-guacamole-lite.test.ts`, fails the same way on an unmodified checkout because postinstall has already applied the patch)
- `npm run type-check`
- `npm run lint` (0 errors; 44 existing warnings only)
- `npm run build`
- `git diff --check`

Closes Termix-SSH/Support#1011