### PR TITLE
fix(hosts): parse portKnockSequence JSON in host-resolver

### DIFF
--- a/src/backend/hosts/host-resolver.ts
+++ b/src/backend/hosts/host-resolver.ts
@@ -113,6 +113,13 @@ export async function resolveHostById(
       host.quickActions = [];
     }
   }
+  if (typeof host.portKnockSequence === "string" && host.portKnockSequence) {
+    try {
+      host.portKnockSequence = JSON.parse(host.portKnockSequence as string);
+    } catch {
+      host.portKnockSequence = [];
+    }
+  }
 
   if (!ownerEquivalent) {
     const resolved = await resolveSharedSshSecrets(

--- a/src/backend/tests/hosts/host-resolver.test.ts
+++ b/src/backend/tests/hosts/host-resolver.test.ts
@@ -301,4 +301,27 @@ describe("resolveHostById", () => {
     await resolveHostById(42, "owner");
     expect(state.auditCalls).toHaveLength(0);
   });
+
+  it("parses an empty port_knock_sequence '[]' string into an empty array (no bogus knock)", async () => {
+    state.host = baseHost({ portKnockSequence: "[]" });
+    const host = (await resolveHostById(42, "owner")) as Record<
+      string,
+      unknown
+    >;
+    expect(host.portKnockSequence).toEqual([]);
+  });
+
+  it("parses a real port_knock_sequence JSON string into an array", async () => {
+    state.host = baseHost({
+      portKnockSequence: '[{"port":1234,"protocol":"tcp","delay":100}]',
+    });
+    const host = (await resolveHostById(42, "owner")) as Record<
+      string,
+      unknown
+    >;
+    expect(host.portKnockSequence).toEqual([
+      { port: 1234, protocol: "tcp", delay: 100 },
+    ]);
+  });
+
 });


### PR DESCRIPTION
## Problem

`resolveHostById` in `src/backend/hosts/host-resolver.ts` JSON-parses every serialized column — `jumpHosts`, `tunnelConnections`, `statsConfig`, `terminalConfig`, `socks5ProxyChain`, `quickActions` — **except** `portKnockSequence`.

An empty port-knock config is persisted as the **string** `"[]"` (the UI saves an empty array). Because `portKnockSequence` is never parsed, it stays a string, and the terminal code then evaluates `resolvedHostData.portKnockSequence.length > 0` on that string:

- `"[]".length === 2` → truthy → the backend logs `Loaded 2 port knock(s) from server-side host data` and `Port knocking <ip> (2 ports)` and attempts a knock for a host that has **no** knock configured.
- The `(2 ports)` is not a knock count — it's the character length of `"[]"`.

For a **real** knock sequence the same omission bites harder: the JSON string is never turned into the `Array<{ port, protocol?, delay? }>` that `performPortKnocking` iterates, so a genuine knock sequence would iterate string characters (`Number(char)` → `NaN` → skipped) and **never actually knock** — the host would silently fail to connect on setups that require knocking.

## Fix

Parse `portKnockSequence` like the sibling JSON columns:

- `"[]"` → `[]` → `length === 0` → no bogus log, no knock.
- a real sequence string → the array `performPortKnocking` expects.

## Tests

Adds two unit tests to `host-resolver.test.ts` covering both cases (`"[]"` → `[]`, and a real JSON sequence → parsed array). Full suite green (13/13); `tsc -p tsconfig.node.json` clean.