### PR TITLE
Stop highlighting inside a split control string

### DIFF
--- a/src/ui/features/terminal/Terminal.tsx
+++ b/src/ui/features/terminal/Terminal.tsx
@@ -45,7 +45,10 @@ import { ensureTerminalFontsLoaded } from "./terminal-global-styles.ts";
 import { useTheme } from "@/components/theme-provider.tsx";
 import { globalShortcutHandler } from "@/lib/global-shortcut-handler";
 import { useCommandTracker } from "@/features/terminal/command-history/useCommandTracker.ts";
-import { highlightTerminalOutput } from "@/lib/terminal-syntax-highlighter.ts";
+import {
+  highlightTerminalOutput,
+  updateControlStringMode,
+} from "@/lib/terminal-syntax-highlighter.ts";
 import { useCommandHistory } from "@/features/terminal/command-history/CommandHistoryContext.tsx";
 import { CommandAutocomplete } from "./command-history/CommandAutocomplete.tsx";
 import { SimpleLoader } from "@/lib/SimpleLoader.tsx";
@@ -419,6 +422,7 @@ const TerminalInner = forwardRef<TerminalHandle, SSHTerminalProps>(
     const activityLoggingRef = useRef(false);
     const passwordPromptShownRef = useRef(false);
     const alternateScreenModeRef = useRef(false);
+    const controlStringModeRef = useRef(false);
 
     const lastSentSizeRef = useRef<{ cols: number; rows: number } | null>(null);
     const pendingSizeRef = useRef<{ cols: number; rows: number } | null>(null);
@@ -689,12 +693,22 @@ const TerminalInner = forwardRef<TerminalHandle, SSHTerminalProps>(
       );
       alternateScreenModeRef.current = alternateScreen.isActive;
 
+      // Must run for every chunk, including ones we go on to skip, or the
+      // control-string state stops tracking the stream.
+      const controlString = updateControlStringMode(
+        output,
+        controlStringModeRef.current,
+      );
+      controlStringModeRef.current = controlString.isActive;
+
       const syntaxHighlightingEnabled =
         hostConfig.terminalConfig?.syntaxHighlighting !== false;
       if (
         !syntaxHighlightingEnabled ||
         alternateScreen.sawSequence ||
-        alternateScreen.isActive
+        alternateScreen.isActive ||
+        controlString.wasActive ||
+        controlString.isActive
       ) {
         return output;
       }
@@ -1061,6 +1075,7 @@ const TerminalInner = forwardRef<TerminalHandle, SSHTerminalProps>(
     ) {
       ws.addEventListener("open", () => {
         alternateScreenModeRef.current = false;
+        controlStringModeRef.current = false;
         connectionTimeoutRef.current = setTimeout(() => {
           if (
             !isConnected &&

--- a/src/ui/lib/terminal-syntax-highlighter.ts
+++ b/src/ui/lib/terminal-syntax-highlighter.ts
@@ -221,6 +221,55 @@ function hasIncompleteAnsiSequence(text: string): boolean {
   return /\x1b\[[0-9;?>=!]*$/.test(text);
 }
 
+/**
+ * Tracks whether the stream is inside a control string (OSC/DCS/APC/PM) across
+ * chunk boundaries.
+ *
+ * A control string carries text that must never reach the screen — an OSC 0
+ * title, for instance, contains the user, host and path. Its opening `ESC ]`
+ * and its terminator often land in different websocket frames, and the
+ * continuation frame contains no escape byte at all, so every single-chunk
+ * guard here misses it. Highlighting that continuation injects an SGR sequence
+ * into the middle of the string, which aborts it early in xterm.js and dumps
+ * the rest of the payload on screen as ordinary text.
+ *
+ * A trailing lone ESC counts as active for the same reason: its intent is only
+ * knowable from the next chunk.
+ */
+export function updateControlStringMode(
+  output: string,
+  currentMode: boolean,
+): { isActive: boolean; wasActive: boolean } {
+  const wasActive = currentMode;
+  let isActive = currentMode;
+
+  for (let i = 0; i < output.length; i++) {
+    const char = output[i];
+
+    if (isActive) {
+      if (char === "\x07") {
+        isActive = false;
+      } else if (char === "\x1b") {
+        // ST (ESC \) closes it; any other ESC aborts it.
+        isActive = false;
+        if (output[i + 1] === "\\") i++;
+      }
+      continue;
+    }
+
+    if (char !== "\x1b") continue;
+
+    const next = output[i + 1];
+    if (next === undefined) return { isActive: true, wasActive };
+    if (next === "]" || next === "P" || next === "^" || next === "_") {
+      isActive = true;
+      i++;
+    }
+  }
+
+  return { isActive, wasActive };
+}
+
 function parseAnsiSegments(text: string): TextSegment[] {
   const segments: TextSegment[] = [];
   ANSI_REGEX.lastIndex = 0;

--- a/src/ui/tests/lib/terminal-syntax-highlighter.test.ts
+++ b/src/ui/tests/lib/terminal-syntax-highlighter.test.ts
@@ -1,5 +1,8 @@
 import { describe, it, expect } from "vitest";
-import { highlightTerminalOutput } from "../../lib/terminal-syntax-highlighter.js";
+import {
+  highlightTerminalOutput,
+  updateControlStringMode,
+} from "../../lib/terminal-syntax-highlighter.js";
 
 const ESC = "\x1b";
 
@@ -333,5 +336,87 @@ describe("highlightTerminalOutput", () => {
     const out = highlightTerminalOutput(chunk);
     expect(out.split("\n")[0]).toContain(ESC + "[91m");
     expect(out.split("\n")[1]).toContain(ESC + "[36m");
+  });
+});
+
+describe("updateControlStringMode", () => {
+  const BEL = "\x07";
+
+  it("stays inactive for output with no control string", () => {
+    expect(updateControlStringMode("total 4\nfile.txt\n", false)).toEqual({
+      isActive: false,
+      wasActive: false,
+    });
+  });
+
+  it("goes active when a control string is left open at the chunk end", () => {
+    // What PROMPT_COMMAND emits: ESC ] 0 ; <title>, terminator not yet sent.
+    const chunk = `${ESC}]0;user@host:~/path/current-dir`;
+
+    expect(updateControlStringMode(chunk, false)).toEqual({
+      isActive: true,
+      wasActive: false,
+    });
+  });
+
+  it("clears on the continuation chunk that carries the terminator", () => {
+    // The continuation has no escape byte at all, which is why every
+    // single-chunk guard misses it.
+    const continuation = `${BEL}[user@host current-dir]$ `;
+
+    expect(updateControlStringMode(continuation, true)).toEqual({
+      isActive: false,
+      wasActive: true,
+    });
+  });
+
+  it("reports a chunk that opens and closes a control string as inactive", () => {
+    const chunk = `${ESC}]0;title${BEL}ready\n`;
+
+    expect(updateControlStringMode(chunk, false)).toEqual({
+      isActive: false,
+      wasActive: false,
+    });
+  });
+
+  it("accepts ST as a terminator", () => {
+    expect(
+      updateControlStringMode(`${ESC}]7;file:///tmp${ESC}\\`, false),
+    ).toEqual({
+      isActive: false,
+      wasActive: false,
+    });
+  });
+
+  it("treats a trailing lone ESC as active, since its meaning is in the next chunk", () => {
+    expect(updateControlStringMode(`done${ESC}`, false)).toEqual({
+      isActive: true,
+      wasActive: false,
+    });
+  });
+
+  it("recognises DCS, APC and PM openers too", () => {
+    for (const opener of ["P", "^", "_"]) {
+      expect(
+        updateControlStringMode(`${ESC}${opener}payload`, false).isActive,
+      ).toBe(true);
+    }
+  });
+
+  it("does not treat CSI as a control string", () => {
+    expect(updateControlStringMode(`${ESC}[31mred${ESC}[0m`, false)).toEqual({
+      isActive: false,
+      wasActive: false,
+    });
+  });
+
+  it("leaves a continuation chunk unhighlighted", () => {
+    // The bug: this chunk highlights cleanly on its own, and injecting SGR
+    // bytes into an open OSC string dumps the payload onto the screen.
+    const continuation = `${BEL}connect to 10.0.0.11 failed`;
+    expect(highlightTerminalOutput(continuation)).not.toBe(continuation);
+
+    const state = updateControlStringMode(continuation, true);
+    expect(state.wasActive).toBe(true);
   });
 });


### PR DESCRIPTION
## Summary

- track OSC/DCS/APC/PM state across chunks, the way alternate-screen mode already is
- skip highlighting for any chunk that starts or ends inside a control string
- reset the state on websocket open, so a reconnect cannot strand highlighting off
- cover the split-chunk case, both terminators, DCS/APC/PM openers, and a trailing lone ESC

The highlighter has thorough guards — `TUI_SEQUENCE`, `TUI_FRAME_SEQUENCE`,
`CONTROL_STRING_SEQUENCE`, `MID_LINE_CR`, `hasIncompleteAnsiSequence` — but every
one of them inspects a single chunk. A control string routinely spans two:

```
chunk A: "…\x1b]0;user@host:~/path/current-dir"   ← CONTROL_STRING_SEQUENCE hits, skipped
chunk B: "\x07[user@host current-dir]$ "          ← no escape byte, every guard misses
```

The reporter's `PROMPT_COMMAND` emits an OSC 0 title on every prompt, so this is
live on each Enter. Chunk B highlights cleanly on its own merits, and the
injected SGR sequence lands inside the still-open control string. xterm.js aborts
the string on that ESC and prints the remainder as ordinary text — which is
exactly the reported `~/path/current-dir` glued in front of the prompt.

It also explains the rest of the report: intermittent (only when the
continuation happens to match a highlight pattern), worse on Flatpak than in the
browser (different framing, so the split lands differently), and the cursor
desync — bash counts the prompt width without those injected bytes, so its
arithmetic diverges from xterm's real column, which is what surfaces as
duplicate prompts and the `Ctrl+R` corruption.

## On the reporter's findings

Their conclusion that the escape sequences never reach the client was the one
thing that pointed away from this, and it came from the session recordings —
which, as they suspected in their own caveat, are not a byte-exact tap. Their
manual `printf '\e]7;…'` test is the reproduction: it prints the payload, which
a terminal never should.

Note this is a highlighter bug, not an xterm.js one. Setting
`terminalConfig.syntaxHighlighting: false` avoids it entirely, which is worth
having as a confirmation step for the reporter.

## Validation

- `npm test -- --run src/ui/tests/lib/terminal-syntax-highlighter.test.ts` (64 passed, 9 new)
- `npm test` (1081 passed, 1 skipped, 2 failed — see below)
- `npm run type-check`
- `npm run lint` (0 errors; 44 existing warnings only)
- `npm run build`
- `git diff --check`

Both full-run failures are unrelated to this change, which is frontend-only:

- `scripts/patch-guacamole-lite.test.ts` fails identically on an unmodified checkout, because postinstall has already applied the patch
- `src/backend/tests/database/routes/session-log-routes.test.ts` fails only under the concurrent full run and passes on its own, on this branch and on a stashed working tree alike — it looks order-dependent, and I left it alone rather than widen this PR

Closes Termix-SSH/Support#1025