### PR TITLE
Restore the closing quote on the version string

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "termix",
   "private": true,
-  "version": "2.6.1,
+  "version": "2.6.1",
   "description": "Self-hosted SSH and remote desktop management.",
   "author": "Karmaa",
   "main": "electron/main.cjs",


### PR DESCRIPTION
One character. `dev-2.6.1` currently has no valid `package.json`.

`2a66775` ("Bump version from 2.6.0 to 2.6.1") wrote:

```diff
-  "version": "2.6.0",
+  "version": "2.6.1,
```

The closing quote is gone, so the file has not parsed since 2026-07-29.

Everything that reads it fails — `npm install`, `npm run build`, and every CI run on this branch. vitest does not even reach the test files: vite parses `package.json` while loading its own config, so the failure surfaces as an opaque rolldown error naming a control character at line 5 column 0, rather than anything pointing at the missing quote on line 4.

**2.6.1 cannot be built or released as it stands.** Worth noting that a PR opened before the bump can still show green checks from a run against the older base, so the branch looks healthier than it is — that is how this went unnoticed for two days.

Keeping this on its own so it can go in immediately, ahead of anything else queued.
