### PR TITLE
Report why every JWKS fetch failed instead of swallowing the reason

### DIFF
--- a/src/backend/database/routes/user-oidc-utils.ts
+++ b/src/backend/database/routes/user-oidc-utils.ts
@@ -47,6 +47,26 @@ export function buildFetchOptions(caCert?: string): Record<string, unknown> {
   return { dispatcher: new Agent({ connect: { ca: caCert } }) };
 }
 
+/**
+ * Renders why a fetch failed in a form an administrator can act on.
+ *
+ * undici reports every transport failure as the same "fetch failed" message
+ * and puts the reason that actually matters -- ENOTFOUND, ECONNREFUSED,
+ * UNABLE_TO_VERIFY_LEAF_SIGNATURE, a timeout -- on the cause. Reporting only
+ * the outer message says nothing at all.
+ */
+export function describeFetchFailure(error: unknown): string {
+  if (!(error instanceof Error)) return String(error);
+  const cause = (error as { cause?: unknown }).cause;
+  if (cause instanceof Error) {
+    const code = (cause as { code?: unknown }).code;
+    return code
+      ? `${error.message}: ${cause.message} (${code})`
+      : `${error.message}: ${cause.message}`;
+  }
+  return cause ? `${error.message}: ${String(cause)}` : error.message;
+}
+
 export function getOIDCConfigFromEnv(): OIDCConfig | null {
   const client_id = process.env.OIDC_CLIENT_ID;
   const client_secret = process.env.OIDC_CLIENT_SECRET;
@@ -187,20 +207,30 @@ export async function verifyOIDCToken(
     `${normalizedIssuerUrl.replace(/\/application\/o\/[^/]+$/, "")}/.well-known/jwks.json`,
   ];
 
+  // Every attempt records why it failed. Without this the only thing an
+  // administrator ever sees is "Failed to fetch JWKS from any URL", which
+  // does not distinguish an issuer URL typo from a proxy, a private CA, or
+  // a provider outage.
+  const attempts: string[] = [];
+
+  const discoveryUrl = `${normalizedIssuerUrl}/.well-known/openid-configuration`;
   try {
-    const discoveryUrl = `${normalizedIssuerUrl}/.well-known/openid-configuration`;
     const discoveryResponse = await fetch(discoveryUrl, fetchOptions);
-    if (discoveryResponse.ok) {
+    if (!discoveryResponse.ok) {
+      attempts.push(`${discoveryUrl}: HTTP ${discoveryResponse.status}`);
+    } else {
       const discovery = (await discoveryResponse.json()) as Record<
         string,
         unknown
       >;
-      if (discovery.jwks_uri) {
-        jwksUrls.unshift(discovery.jwks_uri as string);
+      if (typeof discovery.jwks_uri === "string" && discovery.jwks_uri) {
+        jwksUrls.unshift(discovery.jwks_uri);
+      } else {
+        attempts.push(`${discoveryUrl}: no jwks_uri in the discovery document`);
       }
     }
   } catch (discoveryError) {
-    authLogger.error(`OIDC discovery failed: ${discoveryError}`);
+    attempts.push(`${discoveryUrl}: ${describeFetchFailure(discoveryError)}`);
   }
 
   let jwks: Record<string, unknown> | null = null;
@@ -208,26 +238,25 @@ export async function verifyOIDCToken(
   for (const url of jwksUrls) {
     try {
       const response = await fetch(url, fetchOptions);
-      if (response.ok) {
-        const jwksData = (await response.json()) as Record<string, unknown>;
-        if (jwksData && jwksData.keys && Array.isArray(jwksData.keys)) {
-          jwks = jwksData;
-          break;
-        } else {
-          authLogger.error(
-            `Invalid JWKS structure from ${url}: ${JSON.stringify(jwksData)}`,
-          );
-        }
-      } else {
-        // expected - non-ok response, try next URL
+      if (!response.ok) {
+        attempts.push(`${url}: HTTP ${response.status}`);
+        continue;
       }
-    } catch {
-      continue;
+      const jwksData = (await response.json()) as Record<string, unknown>;
+      if (jwksData && Array.isArray(jwksData.keys)) {
+        jwks = jwksData;
+        break;
+      }
+      attempts.push(`${url}: response contains no "keys" array`);
+    } catch (error) {
+      attempts.push(`${url}: ${describeFetchFailure(error)}`);
     }
   }
 
   if (!jwks) {
-    throw new Error("Failed to fetch JWKS from any URL");
+    throw new Error(
+      `Failed to fetch JWKS from any URL. Attempts:\n  ${attempts.join("\n  ")}`,
+    );
   }
 
   if (!jwks.keys || !Array.isArray(jwks.keys)) {

--- a/src/backend/tests/database/routes/user-oidc-utils.test.ts
+++ b/src/backend/tests/database/routes/user-oidc-utils.test.ts
@@ -17,6 +17,7 @@ const {
   extractOidcGroups,
   validateLogoutTokenClaims,
   verifyOIDCToken,
+  describeFetchFailure,
 } = await import("../../../database/routes/user-oidc-utils.js");
 
 const BACKCHANNEL_LOGOUT_EVENT =
@@ -24,6 +25,102 @@ const BACKCHANNEL_LOGOUT_EVENT =
 
 afterEach(() => {
   vi.restoreAllMocks();
+});
+
+describe("describeFetchFailure", () => {
+  it("unwraps the undici cause, which carries the reason that matters", () => {
+    // Every transport failure surfaces as this same outer message.
+    const error = new TypeError("fetch failed", {
+      cause: Object.assign(new Error("getaddrinfo ENOTFOUND idp.example"), {
+        code: "ENOTFOUND",
+      }),
+    });
+    expect(describeFetchFailure(error)).toBe(
+      "fetch failed: getaddrinfo ENOTFOUND idp.example (ENOTFOUND)",
+    );
+  });
+
+  it("falls back to the outer message when there is no cause", () => {
+    expect(describeFetchFailure(new Error("boom"))).toBe("boom");
+  });
+
+  it("handles a non-Error throw", () => {
+    expect(describeFetchFailure("nope")).toBe("nope");
+  });
+});
+
+describe("verifyOIDCToken JWKS diagnostics", () => {
+  const issuer = "https://login.microsoftonline.com/example/v2.0";
+  const token = "header.payload.signature";
+
+  it("reports every attempted URL and why it failed", async () => {
+    vi.spyOn(globalThis, "fetch").mockResolvedValue(
+      new Response("not found", { status: 404 }),
+    );
+
+    const error = await verifyOIDCToken(token, issuer, "client").catch(
+      (e) => e as Error,
+    );
+    expect(error.message).toMatch(/^Failed to fetch JWKS from any URL/);
+    expect(error.message).toContain(
+      `${issuer}/.well-known/openid-configuration: HTTP 404`,
+    );
+    expect(error.message).toContain(
+      `${issuer}/.well-known/jwks.json: HTTP 404`,
+    );
+    expect(error.message).toContain(`${issuer}/jwks/: HTTP 404`);
+  });
+
+  it("reports a transport failure with its underlying cause", async () => {
+    vi.spyOn(globalThis, "fetch").mockRejectedValue(
+      new TypeError("fetch failed", {
+        cause: Object.assign(new Error("self-signed certificate"), {
+          code: "SELF_SIGNED_CERT_IN_CHAIN",
+        }),
+      }),
+    );
+
+    const error = await verifyOIDCToken(token, issuer, "client").catch(
+      (e) => e as Error,
+    );
+    expect(error.message).toContain(
+      "self-signed certificate (SELF_SIGNED_CERT_IN_CHAIN)",
+    );
+  });
+
+  it("says so when discovery succeeds but advertises no jwks_uri", async () => {
+    vi.spyOn(globalThis, "fetch")
+      .mockResolvedValueOnce(
+        new Response(JSON.stringify({ issuer }), { status: 200 }),
+      )
+      .mockResolvedValue(new Response("not found", { status: 404 }));
+
+    const error = await verifyOIDCToken(token, issuer, "client").catch(
+      (e) => e as Error,
+    );
+    expect(error.message).toContain("no jwks_uri in the discovery document");
+  });
+
+  it("says so when a JWKS response carries no keys array", async () => {
+    vi.spyOn(globalThis, "fetch")
+      .mockResolvedValueOnce(
+        new Response(JSON.stringify({ jwks_uri: "https://idp.example/keys" }), {
+          status: 200,
+        }),
+      )
+      .mockResolvedValue(
+        new Response(JSON.stringify({ error: "unauthorized" }), {
+          status: 200,
+        }),
+      );
+
+    const error = await verifyOIDCToken(token, issuer, "client").catch(
+      (e) => e as Error,
+    );
+    expect(error.message).toContain(
+      'https://idp.example/keys: response contains no "keys" array',
+    );
+  });
 });
 
 describe("verifyOIDCToken", () => {


### PR DESCRIPTION
Refs Termix-SSH/Support#1047.

This does **not** claim to fix that report. It removes the reason nobody can diagnose it — including me. I read the whole path and could not determine a root cause, because the code destroys the evidence before it reaches anyone.

## What is thrown away

An OIDC login that cannot reach the provider's keys produces exactly one line:

```
Error: Failed to fetch JWKS from any URL
```

Four URLs are tried (discovery's `jwks_uri` plus three hardcoded fallbacks) and every failure is discarded on the way:

```ts
if (response.ok) { ... } else {
  // expected - non-ok response, try next URL
}
} catch {
  continue;
}
```

Discovery is no better — it only logged when it *threw*. A 404, or a document with no `jwks_uri`, passed in complete silence, which is the case most likely to be a misconfigured issuer URL.

So an administrator cannot distinguish an issuer typo from an egress proxy, a private CA, a tenant that needs a different endpoint, or an outage at the provider. Neither can whoever picks up the issue.

## What changed

Each attempt is recorded with its reason, and the collected list goes into the thrown error:

```
Failed to fetch JWKS from any URL. Attempts:
  https://login.microsoftonline.com/<tenant>/v2.0/.well-known/openid-configuration: fetch failed: getaddrinfo ENOTFOUND … (ENOTFOUND)
  https://login.microsoftonline.com/<tenant>/v2.0/.well-known/jwks.json: HTTP 404
  https://login.microsoftonline.com/<tenant>/v2.0/jwks/: HTTP 404
```

It reaches the log through the existing `OIDC callback failed` handler. The browser still gets the same generic `OIDC authentication failed` redirect it got before — no new information is exposed to the client.

**Unwrapping `error.cause` is the part that actually matters.** undici reports every transport failure as the string `fetch failed`; the reason that identifies the problem — `ENOTFOUND`, `ECONNREFUSED`, `SELF_SIGNED_CERT_IN_CHAIN`, a timeout — is on the cause. A list built from the outer messages would be four repetitions of `fetch failed`, no more useful than the single line it replaces.

One small correctness fix alongside it: `jwks_uri` was used as a string on a truthiness check alone, so a malformed discovery document turned into a failed fetch of `[object Object]`. It is now type-checked and reported as a malformed document.

## Tests

Cover the cause-unwrapping directly, and the four shapes the diagnostics have to distinguish: all-404, a transport failure with a TLS cause, discovery that returns 200 with no `jwks_uri`, and a 200 JWKS response with no `keys` array. `src/backend/tests/database/routes` passes (176 tests); tsc, eslint, and prettier are clean.

## Still open

The reporter's actual failure is undiagnosed. What would settle it is the `Attempts:` block from this change, or failing that, the issuer URL configured for the Entra provider — I have asked on the issue. Worth noting separately: these fetches have no timeout, so an unreachable provider stalls the callback for as long as the OS lets it. I left that alone rather than widen this change.