### PR TITLE
Apply the configured RDP resolution to the session

### DIFF
--- a/src/ui/features/guacamole/GuacamoleApp.tsx
+++ b/src/ui/features/guacamole/GuacamoleApp.tsx
@@ -17,6 +17,7 @@ import {
   logActivity,
   isElectron,
 } from "@/main-axios.ts";
+import { readConfiguredDimension } from "@/features/guacamole/guacamole-display-size.ts";
 import { resolveConnectionOrigin } from "@/lib/connection-origin.ts";
 import { useTranslation } from "react-i18next";
 import { AlertCircle, RefreshCw } from "lucide-react";
@@ -362,7 +363,15 @@ const GuacamoleAppInner = React.forwardRef<
   }
 
   const resolvedProtocol = resolvedProtocolForConnect;
-  const configuredDpi = Number(hostConfig.guacamoleConfig?.dpi);
+  const configuredDpi = readConfiguredDimension(
+    hostConfig.guacamoleConfig?.dpi,
+  );
+  const configuredWidth = readConfiguredDimension(
+    hostConfig.guacamoleConfig?.width,
+  );
+  const configuredHeight = readConfiguredDimension(
+    hostConfig.guacamoleConfig?.height,
+  );
 
   return (
     <div className="relative w-full h-full">
@@ -400,10 +409,9 @@ const GuacamoleAppInner = React.forwardRef<
           token,
           protocol: resolvedProtocol,
           type: resolvedProtocol,
-          dpi:
-            Number.isFinite(configuredDpi) && configuredDpi > 0
-              ? configuredDpi
-              : undefined,
+          width: configuredWidth,
+          height: configuredHeight,
+          dpi: configuredDpi,
         }}
         isVisible={isVisible}
         touchMode={touchMode}

