### PR TITLE
Honour per-host recording flags and explain a missing recording

### DIFF
--- a/src/backend/hosts/guacamole/guacamole-server.ts
+++ b/src/backend/hosts/guacamole/guacamole-server.ts
@@ -104,10 +104,16 @@ async function persistGuacamoleRecording(
     await new Promise((resolve) => setTimeout(resolve, 100));
   }
   if (!fs.existsSync(resolvedPath)) {
+    const guacdPath = recording.guacdPath ?? GUACAMOLE_RECORDINGS_DIR;
     guacLogger.warn("Guacamole recording file was not found", {
       operation: "guac_recording_missing",
       hostId: recording.hostId,
       path: resolvedPath,
+      guacdPath,
+      hint:
+        "guacd writes the recording to guacdPath, the backend reads it from path. " +
+        "When guacd runs in its own container these must be the same volume — set " +
+        "GUACD_RECORDING_PATH to guacd's mount point and GUACD_RECORDING_BACKEND_PATH to this one.",
     });
     return;
   }

--- a/src/backend/hosts/guacamole/recording-settings.ts
+++ b/src/backend/hosts/guacamole/recording-settings.ts
@@ -1,0 +1,22 @@
+/**
+ * Merges Termix's recording bookkeeping into a host's guacd settings.
+ *
+ * Location and filename are not the host's to choose: recordings are indexed by
+ * them for playback, and the backend refuses to read anything outside its
+ * recordings directory. What a recording *contains* is a host-level decision, so
+ * those flags are only defaulted, never overwritten.
+ */
+export function withRecordingSettings(
+  guacConfig: Record<string, unknown>,
+  recordingPath: string,
+  recordingName: string,
+): Record<string, unknown> {
+  return {
+    ...guacConfig,
+    "recording-path": recordingPath,
+    "recording-name": recordingName,
+    "create-recording-path": true,
+    "recording-exclude-output": guacConfig["recording-exclude-output"] ?? false,
+    "recording-include-keys": guacConfig["recording-include-keys"] ?? true,
+  };
+}

--- a/src/backend/hosts/guacamole/routes.ts
+++ b/src/backend/hosts/guacamole/routes.ts
@@ -1,5 +1,6 @@
 import express from "express";
 import { GuacamoleTokenService } from "./token-service.js";
+import { withRecordingSettings } from "./recording-settings.js";
 import { guacLogger } from "../../utils/logger.js";
 import { AuthManager } from "../../utils/auth-manager.js";
 import { PermissionManager } from "../../utils/permission-manager.js";
@@ -602,15 +603,16 @@ router.post(
             userId,
             protocol: connectionType as "rdp" | "vnc" | "telnet",
             path: recordingName,
+            guacdPath: recordingPath,
             startedAt: new Date().toISOString(),
           }
         : undefined;
       if (recordingEnabled) {
-        guacConfig["recording-path"] = recordingPath;
-        guacConfig["recording-name"] = recordingName;
-        guacConfig["create-recording-path"] = true;
-        guacConfig["recording-exclude-output"] = false;
-        guacConfig["recording-include-keys"] = true;
+        guacConfig = withRecordingSettings(
+          guacConfig,
+          recordingPath,
+          recordingName,
+        );
       }
 
       const termixConnectId = crypto.randomUUID();

--- a/src/backend/hosts/guacamole/token-service.ts
+++ b/src/backend/hosts/guacamole/token-service.ts
@@ -48,6 +48,9 @@ export interface GuacamoleRecordingMetadata {
   userId: string;
   protocol: "rdp" | "vnc" | "telnet";
   path: string;
+  /** Directory guacd was told to write into; differs from the backend's view
+   * when guacd runs in its own container. */
+  guacdPath?: string;
   startedAt: string;
 }
 

