### PR TITLE
Fail the guacamole-lite patch when an anchor is gone

### DIFF
--- a/scripts/patch-guacamole-lite.cjs
+++ b/scripts/patch-guacamole-lite.cjs
@@ -35,6 +35,20 @@ if (
   process.exit(0);
 }
 
+// Every patch below is required for correctness: protocol negotiation, the
+// guacd 1.6.0 name handshake, dynamic argument answering, UTF-8 tokens and
+// read-only joins. If an upstream release moves an anchor string, silently
+// skipping would ship a Termix that looks fine and then drops VNC/RDP sessions
+// at runtime, so a missing anchor has to stop the install instead.
+function missingAnchor(patch) {
+  console.error(
+    `[patch-guacamole-lite] ${patch} anchor not found in guacamole-lite. ` +
+      "The upstream file has changed and this patch no longer applies — " +
+      "update scripts/patch-guacamole-lite.cjs to match the new source.",
+  );
+  process.exit(1);
+}
+
 let guacdClientContent = fs.readFileSync(guacdClientPath, "utf8");
 let cryptContent = fs.readFileSync(cryptPath, "utf8");
 let clientConnectionContent = fs.readFileSync(clientConnectionPath, "utf8");
@@ -157,18 +171,14 @@ if (!guacdClientContent.includes("} else if (/^1_\\d+_0$/.test(version)) {")) {
       newVersionBlock,
     );
   } else {
-    console.log(
-      "[patch-guacamole-lite] Version check target not found, skipping",
-    );
-    process.exit(0);
+    missingAnchor("Version check");
   }
   patched = true;
 }
 
 if (!guacdClientContent.includes(newTimezone)) {
   if (!guacdClientContent.includes(oldTimezone)) {
-    console.log("[patch-guacamole-lite] Timezone target not found, skipping");
-    process.exit(0);
+    missingAnchor("Timezone");
   }
   guacdClientContent = guacdClientContent.replace(oldTimezone, newTimezone);
   patched = true;
@@ -180,20 +190,14 @@ if (!guacdClientContent.includes(newConnect)) {
   } else if (guacdClientContent.includes(oldConnect)) {
     guacdClientContent = guacdClientContent.replace(oldConnect, newConnect);
   } else {
-    console.log(
-      "[patch-guacamole-lite] Connect target not found, skipping name patch",
-    );
-    process.exit(0);
+    missingAnchor("Connect");
   }
   patched = true;
 }
 
 if (!guacdClientContent.includes("this.nextArgumentStreamIndex = 0;")) {
   if (!guacdClientContent.includes(oldSendBuffer)) {
-    console.log(
-      "[patch-guacamole-lite] Argument stream index target not found, skipping",
-    );
-    process.exit(0);
+    missingAnchor("Argument stream index");
   }
   guacdClientContent = guacdClientContent.replace(oldSendBuffer, newSendBuffer);
   patched = true;
@@ -201,10 +205,7 @@ if (!guacdClientContent.includes("this.nextArgumentStreamIndex = 0;")) {
 
 if (!guacdClientContent.includes("sendRequiredArguments(params) {")) {
   if (!guacdClientContent.includes(oldSendInstructionBlock)) {
-    console.log(
-      "[patch-guacamole-lite] Required argument helper target not found, skipping",
-    );
-    process.exit(0);
+    missingAnchor("Required argument helper");
   }
   guacdClientContent = guacdClientContent.replace(
     oldSendInstructionBlock,
@@ -217,10 +218,7 @@ if (
   !guacdClientContent.includes("opcode === 'required' || opcode === 'require'")
 ) {
   if (!guacdClientContent.includes(oldReadyHandler)) {
-    console.log(
-      "[patch-guacamole-lite] Required opcode target not found, skipping",
-    );
-    process.exit(0);
+    missingAnchor("Required opcode");
   }
   guacdClientContent = guacdClientContent.replace(
     oldReadyHandler,
@@ -273,10 +271,7 @@ if (!cryptContent.includes(newDecryptBlock)) {
       newDecryptBlock,
     );
   } else {
-    console.log(
-      "[patch-guacamole-lite] UTF-8 token decrypt target not found, skipping",
-    );
-    process.exit(0);
+    missingAnchor("UTF-8 token decrypt");
   }
   patched = true;
 }
@@ -329,10 +324,7 @@ const newSendMessageToGuacd =
 
 if (!clientConnectionContent.includes("isReadOnlyJoin()")) {
   if (!clientConnectionContent.includes(oldSendMessageToGuacd)) {
-    console.log(
-      "[patch-guacamole-lite] sendMessageToGuacd target not found, skipping read-only patch",
-    );
-    process.exit(0);
+    missingAnchor("sendMessageToGuacd");
   }
   clientConnectionContent = clientConnectionContent.replace(
     oldSendMessageToGuacd,
@@ -357,10 +349,7 @@ const newPreserveJoin =
 
 if (!clientConnectionContent.includes("compiledSettings.readOnly")) {
   if (!clientConnectionContent.includes(oldPreserveJoin)) {
-    console.log(
-      "[patch-guacamole-lite] join-preserve target not found, skipping readOnly propagation patch",
-    );
-    process.exit(0);
+    missingAnchor("join-preserve");
   }
   clientConnectionContent = clientConnectionContent.replace(
     oldPreserveJoin,


### PR DESCRIPTION
## Summary

- replace the nine `console.log` + `process.exit(0)` bail-outs with a `missingAnchor()` helper that exits non-zero and names the patch
- net -11 lines

Each patch in `scripts/patch-guacamole-lite.cjs` gives up like this when its
anchor string is not found:

```js
console.log("[patch-guacamole-lite] Timezone target not found, skipping");
process.exit(0);
```

`fs.writeFileSync` runs at the end of the file, so one moved anchor discards
**all** patches, exits 0, and postinstall reports success. Termix then builds and
runs normally and drops VNC/RDP sessions at runtime, with nothing anywhere
pointing back at the patch step.

Every patch here is load-bearing — protocol negotiation, the guacd 1.6.0 `name`
handshake, dynamic argument answering, UTF-8 token decryption, read-only join
filtering — so a missing anchor is a build failure, not something to skip.

```
[patch-guacamole-lite] Argument stream index anchor not found in guacamole-lite.
The upstream file has changed and this patch no longer applies — update
scripts/patch-guacamole-lite.cjs to match the new source.
exit=1
```

**This makes `npm install` fail after a guacamole-lite bump that moves an
anchor**, which is the intent: the alternative is shipping a build that is quietly
missing the patches. Dependabot opening such a bump will now fail its install
rather than go green.

Behaviour that is deliberately unchanged: a missing guacamole-lite still skips
quietly (`exit 0`), and an already-patched tree still exits 0.

## Validation

Ran against the real `node_modules`:

- already-patched tree → `Already patched`, `exit=0`
- reverted one patch and moved its anchor (simulating an upstream rewrite) → `exit=1` with the message above, and the file was not left half-written, since the bail-out precedes the write-back
- restored → `Already patched`, `exit=0`
- `npm test -- --run scripts/patch-guacamole-lite.test.ts` (4 passed)
- `npm test` (153 files, 1074 passed, 1 skipped — fully green)
- `npm run lint` (0 errors; 44 existing warnings only)
- `npx prettier --check`

## Scope

Only `patch-guacamole-lite.cjs`. The other five patch scripts use the same
`exit(0)`-on-missing shape, but some of their skips may be legitimate — a
platform-conditional `better-sqlite3` or `nan` patch is not the same thing as a
mandatory protocol fix — and I have not verified each one's semantics. Worth a
look, but not something to sweep into this PR blind.

## Background

This surfaced while investigating a failing test in #1125: my `node_modules` had
patches 2, 4 and 5 applied but not 3, so guacd 1.6.0 VNC drops were not actually
being fixed locally, and `patch-guacamole-lite.test.ts` was correctly reporting
it. That particular state came from the script gaining patch 3 without a
reinstall, not from this bail-out path — but it is the same failure mode, and it
took a while to notice precisely because nothing had complained.