### PR TITLE
Fix data export failing on Docker deployments

### DIFF
--- a/src/backend/database/database.ts
+++ b/src/backend/database/database.ts
@@ -713,7 +713,7 @@ app.post("/database/export", authenticateJWT, async (req, res) => {
     }
 
     const timestamp = new Date().toISOString().replace(/[:.]/g, "-");
-    const filename = `termix-export-${user[0].username}-${timestamp}.sqlite`;
+    const filename = `termix-export-${user.username}-${timestamp}.sqlite`;
     const tempPath = path.join(tempDir, filename);
 
     apiLogger.info("Creating export database", {
@@ -882,7 +882,7 @@ app.post("/database/export", authenticateJWT, async (req, res) => {
         );
       `);
 
-      const userRecord = user[0];
+      const userRecord = user;
       const insertUser = exportDb.prepare(`
         INSERT INTO users (id, username, password_hash, is_admin, is_oidc, oidc_identifier, client_id, client_secret, issuer_url, authorization_url, token_url, identifier_path, name_path, scopes, totp_secret, totp_enabled, totp_backup_codes)
         VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)

--- a/src/ui/lib/database-transfer-url.ts
+++ b/src/ui/lib/database-transfer-url.ts
@@ -20,10 +20,7 @@ export function getDatabaseTransferUrl(
     return `${serverUrl.replace(/\/$/, "")}/database/${operation}`;
   }
 
-  const development =
-    location.port === "5173" ||
-    location.hostname === "localhost" ||
-    location.hostname === "127.0.0.1";
+  const development = location.port === "5173";
 
   if (development) {
     return `http://localhost:30001/database/${operation}`;


### PR DESCRIPTION
# Overview

Fixes user data export (SQLite) failing on Docker/localhost deployments — requests either crashed the backend or never reached it, depending on how the app was accessed.

- [ ] Added: ...
- [ ] Updated: ...
- [ ] Removed: ...
- [x] Fixed: User data export throwing `TypeError: Cannot read properties of undefined (reading 'username')`, and export/import requests being sent to an unreachable port on Docker deployments

# Changes Made

- `src/backend/database/database.ts`: `userRepository.findById()` returns a single `UserRecord | null`, not an array, but the `/database/export` route indexed it as `user[0]` in two places (building the export filename and building the exported `users` row). This was always `undefined`, causing the export request to crash with a 500 before any file was produced. Changed both to use `user` directly.
- `src/ui/lib/database-transfer-url.ts`: the dev-mode check treated *any* request from `hostname === "localhost"` or `"127.0.0.1"` as local development and forced the request straight to `http://localhost:30001/...`, bypassing nginx. This works only when port 30001 is published directly to the host (e.g. the raw `dev:docker` npm script), but breaks Docker Compose deployments (e.g. `docker/compose-dev.yml`) that only publish the nginx port, causing `net::ERR_CONNECTION_REFUSED`. Narrowed the check to the actual Vite dev server port (`5173`) only, so all other deployments correctly route through nginx like the rest of the app's API calls already do.

# Related Issues

- Closes #ISSUE_NUMBER

# Screenshots / Demos

<img width="448" height="147" alt="image" src="https://github.com/user-attachments/assets/9fd00a6a-3afc-4cc2-9d96-8ef1fac5abb0" />

<img width="627" height="90" alt="image" src="https://github.com/user-attachments/assets/c08047bd-5ef7-486c-83d0-22d8e39c9f92" />


# Checklist

- [x] Code follows project style guidelines
- [ ] Supports mobile and desktop UI/app (if applicable)
- [x] I have read [Contributing.md](https://github.com/Termix-SSH/Termix/blob/main/CONTRIBUTING.md)
- [x] This is not a translation request. See [docs](https://docs.termix.site/translations)