--- a/src/backend/tests/hosts/guacamole/recording-settings.test.ts
+++ b/src/backend/tests/hosts/guacamole/recording-settings.test.ts
@@ -1,0 +1,68 @@
+import { describe, expect, it } from "vitest";
+import { withRecordingSettings } from "../../../hosts/guacamole/recording-settings.js";
+
+const PATH = "/app/data/session_recordings/guacamole";
+const NAME = "b7e6c0f2-0000-4000-8000-000000000000.guac";
+
+describe("withRecordingSettings", () => {
+  it("takes ownership of the location and filename", () => {
+    const merged = withRecordingSettings(
+      {
+        "recording-path": "/var/lib/termix/recordings",
+        "recording-name": "${GUAC_USERNAME}-${GUAC_DATE}",
+        "create-recording-path": false,
+      },
+      PATH,
+      NAME,
+    );
+
+    expect(merged).toMatchObject({
+      "recording-path": PATH,
+      "recording-name": NAME,
+      "create-recording-path": true,
+    });
+  });
+
+  it("defaults the content flags when the host has no opinion", () => {
+    expect(withRecordingSettings({}, PATH, NAME)).toMatchObject({
+      "recording-exclude-output": false,
+      "recording-include-keys": true,
+    });
+  });
+
+  it("keeps the host's content flags, including the falsy ones", () => {
+    const merged = withRecordingSettings(
+      {
+        "recording-exclude-output": true,
+        "recording-include-keys": false,
+      },
+      PATH,
+      NAME,
+    );
+
+    expect(merged).toMatchObject({
+      "recording-exclude-output": true,
+      "recording-include-keys": false,
+    });
+  });
+
+  it("leaves unrelated settings alone", () => {
+    const merged = withRecordingSettings(
+      { "recording-exclude-mouse": true, width: "1920" },
+      PATH,
+      NAME,
+    );
+
+    expect(merged).toMatchObject({
+      "recording-exclude-mouse": true,
+      width: "1920",
+    });
+  });
+
+  it("does not mutate the settings it was given", () => {
+    const original = { "recording-path": "/tmp/mine" };
+    withRecordingSettings(original, PATH, NAME);
+
+    expect(original).toEqual({ "recording-path": "/tmp/mine" });
+  });
+});

