### PR TITLE
Stop the session-log route test importing the real repository layer

### DIFF
--- a/src/backend/tests/database/routes/session-log-routes.test.ts
+++ b/src/backend/tests/database/routes/session-log-routes.test.ts
@@ -28,6 +28,25 @@ vi.mock("../../../utils/auth-manager.js", () => ({
   },
 }));
 
+// The route module calls PermissionManager.getInstance() at import time and
+// pulls in the repository factory, which loads the drizzle schema and the
+// better-sqlite3 native binding. Importing that tree costs seconds under a
+// concurrent full run — enough to blow the 5s test timeout — and none of it is
+// under test here.
+vi.mock("../../../utils/permission-manager.js", () => ({
+  PermissionManager: {
+    getInstance: () => ({
+      canAccessHost: vi.fn(),
+    }),
+  },
+}));
+
+vi.mock("../../../database/repositories/factory.js", () => ({
+  createCurrentSessionRecordingRepository: vi.fn(),
+  createCurrentSettingsRepository: vi.fn(),
+  getCurrentSettingValue: vi.fn(),
+}));
+
 const mockReadFile = vi.fn();
 const mockStat = vi.fn();
 const mockUnlink = vi.fn();


### PR DESCRIPTION
## Summary

- mock `PermissionManager` and the repository factory in `session-log-routes.test.ts`
- the file now imports in milliseconds instead of seconds, so it no longer times out under a concurrent full run

`session-log-routes.test.ts` mocks `db`, the logger and `AuthManager`, but the
route module also does this at import time:

```ts
import { createCurrentSessionRecordingRepository, ... } from "../repositories/factory.js";

const permissionManager = PermissionManager.getInstance();
```

So `await import("…/session-log-routes.js")` loads the repository factory, which
pulls in the drizzle schema and the better-sqlite3 native binding. Under
`npm test`, where the projects run concurrently, that import exceeded the 5s
test timeout:

```
FAIL |backend| session-log-routes.test.ts > returns logs for the authenticated user with file size
Error: Test timed out in 5000ms.
```

Running the file on its own passed every time, which made it look flaky rather
than under-mocked. None of that tree is under test here — the assertions cover
the path-traversal guard and the fs stubs.

## Validation

- `npm test -- --run src/backend/tests/database/routes/session-log-routes.test.ts` (4 passed, 4.8s → 2.0s)
- `npm test` run three times: the target test passed in all three; the final run is fully green (`153 files, 1074 passed, 1 skipped`)
- `npm run type-check`
- `npm run lint` (0 errors; 44 existing warnings only)
- `npx prettier --check` on the changed file

## Unrelated: `scripts/patch-guacamole-lite.test.ts`

That test was also failing for me, and I want to flag what it turned out to be
rather than leave it looking like noise: it was **correct**. My `node_modules`
had Patch 2, 4 and 5 applied but not Patch 3 (the `name` handshake instruction
for `VERSION_1_1_0`), so guacd 1.6.0 VNC drops were not actually being fixed
locally. Re-running `node scripts/patch-guacamole-lite.cjs` applied it and the
test went green. Stale local state, no code change needed.

It does suggest a sharp edge worth considering separately, though: when a patch
target is not found, the script logs and calls `process.exit(0)` before the
write-back at the end of the file. A guacamole-lite upgrade that shifts any
anchor string would therefore drop every patch, silently, with a success exit
code — and postinstall would report nothing. Happy to open a separate PR making
that path fail loudly if you would like it.