### PR TITLE
fix: make sync deletions reach the other side

### DIFF
--- a/electron/remote-sync.cjs
+++ b/electron/remote-sync.cjs
@@ -398,6 +398,15 @@ class RemoteSyncEngine {
     return data.rows || [];
   }
 
+  /**
+   * Every syncId a side currently holds, ignoring the incremental window.
+   * Used only to decide whether a deletion still has something to delete.
+   */
+  async pullSyncIds(baseUrl, token, entityType) {
+    const rows = await this.pullSide(baseUrl, token, entityType, null);
+    return new Set(rows.filter((row) => row.syncId).map((row) => row.syncId));
+  }
+
   async pullTombstones(baseUrl, token, entityType, since) {
     const url = `${baseUrl}/sync/${entityType}/tombstones${since ? `?since=${encodeURIComponent(since)}` : ""}`;
     const data = await this.fetchJson(url, token);
@@ -482,24 +491,46 @@ class RemoteSyncEngine {
       }
 
       // Apply tombstones to whichever side hasn't already deleted the row.
-      for (const tombstone of localTombstones) {
-        if (remoteBySyncId.has(tombstone.syncId)) {
-          await this.pushTombstone(
-            remoteBaseUrl,
-            remoteJwt,
-            entityType,
-            tombstone.syncId,
-          );
+      //
+      // The presence check cannot use localRows/remoteRows: those are the
+      // incremental window, and a row deleted on one side while untouched on
+      // the other is by definition outside it, so every deletion was dropped.
+      // It also cannot be skipped -- pushing unconditionally makes the
+      // receiving side record a fresh tombstone, which the next pass would push
+      // back, forever. So ask the receiving side what it actually still holds,
+      // and only when there is a deletion to apply.
+      if (localTombstones.length) {
+        const remoteSyncIds = await this.pullSyncIds(
+          remoteBaseUrl,
+          remoteJwt,
+          entityType,
+        );
+        for (const tombstone of localTombstones) {
+          if (remoteSyncIds.has(tombstone.syncId)) {
+            await this.pushTombstone(
+              remoteBaseUrl,
+              remoteJwt,
+              entityType,
+              tombstone.syncId,
+            );
+          }
         }
       }
-      for (const tombstone of remoteTombstones) {
-        if (localBySyncId.has(tombstone.syncId)) {
-          await this.pushTombstone(
-            EMBEDDED_BASE_URL,
-            this.localJwt,
-            entityType,
-            tombstone.syncId,
-          );
+      if (remoteTombstones.length) {
+        const localSyncIds = await this.pullSyncIds(
+          EMBEDDED_BASE_URL,
+          this.localJwt,
+          entityType,
+        );
+        for (const tombstone of remoteTombstones) {
+          if (localSyncIds.has(tombstone.syncId)) {
+            await this.pushTombstone(
+              EMBEDDED_BASE_URL,
+              this.localJwt,
+              entityType,
+              tombstone.syncId,
+            );
+          }
         }
       }
 

--- a/src/backend/database/routes/sync.ts
+++ b/src/backend/database/routes/sync.ts
@@ -268,6 +268,71 @@ router.get(
 
 /**
  * @openapi
+ * /sync/tombstones:
+ *   post:
+ *     summary: Report a deletion from the other side of a sync pair
+ *     description: Applies a remote deletion locally (if the row still exists) and records the tombstone so future pulls stay consistent.
+ *     tags:
+ *       - Sync
+ *     responses:
+ *       200:
+ *         description: Deletion applied (or row already absent).
+ *       400:
+ *         description: Unknown entity type or missing syncId.
+ *       500:
+ *         description: Failed to apply deletion.
+ */
+router.post(
+  "/tombstones",
+  authenticateJWT,
+  async (req: Request, res: Response) => {
+    const userId = (req as AuthenticatedRequest).userId;
+    const entityType = req.body?.entityType;
+    const syncId = req.body?.syncId;
+    if (
+      !isValidEntityType(entityType) ||
+      typeof syncId !== "string" ||
+      !syncId
+    ) {
+      return res.status(400).json({ error: "Missing entityType or syncId" });
+    }
+
+    try {
+      const { table, singleton } = ENTITY_CONFIG[entityType];
+      const context = createCurrentRepositoryContext();
+
+      await context.drizzle
+        .delete(table as typeof hosts)
+        .where(
+          singleton
+            ? eq(table.userId, userId)
+            : and(
+                eq((table as typeof hosts).syncId, syncId),
+                eq(table.userId, userId),
+              ),
+        );
+
+      await createCurrentSyncTombstoneRepository().record(
+        userId,
+        entityType,
+        syncId,
+      );
+      await DatabaseSaveTrigger.forceSave("sync_tombstone_applied");
+
+      res.json({ success: true });
+    } catch (err) {
+      databaseLogger.error("Failed to apply sync tombstone", err, {
+        operation: "sync_tombstone_apply",
+        entityType,
+        userId,
+      });
+      res.status(500).json({ error: "Failed to apply deletion" });
+    }
+  },
+);
+
+/**
+ * @openapi
  * /sync/{entityType}:
  *   post:
  *     summary: Upsert a synced row by syncId
@@ -434,71 +499,6 @@ router.get(
         { operation: "sync_tombstones_pull", entityType, userId },
       );
       res.status(500).json({ error: "Failed to fetch tombstones" });
-    }
-  },
-);
-
-/**
- * @openapi
- * /sync/tombstones:
- *   post:
- *     summary: Report a deletion from the other side of a sync pair
- *     description: Applies a remote deletion locally (if the row still exists) and records the tombstone so future pulls stay consistent.
- *     tags:
- *       - Sync
- *     responses:
- *       200:
- *         description: Deletion applied (or row already absent).
- *       400:
- *         description: Unknown entity type or missing syncId.
- *       500:
- *         description: Failed to apply deletion.
- */
-router.post(
-  "/tombstones",
-  authenticateJWT,
-  async (req: Request, res: Response) => {
-    const userId = (req as AuthenticatedRequest).userId;
-    const entityType = req.body?.entityType;
-    const syncId = req.body?.syncId;
-    if (
-      !isValidEntityType(entityType) ||
-      typeof syncId !== "string" ||
-      !syncId
-    ) {
-      return res.status(400).json({ error: "Missing entityType or syncId" });
-    }
-
-    try {
-      const { table, singleton } = ENTITY_CONFIG[entityType];
-      const context = createCurrentRepositoryContext();
-
-      await context.drizzle
-        .delete(table as typeof hosts)
-        .where(
-          singleton
-            ? eq(table.userId, userId)
-            : and(
-                eq((table as typeof hosts).syncId, syncId),
-                eq(table.userId, userId),
-              ),
-        );
-
-      await createCurrentSyncTombstoneRepository().record(
-        userId,
-        entityType,
-        syncId,
-      );
-      await DatabaseSaveTrigger.forceSave("sync_tombstone_applied");
-
-      res.json({ success: true });
-    } catch (err) {
-      databaseLogger.error("Failed to apply sync tombstone", err, {
-        operation: "sync_tombstone_apply",
-        entityType,
-        userId,
-      });
-      res.status(500).json({ error: "Failed to apply deletion" });
     }
   },
 );

--- a/src/backend/tests/database/routes/sync.test.ts
+++ b/src/backend/tests/database/routes/sync.test.ts
@@ -1,8 +1,29 @@
 import { describe, expect, it } from "vitest";
-import {
+import syncRouter, {
   isValidEntityType,
   stripWritePayload,
 } from "../../../database/routes/sync.js";
+
+describe("sync route order", () => {
+  it("registers POST /tombstones before the POST /:entityType wildcard", () => {
+    const postPaths = (
+      syncRouter as unknown as {
+        stack: Array<{ route?: { path: string; methods: { post?: boolean } } }>;
+      }
+    ).stack
+      .filter((layer) => layer.route?.methods?.post)
+      .map((layer) => layer.route!.path);
+
+    // "/tombstones" is a valid value for :entityType as far as Express is
+    // concerned, so registering the wildcard first makes the tombstone
+    // endpoint unreachable -- every deletion push answers 400 "Unknown entity
+    // type" instead of applying the deletion.
+    expect(postPaths).toContain("/tombstones");
+    expect(postPaths.indexOf("/tombstones")).toBeLessThan(
+      postPaths.indexOf("/:entityType"),
+    );
+  });
+});
 
 describe("isValidEntityType", () => {
   it("accepts every whitelisted sync entity type", () => {

--- a/src/ui/tests/electron/remote-sync-tombstones.test.ts
+++ b/src/ui/tests/electron/remote-sync-tombstones.test.ts
@@ -1,0 +1,132 @@
+import Module from "node:module";
+import { createRequire } from "node:module";
+import os from "node:os";
+import { beforeEach, describe, expect, it } from "vitest";
+
+// remote-sync.cjs is CommonJS and pulls in `electron` at load time, which does
+// not exist outside the Electron runtime. vi.mock cannot reach a require() made
+// through createRequire, so the stub is injected into the CJS loader itself.
+const electronStub = {
+  app: { getPath: () => os.tmpdir() },
+  safeStorage: { isEncryptionAvailable: () => false },
+  ipcMain: { handle: () => {} },
+};
+const loader = Module as unknown as {
+  _load: (request: string, parent: unknown, isMain: boolean) => unknown;
+};
+const originalLoad = loader._load;
+loader._load = (request, parent, isMain) =>
+  request === "electron" ? electronStub : originalLoad(request, parent, isMain);
+
+const require = createRequire(import.meta.url);
+
+type Engine = {
+  stop: () => void;
+  pullSide: (
+    baseUrl: string,
+    token: string,
+    entityType: string,
+    since: string | null,
+  ) => Promise<unknown[]>;
+  pullTombstones: (
+    baseUrl: string,
+    token: string,
+    entityType: string,
+    since: string | null,
+  ) => Promise<unknown[]>;
+  pushRow: (...args: unknown[]) => Promise<void>;
+  pushTombstone: (
+    baseUrl: string,
+    token: string,
+    entityType: string,
+    syncId: string,
+  ) => Promise<void>;
+  syncEntity: (args: {
+    entityType: string;
+    remoteBaseUrl: string;
+    remoteJwt: string;
+    since: string | null;
+  }) => Promise<{ syncedAt: string }>;
+};
+
+const REMOTE = "https://server.example";
+const CURSOR = "2026-07-29T10:24:44.501Z";
+
+describe("remote sync tombstone application", () => {
+  let engine: Engine;
+  let pushed: Array<{ baseUrl: string; syncId: string }>;
+  let fullPulls: string[];
+
+  beforeEach(() => {
+    const { initRemoteSync } = require("../../../../electron/remote-sync.cjs");
+    engine = initRemoteSync(() => null) as Engine;
+    engine.stop();
+    pushed = [];
+    fullPulls = [];
+    engine.pushRow = async () => {};
+    engine.pushTombstone = async (baseUrl, _token, _entityType, syncId) => {
+      pushed.push({ baseUrl, syncId });
+    };
+  });
+
+  /**
+   * The row deleted on the remote is untouched locally, so it is absent from
+   * the incremental window on both sides -- the shape every ordinary deletion
+   * takes once the two sides have converged.
+   */
+  function stubSides(localHolds: string[], remoteTombstoneIds: string[]) {
+    engine.pullSide = async (baseUrl, _token, _entityType, since) => {
+      if (since) return [];
+      fullPulls.push(baseUrl);
+      return baseUrl === REMOTE
+        ? []
+        : localHolds.map((syncId) => ({ syncId, updatedAt: CURSOR }));
+    };
+    engine.pullTombstones = async (baseUrl) =>
+      baseUrl === REMOTE
+        ? remoteTombstoneIds.map((syncId) => ({ syncId }))
+        : [];
+  }
+
+  it("applies a remote deletion to a local row that is outside the incremental window", async () => {
+    stubSides(["cred-1"], ["cred-1"]);
+
+    await engine.syncEntity({
+      entityType: "sshCredentials",
+      remoteBaseUrl: REMOTE,
+      remoteJwt: "remote-jwt",
+      since: CURSOR,
+    });
+
+    expect(pushed).toEqual([
+      { baseUrl: "http://127.0.0.1:30001", syncId: "cred-1" },
+    ]);
+  });
+
+  it("does not re-push a deletion once the row is gone, so tombstones cannot ping-pong", async () => {
+    stubSides([], ["cred-1"]);
+
+    await engine.syncEntity({
+      entityType: "sshCredentials",
+      remoteBaseUrl: REMOTE,
+      remoteJwt: "remote-jwt",
+      since: CURSOR,
+    });
+
+    expect(pushed).toEqual([]);
+  });
+
+  it("does not pay for a presence check when nothing was deleted", async () => {
+    stubSides(["cred-1"], []);
+
+    await engine.syncEntity({
+      entityType: "sshCredentials",
+      remoteBaseUrl: REMOTE,
+      remoteJwt: "remote-jwt",
+      since: CURSOR,
+    });
+
+    expect(pushed).toEqual([]);
+    expect(fullPulls).toEqual([]);
+  });
+});


### PR DESCRIPTION
## Summary

- register `POST /sync/tombstones` before the `POST /:entityType` wildcard that was swallowing it
- check whether the receiving side still holds a row using its full set rather than the incremental window
- pay for that check only on a pass that actually carries a deletion
- regression tests for the route order and for both branches of the guard

Deletions have never propagated. Two independent defects, both hidden until now behind
Termix-SSH/Support#1050 (with the cursor broken, no tombstone was ever pulled to begin with).

**The endpoint was unreachable.** Express matches in registration order, and `"tombstones"` is a
perfectly good value for `:entityType`, so every deletion push landed in the wildcard handler and
came back as `400 "Unknown entity type"`. The handler below it has never run:

```
$ curl -X POST /sync/tombstones -d '{"entityType":"sshCredentials","syncId":"82629ab4-..."}'
{"error":"Unknown entity type"}   [400]
```

The GET pair is unaffected — `/:entityType/tombstones` and `/:entityType` differ in segment count.

**The guard consulted the incremental window.** `localBySyncId` / `remoteBySyncId` are built from
`pullSide(..., since)`. A row deleted on one side and untouched on the other is by definition
absent from that window — the shape every ordinary deletion takes once the two sides have
converged — so the tombstone was skipped, and skipped again on each later pass while sliding out of
its own window.

The guard can't just be dropped: `POST /sync/tombstones` records a tombstone on the receiving side,
so an unconditional push would hand the other side a fresh tombstone to push back on the next pass,
and the two would trade deletions forever. Asking the receiving side what it still holds keeps the
original intent and terminates — once the row is gone, nothing is pushed.

Cost: an ordinary pass is unchanged (the check is skipped when there are no tombstones); a pass
carrying a deletion adds one unfiltered list per affected entity type.

## Validation

- `npm test -- --run src/backend/tests/database/routes/sync.test.ts src/ui/tests/electron/remote-sync-tombstones.test.ts` (10 passed)
- both new tests confirmed to fail against `dev-2.6.1` without the corresponding change
- `npm test` — 181 files, 1248 passed, 1 skipped
- `npm run type-check`
- `npm run lint` (0 errors; the 44 existing warnings only)
- `npm run build`
- end to end, with #1050's patch applied on top so tombstones are pulled at all: server image built
  from the combined tree on an isolated volume, real `electron/remote-sync.cjs` against it.
  A credential deleted on the server disappears on the client on the next pass; a credential
  deleted on the client disappears on the server; three consecutive passes report
  `lastError: null` and the tombstone counts stay flat on both sides, so nothing ping-pongs.

## Ordering

This is behaviourally dependent on Termix-SSH/Support#1050 — without it the tombstone pull returns
nothing, so this change has nothing to act on. The two touch different regions of `sync.ts` and
should merge in either order; happy to rebase if they conflict.

Closes Termix-SSH/Support#1051