--- a/src/ui/sidebar/HostEditorGuacamoleTabs.tsx
+++ b/src/ui/sidebar/HostEditorGuacamoleTabs.tsx
@@ -859,26 +859,6 @@ export function HostEditorRdpTab({
         }
       >
         <div className="flex flex-col gap-4 py-3">
-          <div className="flex flex-col gap-1.5">
-            <label className="text-[10px] font-bold uppercase tracking-widest text-muted-foreground">
-              {t("hosts.guac.recordingPath")}
-            </label>
-            <Input
-              placeholder="/var/lib/termix/recordings"
-              value={form.guacamoleConfig["recording-path"] ?? ""}
-              onChange={(e) => setGuacField("recording-path", e.target.value)}
-            />
-          </div>
-          <div className="flex flex-col gap-1.5">
-            <label className="text-[10px] font-bold uppercase tracking-widest text-muted-foreground">
-              {t("hosts.guac.recordingName")}
-            </label>
-            <Input
-              placeholder="${GUAC_USERNAME}-${GUAC_DATE}-${GUAC_TIME}"
-              value={form.guacamoleConfig["recording-name"] ?? ""}
-              onChange={(e) => setGuacField("recording-name", e.target.value)}
-            />
-          </div>
           <SettingRow
             label={t("hosts.guac.createPathIfMissing")}
             description={t("hosts.guac.createPathIfMissingDesc")}
@@ -1418,26 +1398,6 @@ export function HostEditorVncTab({
         }
       >
         <div className="flex flex-col gap-4 py-3">
-          <div className="flex flex-col gap-1.5">
-            <label className="text-[10px] font-bold uppercase tracking-widest text-muted-foreground">
-              {t("hosts.guac.recordingPath")}
-            </label>
-            <Input
-              placeholder="/var/lib/termix/recordings"
-              value={form.guacamoleConfig["recording-path"] ?? ""}
-              onChange={(e) => setGuacField("recording-path", e.target.value)}
-            />
-          </div>
-          <div className="flex flex-col gap-1.5">
-            <label className="text-[10px] font-bold uppercase tracking-widest text-muted-foreground">
-              {t("hosts.guac.recordingName")}
-            </label>
-            <Input
-              placeholder="${GUAC_USERNAME}-${GUAC_DATE}-${GUAC_TIME}"
-              value={form.guacamoleConfig["recording-name"] ?? ""}
-              onChange={(e) => setGuacField("recording-name", e.target.value)}
-            />
-          </div>
           <SettingRow
             label={t("hosts.guac.createPathIfMissing")}
             description={t("hosts.guac.createPathIfMissingDesc")}
@@ -1889,26 +1849,6 @@ export function HostEditorTelnetTab({
         }
       >
         <div className="flex flex-col gap-4 py-3">
-          <div className="flex flex-col gap-1.5">
-            <label className="text-[10px] font-bold uppercase tracking-widest text-muted-foreground">
-              {t("hosts.guac.recordingPath")}
-            </label>
-            <Input
-              placeholder="/var/lib/termix/recordings"
-              value={form.guacamoleConfig["recording-path"] ?? ""}
-              onChange={(e) => setGuacField("recording-path", e.target.value)}
-            />
-          </div>
-          <div className="flex flex-col gap-1.5">
-            <label className="text-[10px] font-bold uppercase tracking-widest text-muted-foreground">
-              {t("hosts.guac.recordingName")}
-            </label>
-            <Input
-              placeholder="${GUAC_USERNAME}-${GUAC_DATE}-${GUAC_TIME}"
-              value={form.guacamoleConfig["recording-name"] ?? ""}
-              onChange={(e) => setGuacField("recording-name", e.target.value)}
-            />
-          </div>
           <SettingRow
             label={t("hosts.guac.createPathIfMissing")}
             description={t("hosts.guac.createPathIfMissingDesc")}


### PR DESCRIPTION
## Summary

- default `recording-exclude-output` and `recording-include-keys` instead of overwriting them, so the host's content toggles apply
- remove the Recording Path and Recording Name inputs, which the backend has always discarded
- report both the guacd-side and backend-side path in the `guac_recording_missing` warning, and name the two env vars that align them
- move the merge into `withRecordingSettings` with coverage for ownership, defaulting, falsy host values and non-mutation

The session recording section offers a path, a filename template and four
content toggles. The backend overwrote five of the six on every connection:

```ts
guacConfig["recording-path"] = recordingPath;
guacConfig["recording-name"] = recordingName;
guacConfig["create-recording-path"] = true;
guacConfig["recording-exclude-output"] = false;   // discards the host setting
guacConfig["recording-include-keys"] = true;      // discards the host setting
```

Only `recording-exclude-mouse` survived. Configuring a path or a filename did
nothing at all, which is what the report describes.

Path and filename are genuinely not the host's to choose — recordings are indexed
by them for playback, and `persistGuacamoleRecording` refuses to read anything
outside its recordings directory — so this removes those two inputs rather than
keep offering settings that cannot take effect. The content flags are a host-level
decision and are now only defaulted.

## The missing file

That alone does not create the recording, because the reported failure is
elsewhere: guacd writes to the path it was given, the backend reads from its own.
When guacd runs in its own container those are two different filesystems, and
`create-recording-path` means guacd silently creates its own empty directory. The
warning previously reported one path and no context; it now reports both plus the
fix:

> guacd writes the recording to guacdPath, the backend reads it from path. When guacd runs in its own container these must be the same volume — set GUACD_RECORDING_PATH to guacd's mount point and GUACD_RECORDING_BACKEND_PATH to this one.

Both env vars already exist and are wired correctly; nothing pointed users at
them. Happy to turn this into a startup-time check instead if you would rather
catch it before the first recording is lost.

## Validation

- `npm test -- --run src/backend/tests/hosts/guacamole/` (11 passed)
- `npm test` (1078 passed, 1 skipped; the one failure, `scripts/patch-guacamole-lite.test.ts`, fails identically on an unmodified checkout because postinstall has already applied the patch)
- `npm run type-check`
- `npm run lint` (0 errors; 44 existing warnings only)
- `npm run build`
- `git diff --check`

Closes Termix-SSH/Support#1041