### PR TITLE
Audit the remaining remote access paths

### DIFF
--- a/src/backend/database/routes/credentials.ts
+++ b/src/backend/database/routes/credentials.ts
@@ -6,12 +6,15 @@ import { AuthManager } from "../../utils/auth-manager.js";
 import { parseSSHKey } from "../../utils/ssh-key-utils.js";
 import { registerCredentialKeyRoutes } from "./credential-key-routes.js";
 import { registerCredentialDeployRoutes } from "./credential-deploy-routes.js";
-import { logAudit, getRequestMeta } from "../../utils/audit-logger.js";
+import {
+  logAudit,
+  getAuditUsername,
+  getRequestMeta,
+} from "../../utils/audit-logger.js";
 import {
   createCurrentCredentialRepository,
   createCurrentHostResolutionRepository,
   createCurrentHostRepository,
-  createCurrentUserRepository,
   createCurrentSyncTombstoneRepository,
 } from "../repositories/factory.js";
 
@@ -24,11 +27,6 @@ function isNonEmptyString(val: unknown): val is string {
 const authManager = AuthManager.getInstance();
 const authenticateJWT = authManager.createAuthMiddleware();
 const requireDataAccess = authManager.createDataAccessMiddleware();
-
-async function getAuditUsername(userId: string): Promise<string> {
-  const actor = await createCurrentUserRepository().findById(userId);
-  return actor?.username ?? userId;
-}
 
 /**
  * @openapi

--- a/src/backend/database/routes/host.ts
+++ b/src/backend/database/routes/host.ts
@@ -47,18 +47,17 @@ import {
   applyHostEnrollmentDefaults,
   requireHostEnrollmentAccessForPath,
 } from "./host-enrollment-auth.js";
-import { logAudit, getRequestMeta } from "../../utils/audit-logger.js";
+import {
+  logAudit,
+  getAuditUsername,
+  getRequestMeta,
+} from "../../utils/audit-logger.js";
 
 const router = express.Router();
 
 const upload = multer({ storage: multer.memoryStorage() });
 
 const STATS_SERVER_URL = "http://localhost:30005";
-
-async function getAuditUsername(userId: string): Promise<string> {
-  const actor = await createCurrentUserRepository().findById(userId);
-  return actor?.username ?? userId;
-}
 
 function notifyStatsHostUpdated(
   hostId: number,

--- a/src/backend/hosts/docker/routes.ts
+++ b/src/backend/hosts/docker/routes.ts
@@ -3,6 +3,11 @@ import axios from "axios";
 import { Client as SSHClient } from "ssh2";
 import { logger } from "../../utils/logger.js";
 import {
+  logAudit,
+  getAuditUsername,
+  getRequestMeta,
+} from "../../utils/audit-logger.js";
+import {
   createCurrentCredentialRepository,
   createCurrentHostRepository,
   createCurrentHostResolutionRepository,
@@ -590,6 +595,20 @@ export function registerDockerSshRoutes(app: express.Express): void {
             stream.stderr.on("data", () => {});
           }
         });
+
+        void (async () => {
+          const { ipAddress, userAgent } = getRequestMeta(req);
+          await logAudit({
+            userId,
+            username: await getAuditUsername(userId),
+            action: "docker_connect",
+            resourceType: "host",
+            resourceId: hostId ? String(hostId) : undefined,
+            ipAddress,
+            userAgent,
+            success: true,
+          });
+        })();
 
         res.json({
           success: true,

--- a/src/backend/hosts/file-manager/index.ts
+++ b/src/backend/hosts/file-manager/index.ts
@@ -1,4 +1,9 @@
 import express from "express";
+import {
+  logAudit,
+  getAuditUsername,
+  getRequestMeta,
+} from "../../utils/audit-logger.js";
 import { createCorsMiddleware } from "../../utils/cors-config.js";
 import cookieParser from "cookie-parser";
 import axios from "axios";
@@ -1165,6 +1170,24 @@ app.post("/ssh/file_manager/ssh/connect", async (req, res) => {
       scpLegacy: resolvedScpLegacy,
     };
     scheduleSessionCleanup(sessionId);
+
+    if (userId) {
+      const { ipAddress, userAgent } = getRequestMeta(req);
+      void (async () => {
+        await logAudit({
+          userId,
+          username: await getAuditUsername(userId),
+          action: "file_manager_connect",
+          resourceType: "host",
+          resourceId: hostId ? String(hostId) : undefined,
+          resourceName: `${username}@${ip}:${port}`,
+          ipAddress,
+          userAgent,
+          success: true,
+        });
+      })();
+    }
+
     res.json({
       status: "success",
       message: "SSH connection established",

--- a/src/backend/hosts/guacamole/routes.ts
+++ b/src/backend/hosts/guacamole/routes.ts
@@ -15,6 +15,11 @@ import {
 import { resolveGuacdOptions } from "../../utils/guacd-config.js";
 import { createJumpHostChain } from "../jump-host-chain.js";
 import { waitForGuacdOpen } from "./guacamole-server.js";
+import {
+  logAudit,
+  getAuditUsername,
+  getRequestMeta,
+} from "../../utils/audit-logger.js";
 import { resolveJumpTunnelEndpoint } from "./jump-tunnel-endpoint.js";
 
 const router = express.Router();
@@ -667,6 +672,19 @@ router.post(
       }
 
       const sessionInfo = await waitForGuacdOpen(termixConnectId, 10000);
+
+      const { ipAddress, userAgent } = getRequestMeta(req);
+      await logAudit({
+        userId,
+        username: await getAuditUsername(userId),
+        action: `${connectionType}_connect`,
+        resourceType: "host",
+        resourceId: String(hostId),
+        resourceName: `${hostname}:${port}`,
+        ipAddress,
+        userAgent,
+        success: true,
+      });
 
       res.json({
         token,

--- a/src/backend/hosts/tunnel/routes.ts
+++ b/src/backend/hosts/tunnel/routes.ts
@@ -7,6 +7,11 @@ import type {
   AuthenticatedRequest,
 } from "../../../types/index.js";
 import { CONNECTION_STATES } from "../../../types/index.js";
+import {
+  logAudit,
+  getAuditUsername,
+  getRequestMeta,
+} from "../../utils/audit-logger.js";
 import { tunnelLogger } from "../../utils/logger.js";
 import { SystemCrypto } from "../../utils/system-crypto.js";
 import { AuthManager } from "../../utils/auth-manager.js";
@@ -362,6 +367,26 @@ export function registerTunnelRoutes(app: express.Express): void {
         })();
 
         pendingTunnelOperations.set(tunnelName, operation);
+
+        const { ipAddress, userAgent } = getRequestMeta(req);
+        await logAudit({
+          userId,
+          username: await getAuditUsername(userId),
+          action: "tunnel_connect",
+          resourceType: "tunnel",
+          resourceId: tunnelConfig.sourceHostId
+            ? String(tunnelConfig.sourceHostId)
+            : undefined,
+          resourceName: tunnelName,
+          details: JSON.stringify({
+            endpointHost: tunnelConfig.endpointHost,
+            endpointPort: tunnelConfig.endpointPort,
+            sourcePort: tunnelConfig.sourcePort,
+          }),
+          ipAddress,
+          userAgent,
+          success: true,
+        });
 
         res.json({ message: "Connection request received", tunnelName });
 

--- a/src/backend/tests/utils/audit-username.test.ts
+++ b/src/backend/tests/utils/audit-username.test.ts
@@ -1,0 +1,57 @@
+import { describe, expect, it, vi, beforeEach } from "vitest";
+
+const findById = vi.hoisted(() => vi.fn());
+
+vi.mock("../../database/repositories/factory.js", () => ({
+  createCurrentAuditLogRepository: () => ({ create: vi.fn() }),
+  createCurrentUserRepository: () => ({ findById }),
+}));
+
+const { getAuditUsername, getRequestMeta } =
+  await import("../../utils/audit-logger.js");
+
+beforeEach(() => findById.mockReset());
+
+describe("getAuditUsername", () => {
+  it("resolves the username to store alongside the entry", async () => {
+    findById.mockResolvedValueOnce({ id: "u-1", username: "alice" });
+
+    await expect(getAuditUsername("u-1")).resolves.toBe("alice");
+  });
+
+  it("falls back to the id for an account that no longer exists", async () => {
+    findById.mockResolvedValueOnce(undefined);
+
+    await expect(getAuditUsername("u-gone")).resolves.toBe("u-gone");
+  });
+
+  it("never throws, so it cannot break the operation being audited", async () => {
+    findById.mockRejectedValueOnce(new Error("database unavailable"));
+
+    await expect(getAuditUsername("u-1")).resolves.toBe("u-1");
+  });
+});
+
+describe("getRequestMeta", () => {
+  it("prefers the first x-forwarded-for hop", () => {
+    const meta = getRequestMeta({
+      headers: {
+        "x-forwarded-for": "203.0.113.9, 10.0.0.1",
+        "user-agent": "Mozilla/5.0",
+      },
+      ip: "10.0.0.1",
+    } as never);
+
+    expect(meta).toEqual({
+      ipAddress: "203.0.113.9",
+      userAgent: "Mozilla/5.0",
+    });
+  });
+
+  it("falls back to the socket address", () => {
+    const meta = getRequestMeta({ headers: {}, ip: "192.0.2.5" } as never);
+
+    expect(meta.ipAddress).toBe("192.0.2.5");
+    expect(meta.userAgent).toBe("");
+  });
+});

--- a/src/backend/utils/audit-logger.ts
+++ b/src/backend/utils/audit-logger.ts
@@ -1,5 +1,21 @@
 import type { Request } from "express";
-import { createCurrentAuditLogRepository } from "../database/repositories/factory.js";
+import {
+  createCurrentAuditLogRepository,
+  createCurrentUserRepository,
+} from "../database/repositories/factory.js";
+
+/**
+ * Resolves the display name to store alongside the entry. It is denormalised on
+ * purpose: the record has to stay readable after the account is gone.
+ */
+export async function getAuditUsername(userId: string): Promise<string> {
+  try {
+    const actor = await createCurrentUserRepository().findById(userId);
+    return actor?.username ?? userId;
+  } catch {
+    return userId;
+  }
+}
 
 export interface AuditLogParams {
   userId: string;


### PR DESCRIPTION
## Summary

- write an audit entry when a file manager, RDP/VNC/Telnet, Docker or SSH tunnel session is established
- move `getAuditUsername` next to `logAudit`, replacing two identical copies

## The gap

`logAudit` is called in 54 places, covering hosts, credentials, snippets, users,
sessions and API keys. But of the modules that actually reach a remote machine:

| Module | Audit entries before |
|---|---|
| `terminal/` | 1 (`ssh_connect`) |
| `file-manager/` | **0** |
| `guacamole/` | **0** |
| `tunnel/` | **0** |
| `docker/` | **0** |

So opening a file manager session, a remote desktop, a Docker session or a
tunnel left no trace — which is most of the ways data leaves a host or a
foothold gets established. A tunnel in particular is the one action whose whole
purpose is to reach something that was not directly reachable.

## What is recorded

Each connect point now mirrors the existing `ssh_connect`: actor, host, IP and
user agent.

| Action | Resource | Extra |
|---|---|---|
| `file_manager_connect` | host | `user@ip:port` |
| `rdp_connect` / `vnc_connect` / `telnet_connect` | host | `hostname:port` |
| `docker_connect` | host | — |
| `tunnel_connect` | tunnel | endpoint host/port and forwarded local port |

The guacamole action is derived from the connection type, so the three protocols
are distinguishable without a separate resource field.

Writes are fire-and-forget: `logAudit` already swallows its own errors so it can
never break the caller, and this keeps it off the connection path entirely.

## Scope

Session *establishment* only. Per-operation auditing inside a session — file
downloads, deletions, container start/stop/exec — is a larger design question
(volume, and where to draw the line on a file listing) and is not attempted
here. This covers the access events, which is what an offboarding or incident
review starts from.

## Validation

- new `audit-username.test.ts` — resolution, fallback for a deleted account, and that a repository failure still cannot throw into the audited operation; plus `getRequestMeta` x-forwarded-for handling
- `npm test` — 172 files, 1175 passed, 1 skipped
- `npm run build`, `npm run lint` (0 errors, 44 existing warnings)

Note for reviewers: `npm run type-check` uses the app tsconfig and does not cover
`src/backend`, so a non-async handler here only surfaced under `npm run build`.
Worth running both on backend changes.