--- a/src/ui/features/guacamole/GuacamoleDisplay.tsx
+++ b/src/ui/features/guacamole/GuacamoleDisplay.tsx
@@ -69,6 +69,10 @@ export const GuacamoleDisplay = forwardRef<
   ref,
 ) {
   const { t } = useTranslation();
+  // The host config pins the session resolution; without it the display follows
+  // the container.
+  const hasConfiguredSize =
+    connectionConfig.width != null && connectionConfig.height != null;
   const containerRef = useRef<HTMLDivElement>(null);
   const displayRef = useRef<HTMLDivElement>(null);
   const displayElementRef = useRef<HTMLElement | null>(null);
@@ -493,7 +497,10 @@ export const GuacamoleDisplay = forwardRef<
           isConnectingRef.current = false;
           setIsReady(true);
           onConnect?.();
-          if (containerRef.current) {
+          // A configured resolution is the size the session should render at;
+          // resizing it to the container would discard it. rescaleDisplay still
+          // fits that fixed display into whatever space is available.
+          if (!hasConfiguredSize && containerRef.current) {
             const rect = containerRef.current.getBoundingClientRect();
             const size = getGuacamoleDisplaySize(
               rect.width,
@@ -601,6 +608,7 @@ export const GuacamoleDisplay = forwardRef<
     connectionConfig.protocol,
     connectionConfig.type,
     connectionConfig.dpi,
+    hasConfiguredSize,
     touchMode,
     t,
   ]);
@@ -675,15 +683,17 @@ export const GuacamoleDisplay = forwardRef<
       resizeTimeoutRef.current = setTimeout(() => {
         if (clientRef.current && containerRef.current) {
           const rect = containerRef.current.getBoundingClientRect();
-          const size = getGuacamoleDisplaySize(
-            rect.width,
-            rect.height,
-            connectionConfig.protocol ?? connectionConfig.type,
-            window.devicePixelRatio,
-            connectionConfig.dpi,
-          );
           if (rect.width > 0 && rect.height > 0) {
-            clientRef.current.sendSize(size.width, size.height);
+            if (!hasConfiguredSize) {
+              const size = getGuacamoleDisplaySize(
+                rect.width,
+                rect.height,
+                connectionConfig.protocol ?? connectionConfig.type,
+                window.devicePixelRatio,
+                connectionConfig.dpi,
+              );
+              clientRef.current.sendSize(size.width, size.height);
+            }
             rescaleDisplay(true);
           }
         }
@@ -699,6 +709,7 @@ export const GuacamoleDisplay = forwardRef<
     connectionConfig.dpi,
     connectionConfig.protocol,
     connectionConfig.type,
+    hasConfiguredSize,
     rescaleDisplay,
   ]);
 

--- a/src/ui/features/guacamole/guacamole-display-size.ts
+++ b/src/ui/features/guacamole/guacamole-display-size.ts
@@ -1,6 +1,15 @@
 const DEFAULT_RDP_DPI = 96;
 const MAX_DEVICE_PIXEL_RATIO = 3;
 
+/**
+ * Reads a guacamoleConfig display field. The UI stores these as strings, and
+ * leaves them empty when the size should follow the browser window.
+ */
+export function readConfiguredDimension(value: unknown): number | undefined {
+  const parsed = Number(value);
+  return Number.isFinite(parsed) && parsed > 0 ? parsed : undefined;
+}
+
 export interface GuacamoleDisplaySize {
   width: number;
   height: number;

--- a/src/ui/tests/features/guacamole/guacamole-display-size.test.ts
+++ b/src/ui/tests/features/guacamole/guacamole-display-size.test.ts
@@ -1,5 +1,8 @@
 import { describe, expect, it } from "vitest";
-import { getGuacamoleDisplaySize } from "../../../features/guacamole/guacamole-display-size";
+import {
+  getGuacamoleDisplaySize,
+  readConfiguredDimension,
+} from "../../../features/guacamole/guacamole-display-size";
 
 describe("getGuacamoleDisplaySize", () => {
   it("requests native pixels and matching DPI for HiDPI RDP", () => {
@@ -35,5 +38,30 @@ describe("getGuacamoleDisplaySize", () => {
       dpi: 288,
       pixelRatio: 3,
     });
+  });
+
+  it("uses a configured resolution in place of the container size", () => {
+    expect(
+      getGuacamoleDisplaySize(800, 600, "rdp", 1, undefined),
+    ).toMatchObject({ width: 800, height: 600 });
+    expect(
+      getGuacamoleDisplaySize(1920, 1080, "rdp", 1, undefined),
+    ).toMatchObject({ width: 1920, height: 1080 });
+  });
+});
+
+describe("readConfiguredDimension", () => {
+  it("accepts the strings the host editor stores", () => {
+    expect(readConfiguredDimension("1920")).toBe(1920);
+    expect(readConfiguredDimension(1080)).toBe(1080);
+  });
+
+  it("treats an unset or unusable value as 'follow the container'", () => {
+    expect(readConfiguredDimension("")).toBeUndefined();
+    expect(readConfiguredDimension(undefined)).toBeUndefined();
+    expect(readConfiguredDimension(null)).toBeUndefined();
+    expect(readConfiguredDimension("auto")).toBeUndefined();
+    expect(readConfiguredDimension("0")).toBeUndefined();
+    expect(readConfiguredDimension("-1080")).toBeUndefined();
   });
 });


### PR DESCRIPTION
## Summary

- pass the host's configured `width` and `height` into the connection config alongside `dpi`, so a pinned resolution reaches the session
- skip the container-driven `sendSize` on connect and on resize when a resolution is pinned, instead of immediately resizing away from it
- add `readConfiguredDimension` for the string-or-empty values the host editor stores, with coverage for the unset, zero, negative and `auto` cases

The host editor writes `width` and `height` into `guacamoleConfig`, and the
backend already forwards them to guacd inside the connection token. The renderer
then appends its own `width` and `height` query parameters measured from the
container, and those take precedence — so the configured resolution never
reached the session. `dpi` was the only display field `GuacamoleApp` read back
out of `guacamoleConfig`, which is why DPI applied and resolution did not.

Even with the size passed through, both `sendSize` paths (on state 3, and the
`ResizeObserver`) would have resized the session back to the container on the
next tick, so those are gated on whether a resolution is pinned. `rescaleDisplay`
is untouched and still scales the fixed display to fit the available space.

## Scope

This covers the resolution part of the report. The other `guacamoleConfig` keys —
multi-monitor and the rest — are already forwarded verbatim by the backend and
were never overridden by the renderer; `width`/`height` were the only fields the
query string clobbered. If fullscreen or scaling still misbehave after this,
they are a separate defect.

Worth noting for triage: `width`/`height` have never been passed since at least
2.4.1, so despite the report saying it worked in a previous release, this is a
long-standing gap rather than a 2.6.0 regression.

## Validation

- `npm test -- --run src/ui/tests/features/guacamole/` (14 passed)
- `npm test` (1076 passed, 1 skipped; the one failure, `scripts/patch-guacamole-lite.test.ts`, fails identically on an unmodified checkout because postinstall has already applied the patch)
- `npm run type-check`
- `npm run lint` (0 errors; 44 existing warnings only)
- `npm run build`
- `git diff --check`

Closes Termix-SSH/Support#1039