### PR TITLE
fix: compare sync cursors independently of timestamp layout

### DIFF
--- a/src/backend/database/repositories/sync-tombstone-repository.ts
+++ b/src/backend/database/repositories/sync-tombstone-repository.ts
@@ -1,5 +1,6 @@
-import { and, eq, gt } from "drizzle-orm";
+import { and, eq } from "drizzle-orm";
 import { syncTombstones } from "../db/schema.js";
+import { timestampAtOrAfter } from "../sync-timestamp.js";
 import type { DatabaseContext } from "./database-context.js";
 
 export type SyncTombstoneRecord = typeof syncTombstones.$inferSelect;
@@ -57,7 +58,8 @@ export class SyncTombstoneRepository {
       eq(syncTombstones.userId, userId),
       eq(syncTombstones.entityType, entityType),
     ];
-    if (since) conditions.push(gt(syncTombstones.deletedAt, since));
+    if (since)
+      conditions.push(timestampAtOrAfter(syncTombstones.deletedAt, since));
 
     return this.context.drizzle
       .select()

--- a/src/backend/database/routes/sync.ts
+++ b/src/backend/database/routes/sync.ts
@@ -1,6 +1,6 @@
 import type { Request, Response } from "express";
 import express from "express";
-import { and, eq, gt } from "drizzle-orm";
+import { and, eq } from "drizzle-orm";
 import {
   hosts,
   sshCredentials,
@@ -27,6 +27,7 @@ import {
   serializeSyncReferences,
   type SyncReferenceEntity,
 } from "./sync-references.js";
+import { timestampAtOrAfter } from "../sync-timestamp.js";
 
 const router = express.Router();
 const authManager = AuthManager.getInstance();
@@ -232,7 +233,9 @@ router.get(
       const context = createCurrentRepositoryContext();
       const conditions = [eq(table.userId, userId)];
       if (since && "updatedAt" in table) {
-        conditions.push(gt((table as typeof hosts).updatedAt, since));
+        conditions.push(
+          timestampAtOrAfter((table as typeof hosts).updatedAt, since),
+        );
       }
 
       const rows = await context.drizzle

--- a/src/backend/database/sync-timestamp.ts
+++ b/src/backend/database/sync-timestamp.ts
@@ -1,0 +1,35 @@
+import { sql, type SQLWrapper } from "drizzle-orm";
+
+/**
+ * Sync cursors and stored timestamps do not share a layout.
+ *
+ * `updated_at` and `deleted_at` are TEXT columns written both by
+ * `default(sql`CURRENT_TIMESTAMP`)` ("2026-07-29 10:11:21") and by
+ * `new Date().toISOString()` ("2026-07-29T10:11:21.123Z"), while the desktop
+ * sync engine always sends the ISO form as `since`. Comparing those as text is
+ * decided at position 10, where ' ' (0x20) sorts below 'T' (0x54), so the
+ * answer depends on which writer produced the row rather than on when it was
+ * written -- and `column > :isoCursor` is false for every row stored in the
+ * CURRENT_TIMESTAMP form, however new it is.
+ *
+ * Both layouts share a prefix once the separator is levelled, so comparing
+ * "YYYY-MM-DD HH:MM:SS" on both sides is layout-independent. `replace` and
+ * `substr` are used rather than `datetime()` to keep the expression portable
+ * across engines.
+ */
+export const CANONICAL_TIMESTAMP_LENGTH = 19;
+
+export function normalizeSyncTimestamp(value: string): string {
+  return value.replace("T", " ").slice(0, CANONICAL_TIMESTAMP_LENGTH);
+}
+
+/**
+ * `>=` rather than `>`: normalising truncates sub-second precision, so a strict
+ * comparison would permanently skip rows written in the same second as the
+ * cursor. Re-sending that boundary second costs nothing -- the sync engine only
+ * pushes a row when one side is strictly newer, so rows equal on both sides are
+ * a no-op.
+ */
+export function timestampAtOrAfter(column: SQLWrapper, since: string) {
+  return sql`substr(replace(${column}, 'T', ' '), 1, ${CANONICAL_TIMESTAMP_LENGTH}) >= ${normalizeSyncTimestamp(since)}`;
+}

--- a/src/backend/tests/database/repositories/sync-tombstone-since.test.ts
+++ b/src/backend/tests/database/repositories/sync-tombstone-since.test.ts
@@ -1,0 +1,135 @@
+import { afterEach, describe, expect, it } from "vitest";
+import { TestSqliteDatabase } from "./test-support.js";
+import { SyncTombstoneRepository } from "../../../database/repositories/sync-tombstone-repository.js";
+import {
+  normalizeSyncTimestamp,
+  timestampAtOrAfter,
+} from "../../../database/sync-timestamp.js";
+import { sshCredentials } from "../../../database/db/schema.js";
+import { and, eq } from "drizzle-orm";
+
+// The desktop sync engine always sends its cursor as new Date().toISOString().
+const ISO_CURSOR = "2026-07-29T09:00:00.000Z";
+
+describe("sync cursors across timestamp layouts", () => {
+  let adapter: TestSqliteDatabase | null = null;
+
+  afterEach(async () => {
+    if (adapter) {
+      await adapter.close();
+      adapter = null;
+    }
+  });
+
+  async function connect(): Promise<TestSqliteDatabase> {
+    adapter = new TestSqliteDatabase();
+    await adapter.connect();
+    return adapter;
+  }
+
+  it("normalizes both layouts to one comparable form", () => {
+    expect(normalizeSyncTimestamp("2026-07-29T10:11:21.123Z")).toBe(
+      "2026-07-29 10:11:21",
+    );
+    expect(normalizeSyncTimestamp("2026-07-29 10:11:21")).toBe(
+      "2026-07-29 10:11:21",
+    );
+  });
+
+  it("returns tombstones recorded after an ISO cursor, whatever layout they were stored in", async () => {
+    const db = await connect();
+    const context = await db.connect();
+    db.exec(`
+      CREATE TABLE sync_tombstones (
+        id INTEGER PRIMARY KEY AUTOINCREMENT,
+        user_id TEXT NOT NULL,
+        entity_type TEXT NOT NULL,
+        sync_id TEXT NOT NULL,
+        deleted_at TEXT NOT NULL DEFAULT CURRENT_TIMESTAMP
+      );
+
+      INSERT INTO sync_tombstones (user_id, entity_type, sync_id, deleted_at) VALUES
+        ('user-1', 'sshCredentials', 'sqlite-layout', '2026-07-29 10:07:32'),
+        ('user-1', 'sshCredentials', 'iso-layout',    '2026-07-29T10:07:32.500Z'),
+        ('user-1', 'sshCredentials', 'too-old',       '2026-07-29 08:00:00');
+    `);
+
+    const repo = new SyncTombstoneRepository(context);
+    const rows = await repo.listSince("user-1", "sshCredentials", ISO_CURSOR);
+
+    expect(rows.map((row) => row.syncId).sort()).toEqual([
+      "iso-layout",
+      "sqlite-layout",
+    ]);
+  });
+
+  it("returns rows written by CURRENT_TIMESTAMP against an ISO cursor", async () => {
+    const db = await connect();
+    const context = await db.connect();
+    db.exec(`
+      CREATE TABLE ssh_credentials (
+        id INTEGER PRIMARY KEY AUTOINCREMENT,
+        user_id TEXT NOT NULL,
+        name TEXT NOT NULL,
+        description TEXT,
+        folder TEXT,
+        tags TEXT,
+        auth_type TEXT NOT NULL DEFAULT 'password',
+        username TEXT NOT NULL DEFAULT 'root',
+        sync_id TEXT,
+        created_at TEXT NOT NULL DEFAULT CURRENT_TIMESTAMP,
+        updated_at TEXT NOT NULL DEFAULT CURRENT_TIMESTAMP
+      );
+
+      INSERT INTO ssh_credentials (user_id, name, updated_at) VALUES
+        ('user-1', 'newer-sqlite-layout', '2026-07-29 10:11:21'),
+        ('user-1', 'newer-iso-layout',    '2026-07-29T10:11:21.123Z'),
+        ('user-1', 'older',               '2026-07-29 08:59:59');
+    `);
+
+    const rows = await context.drizzle
+      .select({ name: sshCredentials.name })
+      .from(sshCredentials)
+      .where(
+        and(
+          eq(sshCredentials.userId, "user-1"),
+          timestampAtOrAfter(sshCredentials.updatedAt, ISO_CURSOR),
+        ),
+      );
+
+    expect(rows.map((row) => row.name).sort()).toEqual([
+      "newer-iso-layout",
+      "newer-sqlite-layout",
+    ]);
+  });
+
+  it("keeps rows written in the same second as the cursor", async () => {
+    const db = await connect();
+    const context = await db.connect();
+    db.exec(`
+      CREATE TABLE ssh_credentials (
+        id INTEGER PRIMARY KEY AUTOINCREMENT,
+        user_id TEXT NOT NULL,
+        name TEXT NOT NULL,
+        description TEXT,
+        folder TEXT,
+        tags TEXT,
+        auth_type TEXT NOT NULL DEFAULT 'password',
+        username TEXT NOT NULL DEFAULT 'root',
+        sync_id TEXT,
+        created_at TEXT NOT NULL DEFAULT CURRENT_TIMESTAMP,
+        updated_at TEXT NOT NULL DEFAULT CURRENT_TIMESTAMP
+      );
+
+      INSERT INTO ssh_credentials (user_id, name, updated_at)
+      VALUES ('user-1', 'same-second', '2026-07-29 09:00:00');
+    `);
+
+    const rows = await context.drizzle
+      .select({ name: sshCredentials.name })
+      .from(sshCredentials)
+      .where(timestampAtOrAfter(sshCredentials.updatedAt, ISO_CURSOR));
+
+    expect(rows.map((row) => row.name)).toEqual(["same-second"]);
+  });
+});

--- a/src/backend/tests/database/repositories/sync-tombstone-since.test.ts
+++ b/src/backend/tests/database/repositories/sync-tombstone-since.test.ts
@@ -6,6 +6,7 @@ import {
   timestampAtOrAfter,
 } from "../../../database/sync-timestamp.js";
 import { sshCredentials } from "../../../database/db/schema.js";
+import type { DatabaseContext } from "../../../database/repositories/database-context.js";
 import { and, eq } from "drizzle-orm";
 
 // The desktop sync engine always sends its cursor as new Date().toISOString().
@@ -21,10 +22,24 @@ describe("sync cursors across timestamp layouts", () => {
     }
   });
 
-  async function connect(): Promise<TestSqliteDatabase> {
-    adapter = new TestSqliteDatabase();
-    await adapter.connect();
-    return adapter;
+  /**
+   * The harness migrates the schema itself, so the seeds below are INSERTs into
+   * the real tables. Both `sync_tombstones.user_id` and `ssh_credentials.user_id`
+   * are foreign keys into `users`, which the harness enforces, so the owning row
+   * has to exist before either seed runs.
+   */
+  async function connect(): Promise<{
+    db: TestSqliteDatabase;
+    context: DatabaseContext;
+  }> {
+    const db = new TestSqliteDatabase();
+    adapter = db;
+    const context = await db.connect();
+    await db.exec(`
+      INSERT INTO users (id, username, password_hash) VALUES
+        ('user-1', 'user', 'hash');
+    `);
+    return { db, context };
   }
 
   it("normalizes both layouts to one comparable form", () => {
@@ -37,17 +52,8 @@ describe("sync cursors across timestamp layouts", () => {
   });
 
   it("returns tombstones recorded after an ISO cursor, whatever layout they were stored in", async () => {
-    const db = await connect();
-    const context = await db.connect();
-    db.exec(`
-      CREATE TABLE sync_tombstones (
-        id INTEGER PRIMARY KEY AUTOINCREMENT,
-        user_id TEXT NOT NULL,
-        entity_type TEXT NOT NULL,
-        sync_id TEXT NOT NULL,
-        deleted_at TEXT NOT NULL DEFAULT CURRENT_TIMESTAMP
-      );
-
+    const { db, context } = await connect();
+    await db.exec(`
       INSERT INTO sync_tombstones (user_id, entity_type, sync_id, deleted_at) VALUES
         ('user-1', 'sshCredentials', 'sqlite-layout', '2026-07-29 10:07:32'),
         ('user-1', 'sshCredentials', 'iso-layout',    '2026-07-29T10:07:32.500Z'),
@@ -64,27 +70,12 @@ describe("sync cursors across timestamp layouts", () => {
   });
 
   it("returns rows written by CURRENT_TIMESTAMP against an ISO cursor", async () => {
-    const db = await connect();
-    const context = await db.connect();
-    db.exec(`
-      CREATE TABLE ssh_credentials (
-        id INTEGER PRIMARY KEY AUTOINCREMENT,
-        user_id TEXT NOT NULL,
-        name TEXT NOT NULL,
-        description TEXT,
-        folder TEXT,
-        tags TEXT,
-        auth_type TEXT NOT NULL DEFAULT 'password',
-        username TEXT NOT NULL DEFAULT 'root',
-        sync_id TEXT,
-        created_at TEXT NOT NULL DEFAULT CURRENT_TIMESTAMP,
-        updated_at TEXT NOT NULL DEFAULT CURRENT_TIMESTAMP
-      );
-
-      INSERT INTO ssh_credentials (user_id, name, updated_at) VALUES
-        ('user-1', 'newer-sqlite-layout', '2026-07-29 10:11:21'),
-        ('user-1', 'newer-iso-layout',    '2026-07-29T10:11:21.123Z'),
-        ('user-1', 'older',               '2026-07-29 08:59:59');
+    const { db, context } = await connect();
+    await db.exec(`
+      INSERT INTO ssh_credentials (user_id, name, auth_type, updated_at) VALUES
+        ('user-1', 'newer-sqlite-layout', 'password', '2026-07-29 10:11:21'),
+        ('user-1', 'newer-iso-layout',    'password', '2026-07-29T10:11:21.123Z'),
+        ('user-1', 'older',               'password', '2026-07-29 08:59:59');
     `);
 
     const rows = await context.drizzle
@@ -104,25 +95,10 @@ describe("sync cursors across timestamp layouts", () => {
   });
 
   it("keeps rows written in the same second as the cursor", async () => {
-    const db = await connect();
-    const context = await db.connect();
-    db.exec(`
-      CREATE TABLE ssh_credentials (
-        id INTEGER PRIMARY KEY AUTOINCREMENT,
-        user_id TEXT NOT NULL,
-        name TEXT NOT NULL,
-        description TEXT,
-        folder TEXT,
-        tags TEXT,
-        auth_type TEXT NOT NULL DEFAULT 'password',
-        username TEXT NOT NULL DEFAULT 'root',
-        sync_id TEXT,
-        created_at TEXT NOT NULL DEFAULT CURRENT_TIMESTAMP,
-        updated_at TEXT NOT NULL DEFAULT CURRENT_TIMESTAMP
-      );
-
-      INSERT INTO ssh_credentials (user_id, name, updated_at)
-      VALUES ('user-1', 'same-second', '2026-07-29 09:00:00');
+    const { db, context } = await connect();
+    await db.exec(`
+      INSERT INTO ssh_credentials (user_id, name, auth_type, updated_at)
+      VALUES ('user-1', 'same-second', 'password', '2026-07-29 09:00:00');
     `);
 
     const rows = await context.drizzle


### PR DESCRIPTION
## Summary

- compare sync cursors on a normalized `YYYY-MM-DD HH:MM:SS` form instead of trusting the stored layout
- apply it to both the row pull (`GET /sync/:entityType`) and the tombstone pull (`listSince`)
- cover rows written by `CURRENT_TIMESTAMP` and by `toISOString()`, plus the cursor's own second

Incremental sync returned nothing at all after its first pass. `gt(table.updatedAt, since)` runs on
a TEXT column whose values default to `CURRENT_TIMESTAMP` (`2026-07-29 10:11:21`), while the desktop
engine sends `new Date().toISOString()` (`2026-07-29T10:06:55.172Z`). Text comparison is decided at
position 10, where `' '` (0x20) sorts below `'T'` (0x54), so the predicate answers on layout rather
than on time — and is false for every `CURRENT_TIMESTAMP` row however new it is:

```
GET /sync/hosts                                 -> 3 rows (newest 2026-07-29 10:11:21)
GET /sync/hosts?since=2026-07-29T09:00:00.000Z  -> 0 rows    <- the format the client sends
GET /sync/hosts?since=2026-07-29 09:00:00       -> 3 rows    <- the format the column stores
```

The engine only sends a cursor from the second pass onward, so pass 1 synced everything and passes
2..n pulled zero rows and zero tombstones while reporting `lastError: null`. Edits and deletions
stopped propagating in both directions, silently.

Not a regression from #1092 — this code is unchanged since #1085. It was *masked*: before the
reference fix the loop threw before persisting state, so the cursor never advanced past `null` and
every cycle was a full sync. Now that a pass completes, the latent defect is reachable, and it will
reach users as 2.6.1 rather than as a visible change.

## Notes on the approach

- `replace`/`substr` rather than `datetime()`: the repository layer is deliberately drizzle-only so
  that no repository reaches for engine-specific SQL, and #1134 is laying Postgres/MySQL
  groundwork, so I avoided the SQLite-only date function. To be precise about what I actually
  verified: this is tested on SQLite only. `replace`/`substr` are much likelier to survive a
  dialect change than `datetime()`, but I can't claim Postgres/MySQL compatibility I haven't run.
  If the multi-dialect work needs a different expression, `sync-timestamp.ts` is the single place
  to change — and I'm happy to move it behind the engine boundary instead if you'd rather own it
  there.
- `>=` rather than `>`: normalising truncates sub-second precision, so a strict comparison would
  permanently skip rows written in the cursor's own second. Re-sending that boundary is a no-op —
  `syncEntity()` pushes only when one side is strictly newer, so rows equal on both sides do
  nothing.
- `updatedAt` is written in both layouts across the codebase (14 sites use `toISOString`, 11 use
  `CURRENT_TIMESTAMP`), so the tests assert on rows of each kind rather than assuming one.

## Validation

- `npm test -- --run src/backend/tests/database/repositories/sync-tombstone-since.test.ts` (4 passed)
- `npm test` — 181 files, 1248 passed, 1 skipped
- `npm run type-check`
- `npm run lint` (0 errors; the 44 existing warnings only)
- `npm run build`
- end to end: server image built from this branch on an isolated volume, driving the real
  `electron/remote-sync.cjs` against it with a throwaway profile. Before: pass 2 pulls nothing and a
  rename made on the server never reaches the client. After: the rename arrives on the next pass.

Deletions need #1051 as well — while the tombstone endpoint is unreachable there is nothing to
apply even once the cursor works.

Closes Termix-SSH/Support#1050
