### PR TITLE
Use the configured default credential when importing Proxmox guests

### DIFF
--- a/src/backend/database/routes/proxmox.ts
+++ b/src/backend/database/routes/proxmox.ts
@@ -248,7 +248,13 @@ function mergeTags(
     .join(",");
 }
 
-function resolveProxmoxImportAuth(
+// Auth types that need a secret the discovered guest does not carry. A
+// configured default credential supplies exactly that, so these resolve to
+// credential auth when one is set and fall back to "none" when it is not.
+// Everything else needs no secret and is imported as configured.
+const SECRET_BACKED_AUTH_TYPES = new Set(["password", "key", "credential"]);
+
+export function resolveProxmoxImportAuth(
   defaultAuthType: string | undefined,
   credentialId: number | null | undefined,
 ): {
@@ -256,22 +262,14 @@ function resolveProxmoxImportAuth(
   credentialId: number | null;
   overrideCredentialUsername: number;
 } {
-  if (defaultAuthType === "credential" || (!defaultAuthType && credentialId)) {
+  if (!defaultAuthType || SECRET_BACKED_AUTH_TYPES.has(defaultAuthType)) {
     return credentialId
       ? { authType: "credential", credentialId, overrideCredentialUsername: 1 }
       : { authType: "none", credentialId: null, overrideCredentialUsername: 0 };
   }
 
-  if (defaultAuthType && !["password", "key"].includes(defaultAuthType)) {
-    return {
-      authType: defaultAuthType,
-      credentialId: null,
-      overrideCredentialUsername: 0,
-    };
-  }
-
   return {
-    authType: "none",
+    authType: defaultAuthType,
     credentialId: null,
     overrideCredentialUsername: 0,
   };

--- a/src/backend/tests/database/routes/proxmox-import-auth.test.ts
+++ b/src/backend/tests/database/routes/proxmox-import-auth.test.ts
@@ -1,0 +1,58 @@
+import { describe, expect, it } from "vitest";
+import { resolveProxmoxImportAuth } from "../../../database/routes/proxmox.js";
+
+// The frontend carries its own copy of this decision in
+// src/ui/components/proxmox/proxmox-import-auth.ts. The two drifting apart is
+// what produced the reported bug, so both are held to the same matrix.
+describe("resolveProxmoxImportAuth", () => {
+  it("uses the default credential for key auth when one is configured", () => {
+    expect(resolveProxmoxImportAuth("key", 7)).toEqual({
+      authType: "credential",
+      credentialId: 7,
+      overrideCredentialUsername: 1,
+    });
+  });
+
+  it("uses the default credential for password auth when one is configured", () => {
+    expect(resolveProxmoxImportAuth("password", 7)).toEqual({
+      authType: "credential",
+      credentialId: 7,
+      overrideCredentialUsername: 1,
+    });
+  });
+
+  it("falls back to none when a secret-backed default has no credential", () => {
+    for (const authType of ["password", "key", "credential"]) {
+      expect(resolveProxmoxImportAuth(authType, null)).toEqual({
+        authType: "none",
+        credentialId: null,
+        overrideCredentialUsername: 0,
+      });
+    }
+  });
+
+  it("uses the credential when no default auth type is configured", () => {
+    expect(resolveProxmoxImportAuth(undefined, 42)).toEqual({
+      authType: "credential",
+      credentialId: 42,
+      overrideCredentialUsername: 1,
+    });
+    expect(resolveProxmoxImportAuth(undefined, null)).toEqual({
+      authType: "none",
+      credentialId: null,
+      overrideCredentialUsername: 0,
+    });
+  });
+
+  it("keeps secretless auth types, with or without a credential", () => {
+    for (const authType of ["none", "opkssh", "tailscale", "vault"]) {
+      for (const credentialId of [null, 7]) {
+        expect(resolveProxmoxImportAuth(authType, credentialId)).toEqual({
+          authType,
+          credentialId: null,
+          overrideCredentialUsername: 0,
+        });
+      }
+    }
+  });
+});

--- a/src/ui/components/proxmox/proxmox-import-auth.ts
+++ b/src/ui/components/proxmox/proxmox-import-auth.ts
@@ -1,5 +1,8 @@
-const SECRET_BACKED_AUTH_TYPES = new Set(["password", "key"]);
-const SECRETLESS_AUTH_TYPES = new Set(["none", "opkssh", "tailscale", "vault"]);
+// Auth types that need a secret the discovered guest does not carry. A
+// configured default credential supplies exactly that, so these resolve to
+// credential auth when one is set and fall back to "none" when it is not.
+// Everything else needs no secret and is imported as configured.
+const SECRET_BACKED_AUTH_TYPES = new Set(["password", "key", "credential"]);
 
 export type ProxmoxImportAuth = {
   authType: string;
@@ -11,7 +14,7 @@ export function resolveProxmoxImportAuth(
   defaultAuthType: string | undefined,
   credentialId: number | null | undefined,
 ): ProxmoxImportAuth {
-  if (defaultAuthType === "credential" || (!defaultAuthType && credentialId)) {
+  if (!defaultAuthType || SECRET_BACKED_AUTH_TYPES.has(defaultAuthType)) {
     return credentialId
       ? {
           authType: "credential",
@@ -21,13 +24,5 @@ export function resolveProxmoxImportAuth(
       : { authType: "none" };
   }
 
-  if (defaultAuthType && SECRETLESS_AUTH_TYPES.has(defaultAuthType)) {
-    return { authType: defaultAuthType };
-  }
-
-  if (defaultAuthType && !SECRET_BACKED_AUTH_TYPES.has(defaultAuthType)) {
-    return { authType: defaultAuthType };
-  }
-
-  return { authType: "none" };
+  return { authType: defaultAuthType };
 }

--- a/src/ui/tests/components/proxmox/proxmox-import-auth.test.ts
+++ b/src/ui/tests/components/proxmox/proxmox-import-auth.test.ts
@@ -22,9 +22,47 @@ describe("resolveProxmoxImportAuth", () => {
     });
   });
 
-  it("keeps secretless auth types", () => {
-    expect(resolveProxmoxImportAuth("opkssh", null)).toEqual({
-      authType: "opkssh",
+  // The reported bug: "SSH Key" plus a default credential produced hosts with
+  // auth type "none", because password/key fell past every branch. The
+  // credential holds the key the guest itself cannot carry, so it should be
+  // used rather than discarded.
+  it("uses the default credential for key auth when one is configured", () => {
+    expect(resolveProxmoxImportAuth("key", 7)).toEqual({
+      authType: "credential",
+      credentialId: 7,
+      overrideCredentialUsername: true,
+    });
+  });
+
+  it("uses the default credential for password auth when one is configured", () => {
+    expect(resolveProxmoxImportAuth("password", 7)).toEqual({
+      authType: "credential",
+      credentialId: 7,
+      overrideCredentialUsername: true,
+    });
+  });
+
+  it("still resolves an explicit credential default through the credential", () => {
+    expect(resolveProxmoxImportAuth("credential", 7)).toEqual({
+      authType: "credential",
+      credentialId: 7,
+      overrideCredentialUsername: true,
+    });
+    expect(resolveProxmoxImportAuth("credential", null)).toEqual({
+      authType: "none",
+    });
+  });
+
+  it("keeps secretless auth types, with or without a credential", () => {
+    for (const authType of ["none", "opkssh", "tailscale", "vault"]) {
+      expect(resolveProxmoxImportAuth(authType, null)).toEqual({ authType });
+      expect(resolveProxmoxImportAuth(authType, 7)).toEqual({ authType });
+    }
+  });
+
+  it("passes through an auth type it does not know about", () => {
+    expect(resolveProxmoxImportAuth("agent", null)).toEqual({
+      authType: "agent",
     });
   });
 });


### PR DESCRIPTION
Fixes Termix-SSH/Support#1045.

The Proxmox integration offers five default auth types — `password`, `key`, `credential`, `opkssh`, `none` — and a separate default credential picker. Choosing **SSH Key** (or Password) imported every guest with auth type `none`, which is what the reporter hit.

## Why

`resolveProxmoxImportAuth` had three branches:

```ts
if (defaultAuthType === "credential" || (!defaultAuthType && credentialId)) { ... }
if (defaultAuthType && SECRETLESS_AUTH_TYPES.has(defaultAuthType))  return { authType: defaultAuthType };
if (defaultAuthType && !SECRET_BACKED_AUTH_TYPES.has(defaultAuthType)) return { authType: defaultAuthType };
return { authType: "none" };
```

`password` and `key` match none of them and fall to the final return. So the two types the dropdown documents were exactly the two that got dropped, while an auth type the resolver had never heard of was passed through untouched.

## What changed

`none` was the right answer for a discovered guest with nothing else configured — the guest carries no password and no private key. It is the wrong answer when a **default credential is set**, because that credential holds precisely the secret the guest is missing. That is already how an unset default behaves (`!defaultAuthType && credentialId` → credential auth); selecting `key` just stopped it from getting there.

So `password`, `key`, and `credential` are now treated alike: use the credential if one is configured, fall back to `none` if not. Everything else needs no secret and is imported as configured.

That collapses `SECRET_BACKED_AUTH_TYPES` and `SECRETLESS_AUTH_TYPES` into one set and removes a branch — the secretless list no longer has to be enumerated, since "not secret-backed" is the same statement.

| default auth type | credential | before | after |
|---|---|---|---|
| unset | set | credential | credential |
| unset | none | none | none |
| `credential` | set / none | credential / none | unchanged |
| **`password`** | **set** | **none** | **credential** |
| **`key`** | **set** | **none** | **credential** |
| `password` / `key` | none | none | none |
| `opkssh`, `none`, `tailscale`, `vault` | any | passed through | unchanged |
| unrecognized | any | passed through | unchanged |

Only the two bold rows change.

## Both copies

The backend (`routes/proxmox.ts`) and the frontend (`components/proxmox/proxmox-import-auth.ts`) each carry their own copy of this decision. Both are fixed, and both are now held to the same matrix in tests — including the secretless types and an unrecognized one — so the next drift between them fails a test instead of silently importing hosts that cannot authenticate.

`npx tsc --noEmit`, eslint, and prettier are clean; `src/ui/tests` + `src/backend/tests/database/routes` pass (501 tests).