### PR TITLE
Resolve the dialect in the repository factory instead of assuming sqlite

### DIFF
--- a/docs/database-backends.md
+++ b/docs/database-backends.md
@@ -189,6 +189,19 @@ Tested against PostgreSQL 16 and MySQL 8. **MariaDB is not a substitute for
 MySQL when testing** — it accepts DDL that MySQL 8 rejects, which has hidden a
 real defect here more than once.
 
+### What neither of them covers
+
+Both harnesses build a `DatabaseContext` of their own, so neither runs
+`createCurrentRepositoryContext()` — the one the application actually uses.
+That gap hid a hardcoded `dialect: "sqlite"` in it: every engine reported
+itself as SQLite at runtime while all three test passes stayed green, which on
+MySQL meant `upsert` reached for `onConflictDoUpdate` and died with a
+TypeError on the first write.
+
+Anything the factory decides from the dialect needs its own test against the
+factory. Asserting it through a hand-built context proves nothing about what
+runs in production.
+
 ## Known limits
 
 - The desktop app always uses SQLite. It embeds its own backend and cannot ship

--- a/src/backend/database/repositories/factory.ts
+++ b/src/backend/database/repositories/factory.ts
@@ -47,9 +47,21 @@ import { UserRepository } from "./user-repository.js";
 import { VaultProfileRepository } from "./vault-profile-repository.js";
 import { VaultTokenRepository } from "./vault-token-repository.js";
 
+/**
+ * The context every repository runs against.
+ *
+ * The dialect has to be resolved, not assumed: it is what `returning.ts` reads
+ * to decide whether it can ask for RETURNING, and whether an upsert spells
+ * itself `onConflictDoUpdate` or `onDuplicateKeyUpdate`. Reporting "sqlite"
+ * while connected to MySQL makes the second of those a TypeError on the first
+ * write.
+ *
+ * Both cross-dialect harnesses build a DatabaseContext themselves, so neither
+ * exercises this function — see tests/database/repositories/factory-context.
+ */
 export function createCurrentRepositoryContext(): DatabaseContext {
   return {
-    dialect: "sqlite",
+    dialect: resolveDatabaseDialect(),
     drizzle: getDb(),
   };
 }

--- a/src/backend/tests/database/repositories/factory-context.test.ts
+++ b/src/backend/tests/database/repositories/factory-context.test.ts
@@ -1,0 +1,66 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { DATABASE_DIALECT_ENV } from "../../../database/db/dialect.js";
+
+// getDb() throws unless a database was initialized; the context's handle is
+// not what this file is about.
+vi.mock("../../../database/db/index.js", () => ({
+  getDb: () => ({}),
+  getSqlite: () => ({}),
+  DatabaseSaveTrigger: { forceSave: vi.fn() },
+}));
+
+const { createCurrentRepositoryContext, createCurrentRepositoryWriteHook } =
+  await import("../../../database/repositories/factory.js");
+
+// Neither cross-dialect harness reaches this function: both
+// tests/database/repositories/test-support.ts and scripts/verify-dialects.mjs
+// construct a DatabaseContext of their own. That is why the production path
+// could report "sqlite" while connected to MySQL with CI green on all three
+// engines, and why this asserts on the real factory rather than a fixture.
+describe("createCurrentRepositoryContext", () => {
+  const saved = process.env[DATABASE_DIALECT_ENV];
+
+  beforeEach(() => {
+    delete process.env[DATABASE_DIALECT_ENV];
+  });
+
+  afterEach(() => {
+    if (saved === undefined) delete process.env[DATABASE_DIALECT_ENV];
+    else process.env[DATABASE_DIALECT_ENV] = saved;
+  });
+
+  it("defaults to sqlite when nothing is configured", () => {
+    expect(createCurrentRepositoryContext().dialect).toBe("sqlite");
+  });
+
+  it("reports the configured dialect", () => {
+    for (const dialect of ["sqlite", "postgres", "mysql"]) {
+      process.env[DATABASE_DIALECT_ENV] = dialect;
+      expect(createCurrentRepositoryContext().dialect).toBe(dialect);
+    }
+  });
+
+  it("rejects an unsupported dialect rather than falling back to sqlite", () => {
+    process.env[DATABASE_DIALECT_ENV] = "oracle";
+    expect(() => createCurrentRepositoryContext()).toThrow(/oracle/);
+  });
+});
+
+describe("createCurrentRepositoryWriteHook", () => {
+  const saved = process.env[DATABASE_DIALECT_ENV];
+
+  afterEach(() => {
+    if (saved === undefined) delete process.env[DATABASE_DIALECT_ENV];
+    else process.env[DATABASE_DIALECT_ENV] = saved;
+  });
+
+  it("installs a persist hook only for sqlite", () => {
+    process.env[DATABASE_DIALECT_ENV] = "sqlite";
+    expect(createCurrentRepositoryWriteHook("test")).toBeTypeOf("function");
+
+    for (const dialect of ["postgres", "mysql"]) {
+      process.env[DATABASE_DIALECT_ENV] = dialect;
+      expect(createCurrentRepositoryWriteHook("test")).toBeUndefined();
+    }
+  });
+});


