### PR TITLE
Load the database file when file encryption is disabled

### DIFF
--- a/src/backend/database/db/index.ts
+++ b/src/backend/database/db/index.ts
@@ -156,8 +156,34 @@ async function initializeDatabaseAsync(): Promise<void> {
     }
   } else {
     assertDataDirIsNotMisconfigured(dataDir);
-    memoryDatabase = new Database(":memory:");
-    isNewDatabase = true;
+
+    // The database still lives in memory and is serialised out on every write;
+    // turning encryption off only changes whether that file is ciphertext. It
+    // has to be read back, or each restart starts empty and silently discards
+    // everything the previous run saved.
+    const existing = readPlainDatabaseFile();
+    if (existing) {
+      memoryDatabase = new Database(existing);
+      databaseLogger.info("Loaded unencrypted database from disk", {
+        operation: "db_load_plain",
+        path: dbPath,
+        bytes: existing.length,
+      });
+    } else {
+      memoryDatabase = new Database(":memory:");
+      isNewDatabase = true;
+    }
+  }
+}
+
+/** The plain database file, or null when there is nothing to restore. */
+function readPlainDatabaseFile(): Buffer | null {
+  try {
+    const contents = fs.readFileSync(dbPath);
+    return contents.length > 0 ? contents : null;
+  } catch (error) {
+    if ((error as NodeJS.ErrnoException).code === "ENOENT") return null;
+    throw error;
   }
 }
 

--- a/src/backend/tests/database/db/unencrypted-persistence.test.ts
+++ b/src/backend/tests/database/db/unencrypted-persistence.test.ts
@@ -1,0 +1,80 @@
+import fs from "fs";
+import os from "os";
+import path from "path";
+import Database from "better-sqlite3";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+/**
+ * `DB_FILE_ENCRYPTION=false` used to mean "start empty, every time".
+ *
+ * The database lives in memory on every backend and is serialised to disk after
+ * writes; the flag only decides whether that file is ciphertext. The plain
+ * branch wrote `db.sqlite` faithfully and then never read it back, so each
+ * restart began with an empty database and silently discarded everything the
+ * previous run had saved. The data-dir guard made it worse by confirming a
+ * database was present in DATA_DIR immediately before it was thrown away.
+ */
+describe("unencrypted database persistence", () => {
+  let dataDir: string;
+
+  beforeEach(() => {
+    dataDir = fs.mkdtempSync(path.join(os.tmpdir(), "termix-plain-db-"));
+    vi.resetModules();
+    process.env.DATA_DIR = dataDir;
+    process.env.DB_FILE_ENCRYPTION = "false";
+    process.env.ALLOW_EMPTY_DATA_DIR = "true";
+  });
+
+  afterEach(() => {
+    delete process.env.DATA_DIR;
+    delete process.env.DB_FILE_ENCRYPTION;
+    delete process.env.ALLOW_EMPTY_DATA_DIR;
+    fs.rmSync(dataDir, { recursive: true, force: true });
+  });
+
+  /** A database file with one row, as a previous run would have left it. */
+  function writeExistingDatabase(): void {
+    const seed = new Database(":memory:");
+    seed.exec("CREATE TABLE settings (key TEXT PRIMARY KEY, value TEXT)");
+    seed
+      .prepare("INSERT INTO settings (key, value) VALUES (?, ?)")
+      .run("survives_restart", "yes");
+    fs.writeFileSync(path.join(dataDir, "db.sqlite"), seed.serialize());
+    seed.close();
+  }
+
+  it("reads back what an earlier run wrote", async () => {
+    writeExistingDatabase();
+
+    const db = await import("../../../database/db/index.js");
+    await db.initializeDatabase();
+
+    const row = db
+      .getSqlite()
+      .prepare("SELECT value FROM settings WHERE key = ?")
+      .get("survives_restart") as { value: string } | undefined;
+
+    expect(row?.value).toBe("yes");
+  });
+
+  it("starts empty when there is no file yet", async () => {
+    const db = await import("../../../database/db/index.js");
+    await db.initializeDatabase();
+
+    // Startup creates its own tables; the point is that it does not throw on a
+    // missing file and does not carry rows over from nowhere.
+    const row = db
+      .getSqlite()
+      .prepare("SELECT COUNT(*) AS count FROM users")
+      .get() as { count: number };
+
+    expect(row.count).toBe(0);
+  });
+
+  it("ignores a zero-length file rather than failing to open it", async () => {
+    fs.writeFileSync(path.join(dataDir, "db.sqlite"), "");
+
+    const db = await import("../../../database/db/index.js");
+    await expect(db.initializeDatabase()).resolves.not.toThrow();
+  });
+});


### PR DESCRIPTION
`DB_FILE_ENCRYPTION=false` meant "start empty, every time".

## What happens

The database lives in memory on every configuration and is serialised to disk after writes. The flag only decides whether that file is ciphertext.

The plain branch wrote `db.sqlite` faithfully — and never read it back:

```ts
} else {
  assertDataDirIsNotMisconfigured(dataDir);
  memoryDatabase = new Database(":memory:");
  isNewDatabase = true;
}
```

So every restart began with an empty database and silently discarded everything the previous run had saved. Hosts, credentials, snippets, users — all of it, on every restart, with no error.

## Why it stayed hidden

Nothing fails. The write path works, the file grows, the guard is happy. The only symptom is that the application is empty after a restart, which reads like "it never saved" rather than "it saved and then ignored the file".

The data-dir guard makes it sharper than it first looks. `hasDatabaseFile()` already recognises a plain `db.sqlite`:

```ts
try {
  return fs.statSync(dbPath).size > 0;
} catch {
  return false;
}
```

So on a restart the guard confirmed a database was present in `DATA_DIR` — and the loader threw it away on the next line.

Encrypted deployments, which is the default, were never affected: that branch decrypts the file into the in-memory database as intended.

## The fix

Read the file back, the same way the encrypted branch does:

```ts
const existing = readPlainDatabaseFile();
if (existing) {
  memoryDatabase = new Database(existing);
  ...
} else {
  memoryDatabase = new Database(":memory:");
  isNewDatabase = true;
}
```

`readPlainDatabaseFile()` returns null for a missing file and for a zero-length one — a truncated file should mean "start fresh", not "fail to open".

A log line records the restore, because a database appearing from disk should be visible in the startup log rather than inferred.

## Tests

`unencrypted-persistence.test.ts`, three cases: an earlier run's data is read back, a missing file starts empty, a zero-length file does not break startup.

I checked the first one actually catches the bug by reverting the fix and watching it fail:

```
× reads back what an earlier run wrote
AssertionError: expected undefined to be 'yes'
```

## Scope

30 lines in `db/index.ts` plus the test. No schema change, no change to the encrypted path, no change to the write path.

Found while working on the multi-backend branch (#1134), unrelated to it, and split out so it can go in on its own.

**180 test files, 1243 passed, 1 skipped.** Lint clean, build clean, format clean.
