### PR TITLE
fix tmux UTF-8 and non-login PATH handling

### DIFF
--- a/src/backend/hosts/tmux/helper.ts
+++ b/src/backend/hosts/tmux/helper.ts
@@ -22,12 +22,12 @@ const TMUX_PATH_DIRS = [
 ];
 
 export function withTmuxPath(command: string): string {
-  const script = `PATH=${TMUX_PATH_DIRS.join(":")}:$PATH; export PATH; ${command}`;
+  const script = `PATH=${TMUX_PATH_DIRS.join(":")}:"$PATH"; export PATH; ${command}`;
   return `/bin/sh -c ${shellEscape(script)}`;
 }
 
 export function tmuxCommand(args: string): string {
-  return withTmuxPath(`tmux ${args}`);
+  return withTmuxPath(`tmux -u ${args}`);
 }
 
 /**

--- a/src/backend/tests/hosts/tmux/helper.test.ts
+++ b/src/backend/tests/hosts/tmux/helper.test.ts
@@ -1,4 +1,5 @@
 import { EventEmitter } from "node:events";
+import { execFileSync } from "node:child_process";
 import type { Client } from "ssh2";
 import { describe, expect, it } from "vitest";
 import {
@@ -8,24 +9,27 @@ import {
 } from "../../../hosts/tmux/helper.js";
 
 describe("tmux command path handling", () => {
-  it("adds common non-login shell tmux paths", () => {
-    const command = withTmuxPath("command -v tmux");
-
-    expect(command).toMatch(/^\/bin\/sh -c '/);
-    expect(command).toContain("/opt/homebrew/bin");
-    expect(command).toContain("/usr/local/bin");
-    expect(command).toContain("/opt/bin");
-    expect(command).toContain("/usr/pkg/bin");
-    expect(command).toContain(":$PATH; export PATH; command -v tmux");
-  });
-
-  it("wraps tmux invocations with the same path", () => {
-    expect(tmuxCommand("list-sessions")).toMatch(
-      /^\/bin\/sh -c 'PATH=.*:\$PATH; export PATH; tmux list-sessions'$/,
+  it("prepends all non-login tmux paths while preserving inherited PATH", () => {
+    expect(withTmuxPath("command -v tmux")).toBe(
+      `/bin/sh -c 'PATH=/opt/homebrew/bin:/usr/local/bin:/opt/bin:/usr/pkg/bin:"$PATH"; export PATH; command -v tmux'`,
     );
   });
 
-  it("detects suffixed tmux versions without parsing the version number", async () => {
+  it("shell-escapes embedded single quotes in wrapped commands", () => {
+    const command = withTmuxPath(`printf '%s' "can't"`);
+
+    expect(execFileSync("/bin/sh", ["-c", command], { encoding: "utf8" })).toBe(
+      "can't",
+    );
+  });
+
+  it("runs every tmux invocation in UTF-8 mode through the path wrapper", () => {
+    expect(tmuxCommand("list-sessions")).toBe(
+      `/bin/sh -c 'PATH=/opt/homebrew/bin:/usr/local/bin:/opt/bin:/usr/pkg/bin:"$PATH"; export PATH; tmux -u list-sessions'`,
+    );
+  });
+
+  it("detects tmux with the UTF-8 wrapper", async () => {
     const commands: string[] = [];
     const conn = {
       exec(command: string, callback: (error: null, stream: never) => void) {
@@ -51,6 +55,9 @@ describe("tmux command path handling", () => {
       available: true,
       sessions: [],
     });
-    expect(commands[0]).toContain("tmux -V");
+    expect(commands).toEqual([
+      `/bin/sh -c 'PATH=/opt/homebrew/bin:/usr/local/bin:/opt/bin:/usr/pkg/bin:"$PATH"; export PATH; tmux -u -V'`,
+      `/bin/sh -c 'PATH=/opt/homebrew/bin:/usr/local/bin:/opt/bin:/usr/pkg/bin:"$PATH"; export PATH; tmux -u list-sessions -F "#{session_name}|#{session_created}|#{session_activity}|#{session_windows}|#{session_attached}" 2>/dev/null'`,
+    ]);
   });
 });


### PR DESCRIPTION
## Summary

- Preserve the inherited `PATH` as one quoted value in the non-login shell wrapper.
- Start every tmux client with `-u` so UTF-8 mode does not depend on the remote locale.
- Add focused regression coverage for path prefixes, shell escaping, command wrapping, and tmux detection.

## Root cause

The remote command wrapper expanded the inherited `PATH` without quotes, which could break command discovery when a path component contained whitespace. It also started tmux without forcing UTF-8 mode, so locale-limited remote sessions could create a non-UTF-8 client and corrupt non-ASCII terminal output.

## Impact

Tmux discovery continues to cover common non-login installation paths while preserving the complete inherited path. Attached and newly created tmux sessions consistently use UTF-8 mode.

## Validation

- `npx vitest run src/backend/tests/hosts/tmux/helper.test.ts` (4 tests)
- Prettier check on the changed files
- ESLint on the changed files
- `npm run type-check`
- `git diff --check`