### PR DESCRIPTION
Fixes Termix-SSH/Support#282.

I went in expecting wiring to be missing. It is not — `initializeDatabase()` already branches to `initializeRemoteDatabase()`, `connectRemoteDatabase()` and `runRemoteMigrations()` are in place, the migrations are generated, and CI runs the repository suite against real Postgres 16 and MySQL 8 containers. What was left is one line, and it is the one that matters.

## The line

```ts
export function createCurrentRepositoryContext(): DatabaseContext {
  return {
    dialect: "sqlite",   // <-- regardless of DATABASE_DIALECT
    drizzle: getDb(),
  };
}
```

`dialect` is not decoration. `returning.ts` reads it in five places to decide whether it can ask for RETURNING, and `upsert()` reads it to choose between `onConflictDoUpdate` and `onDuplicateKeyUpdate`. With it pinned to `"sqlite"`, a MySQL deployment takes the SQLite branch and calls `onConflictDoUpdate` on a mysql2 insert builder, which has no such method.

The comment already sitting above that function spelled out the consequence, for the case it assumed could not happen:

> calling it is a TypeError rather than a rejected query

So **MySQL never worked outside the test harness.** Postgres survived by coincidence — it supports RETURNING and shares the conflict syntax, so the wrong branch happens to be the right one.

## Why three layers of verification all missed it

- `tests/database/repositories/test-support.ts:79` builds `{ dialect: this.dialect, drizzle: db }` itself
- `scripts/verify-dialects.mjs:45` builds `{ dialect, drizzle: db }` itself
- the CI matrix runs both of the above against real engines

Every one of them constructs a `DatabaseContext` by hand and never calls the factory the application uses. Three passes, three engines, all green, and none of them touched the function under test. A fixture that agrees with your assumption cannot falsify it.

## The change

Resolve the dialect from the environment, and test the **factory** rather than a hand-built context:

- defaults to `sqlite` when nothing is configured
- reports `sqlite` / `postgres` / `mysql` as configured
- installs the persist write hook only for `sqlite`
- an unsupported value throws instead of silently falling back

Reverting the one-line fix fails two of these, which I checked rather than assumed.

I also added a short section to `docs/database-backends.md` under "What is verified, and how" — that section claimed thorough coverage and was exactly where the blind spot lived.

## Scope

Only the dialect resolution. I checked the rest of the surface rather than taking it on trust:

- every other `resolveDatabaseDialect` / `needsExplicitPersist` branch (`db/index.ts`, `sqlite-foreign-keys.ts`, both crypto migrations, `data-crypto.ts`) already resolves correctly
- `getCurrentSettingValue` correctly reads the primed cache on remote engines and only touches `getSqlite()` on the SQLite branch
- backup **import** genuinely refuses on non-SQLite with a readable message, and that guard is reachable from `database.ts:1277`
- backup **export** reads through repositories and writes a fresh SQLite file, so it is engine-independent

`npx tsc --noEmit`, eslint and prettier are clean; `src/backend/tests` passes (957 passed, 1 skipped).