### PR TITLE
fix(desktop): stop suppressing the update prompt, and make the version badge reachable

### DIFF
--- a/src/ui/api/system-status-api.ts
+++ b/src/ui/api/system-status-api.ts
@@ -137,9 +137,10 @@ export interface VersionInfo {
   };
   cached?: boolean;
   cache_age?: number;
-  // The endpoint carries more than the fields above, and older callers read
-  // some of them (`updateAvailable`, for one), so stay a superset of the
-  // `Record<string, unknown>` this used to return.
+  // Callers reach for fields beyond the ones above -- SystemOverviewWidget
+  // reads `updateAvailable`, which this endpoint does not in fact return --
+  // so keep the index signature the previous `Record<string, unknown>` gave
+  // them. Typing those reads out of existence is a separate change.
   [key: string]: unknown;
 }
 

--- a/src/ui/api/system-status-api.ts
+++ b/src/ui/api/system-status-api.ts
@@ -124,9 +124,26 @@ export async function getReleasesRSS(
   }
 }
 
-export async function getVersionInfo(
-  checkRemote = true,
-): Promise<Record<string, unknown>> {
+export interface VersionInfo {
+  status?: "up_to_date" | "requires_update" | "beta";
+  localVersion?: string;
+  remoteVersion?: string;
+  latest_release?: {
+    tag_name?: string;
+    name?: string;
+    published_at?: string;
+    html_url?: string;
+    body?: string;
+  };
+  cached?: boolean;
+  cache_age?: number;
+  // The endpoint carries more than the fields above, and older callers read
+  // some of them (`updateAvailable`, for one), so stay a superset of the
+  // `Record<string, unknown>` this used to return.
+  [key: string]: unknown;
+}
+
+export async function getVersionInfo(checkRemote = true): Promise<VersionInfo> {
   try {
     const response = await authApi.get(
       `/version${checkRemote ? "" : "?checkRemote=false"}`,

--- a/src/ui/api/system-status-api.ts
+++ b/src/ui/api/system-status-api.ts
@@ -143,6 +143,14 @@ export interface VersionInfo {
   [key: string]: unknown;
 }
 
+// Where the release page lives inside a version response. Both surfaces that
+// render a version badge read it, and an empty string is what they treat as
+// "no link to offer", so keep the shape in one place rather than repeating the
+// optional chain at each call site.
+export function releaseUrlFrom(info: VersionInfo | null | undefined): string {
+  return info?.latest_release?.html_url ?? "";
+}
+
 export async function getVersionInfo(checkRemote = true): Promise<VersionInfo> {
   try {
     const response = await authApi.get(

--- a/src/ui/components/version-badge.tsx
+++ b/src/ui/components/version-badge.tsx
@@ -1,0 +1,52 @@
+import { useTranslation } from "react-i18next";
+
+interface VersionBadgeProps {
+  status: "up_to_date" | "requires_update" | "beta";
+  releaseUrl?: string;
+  className?: string;
+}
+
+export function VersionBadge({
+  status,
+  releaseUrl,
+  className = "",
+}: VersionBadgeProps) {
+  const { t } = useTranslation();
+
+  const badgeClassName = `text-[10px] px-1.5 py-0.5 font-semibold leading-none ${
+    status === "beta"
+      ? "bg-blue-500/20 text-blue-400"
+      : status === "requires_update"
+        ? "bg-yellow-500/20 text-yellow-400"
+        : "bg-accent-brand/20 text-accent-brand"
+  }${className ? ` ${className}` : ""}`;
+
+  const label =
+    status === "beta"
+      ? t("dashboard.beta").toUpperCase()
+      : status === "requires_update"
+        ? t("dashboard.updateAvailable").toUpperCase()
+        : t("dashboardTab.stable");
+
+  // Only the update case leads anywhere. Wherever this badge is rendered it is
+  // the one place a pending release is announced, so it also has to be the way
+  // to reach it -- otherwise "UPDATE AVAILABLE" is a dead end. The label alone
+  // does not say where the link goes, hence the spelled-out accessible name.
+  if (status === "requires_update" && releaseUrl) {
+    const linkLabel = t("versionCheck.updateLinkLabel");
+    return (
+      <a
+        href={releaseUrl}
+        target="_blank"
+        rel="noopener noreferrer"
+        title={linkLabel}
+        aria-label={linkLabel}
+        className={`${badgeClassName} cursor-pointer hover:underline`}
+      >
+        {label}
+      </a>
+    );
+  }
+
+  return <span className={badgeClassName}>{label}</span>;
+}

--- a/src/ui/dashboard/DashboardTab.tsx
+++ b/src/ui/dashboard/DashboardTab.tsx
@@ -31,6 +31,7 @@ import {
   getSSHHosts,
   getUptime,
   getVersionInfo,
+  releaseUrlFrom,
   getDatabaseHealth,
   getRecentActivity,
   getTunnelStatuses,
@@ -1378,7 +1379,7 @@ export function DashboardTab({
       .then((info) => {
         setVersionText(info.localVersion ?? "");
         setVersionStatus(info.status ?? "up_to_date");
-        setReleaseUrl(info.latest_release?.html_url ?? "");
+        setReleaseUrl(releaseUrlFrom(info));
       })
       .catch(() => {});
     getDatabaseHealth()

--- a/src/ui/dashboard/DashboardTab.tsx
+++ b/src/ui/dashboard/DashboardTab.tsx
@@ -24,6 +24,7 @@ import {
   Zap,
 } from "lucide-react";
 import { Kbd } from "@/components/kbd";
+import { VersionBadge } from "@/components/version-badge";
 import { DASHBOARD_CARDS } from "@/lib/theme";
 import type { DashboardCardId, TabType, Host } from "@/types/ui-types";
 import {
@@ -130,28 +131,18 @@ function StatsBarCard({
   uptimeFormatted,
   versionText,
   versionStatus,
+  releaseUrl,
   dbHealth,
 }: {
   hosts: Host[];
   uptimeFormatted: string;
   versionText: string;
   versionStatus: "up_to_date" | "requires_update" | "beta";
+  releaseUrl: string;
   dbHealth: "healthy" | "error";
 }) {
   const { t } = useTranslation();
   const online = hosts.filter((h) => h.online).length;
-  const statusLabel =
-    versionStatus === "beta"
-      ? t("dashboard.beta").toUpperCase()
-      : versionStatus === "requires_update"
-        ? t("dashboard.updateAvailable").toUpperCase()
-        : t("dashboardTab.stable");
-  const statusColor =
-    versionStatus === "beta"
-      ? "bg-blue-500/20 text-blue-400"
-      : versionStatus === "requires_update"
-        ? "bg-yellow-500/20 text-yellow-400"
-        : "bg-accent-brand/20 text-accent-brand";
   return (
     <Card className="grid grid-cols-4 divide-x divide-border overflow-hidden w-full h-full py-0 gap-0">
       <div className="flex flex-col justify-center px-4 py-2 gap-1">
@@ -161,11 +152,11 @@ function StatsBarCard({
         <span className="text-xl font-bold text-accent-brand leading-none">
           {versionText || "—"}
         </span>
-        <span
-          className={`text-[10px] px-1.5 py-0.5 w-fit font-semibold leading-none ${statusColor}`}
-        >
-          {statusLabel}
-        </span>
+        <VersionBadge
+          status={versionStatus}
+          releaseUrl={releaseUrl}
+          className="w-fit"
+        />
       </div>
       <div className="flex flex-col justify-center px-4 py-2 gap-1">
         <span className="text-[10px] text-muted-foreground uppercase tracking-widest font-semibold">
@@ -792,6 +783,7 @@ function CardItem({
   uptimeFormatted,
   versionText,
   versionStatus,
+  releaseUrl,
   dbHealth,
   credentialCount,
   activeTunnelCount,
@@ -822,6 +814,7 @@ function CardItem({
   uptimeFormatted: string;
   versionText: string;
   versionStatus: "up_to_date" | "requires_update" | "beta";
+  releaseUrl: string;
   dbHealth: "healthy" | "error";
   credentialCount: number;
   activeTunnelCount: number;
@@ -890,6 +883,7 @@ function CardItem({
             uptimeFormatted={uptimeFormatted}
             versionText={versionText}
             versionStatus={versionStatus}
+            releaseUrl={releaseUrl}
             dbHealth={dbHealth}
           />
         )}
@@ -1048,6 +1042,7 @@ type PanelColumnProps = {
   uptimeFormatted: string;
   versionText: string;
   versionStatus: "up_to_date" | "requires_update" | "beta";
+  releaseUrl: string;
   dbHealth: "healthy" | "error";
   credentialCount: number;
   activeTunnelCount: number;
@@ -1080,6 +1075,7 @@ function PanelColumn({
   uptimeFormatted,
   versionText,
   versionStatus,
+  releaseUrl,
   dbHealth,
   credentialCount,
   activeTunnelCount,
@@ -1138,6 +1134,7 @@ function PanelColumn({
             uptimeFormatted={uptimeFormatted}
             versionText={versionText}
             versionStatus={versionStatus}
+            releaseUrl={releaseUrl}
             dbHealth={dbHealth}
             credentialCount={credentialCount}
             activeTunnelCount={activeTunnelCount}
@@ -1288,6 +1285,7 @@ export function DashboardTab({
   const [versionStatus, setVersionStatus] = useState<
     "up_to_date" | "requires_update" | "beta"
   >("up_to_date");
+  const [releaseUrl, setReleaseUrl] = useState("");
   const [dbHealth, setDbHealth] = useState<"healthy" | "error">("healthy");
   const [credentialCount, setCredentialCount] = useState(0);
   const [activeTunnelCount, setActiveTunnelCount] = useState(0);
@@ -1380,6 +1378,7 @@ export function DashboardTab({
       .then((info) => {
         setVersionText(info.localVersion ?? "");
         setVersionStatus(info.status ?? "up_to_date");
+        setReleaseUrl(info.latest_release?.html_url ?? "");
       })
       .catch(() => {});
     getDatabaseHealth()
@@ -1606,6 +1605,7 @@ export function DashboardTab({
     uptimeFormatted,
     versionText,
     versionStatus,
+    releaseUrl,
     dbHealth,
     credentialCount,
     activeTunnelCount,
@@ -1720,6 +1720,7 @@ export function DashboardTab({
                   uptimeFormatted={uptimeFormatted}
                   versionText={versionText}
                   versionStatus={versionStatus}
+                  releaseUrl={releaseUrl}
                   dbHealth={dbHealth}
                 />
               )}

--- a/src/ui/locales/en.json
+++ b/src/ui/locales/en.json
@@ -434,6 +434,7 @@
     "upToDate": "App is Up to Date",
     "currentVersion": "You are running version {{version}}",
     "updateAvailable": "Update Available",
+    "updateLinkLabel": "Update available — open the release notes on GitHub",
     "newVersionAvailable": "A new version is available! You are running {{current}}, but {{latest}} is available.",
     "betaVersion": "Beta Version",
     "betaVersionDesc": "You are running {{current}}, which is newer than the latest stable release {{latest}}.",

--- a/src/ui/main-axios.ts
+++ b/src/ui/main-axios.ts
@@ -2002,6 +2002,7 @@ export {
   dismissAlert,
   getReleasesRSS,
   getVersionInfo,
+  releaseUrlFrom,
   getDatabaseHealth,
 } from "@/api/system-status-api";
 

--- a/src/ui/sidebar/UserProfilePanel.tsx
+++ b/src/ui/sidebar/UserProfilePanel.tsx
@@ -35,6 +35,7 @@ import { shouldForceLocalPreferenceStorage } from "@/settings/remote-sync-state"
 import { C2STunnelPresetManager } from "@/user/C2STunnelPresetManager";
 import { Button } from "@/components/button";
 import { Input } from "@/components/input";
+import { VersionBadge } from "@/components/version-badge";
 import {
   Dialog,
   DialogContent,
@@ -485,6 +486,7 @@ export function UserProfilePanel({
   const [versionStatus, setVersionStatus] = useState<
     "up_to_date" | "requires_update" | "beta"
   >("up_to_date");
+  const [releaseUrl, setReleaseUrl] = useState("");
   const [isOidc, setIsOidc] = useState(false);
   const [isDualAuth, setIsDualAuth] = useState(false);
 
@@ -692,6 +694,7 @@ export function UserProfilePanel({
       .then((info) => {
         setVersion(info.localVersion);
         setVersionStatus(info.status ?? "up_to_date");
+        setReleaseUrl(info.latest_release?.html_url ?? "");
       })
       .catch(() => {});
   }, [t]);
@@ -1483,21 +1486,7 @@ export function UserProfilePanel({
               <span className="text-sm font-bold text-accent-brand">
                 {version ? `v${version}` : "—"}
               </span>
-              <span
-                className={`text-[10px] px-1.5 py-0.5 font-semibold leading-none ${
-                  versionStatus === "beta"
-                    ? "bg-blue-500/20 text-blue-400"
-                    : versionStatus === "requires_update"
-                      ? "bg-yellow-500/20 text-yellow-400"
-                      : "bg-accent-brand/20 text-accent-brand"
-                }`}
-              >
-                {versionStatus === "beta"
-                  ? t("dashboard.beta").toUpperCase()
-                  : versionStatus === "requires_update"
-                    ? t("dashboard.updateAvailable").toUpperCase()
-                    : t("dashboardTab.stable")}
-              </span>
+              <VersionBadge status={versionStatus} releaseUrl={releaseUrl} />
             </div>
           </div>
 

--- a/src/ui/sidebar/UserProfilePanel.tsx
+++ b/src/ui/sidebar/UserProfilePanel.tsx
@@ -14,6 +14,7 @@ import {
   enableTOTP,
   disableTOTP,
   getVersionInfo,
+  releaseUrlFrom,
   getUserRoles,
   saveUserPreferences,
   getUserPreferences,
@@ -694,7 +695,7 @@ export function UserProfilePanel({
       .then((info) => {
         setVersion(info.localVersion);
         setVersionStatus(info.status ?? "up_to_date");
-        setReleaseUrl(info.latest_release?.html_url ?? "");
+        setReleaseUrl(releaseUrlFrom(info));
       })
       .catch(() => {});
   }, [t]);

--- a/src/ui/tests/api/system-status-api.test.ts
+++ b/src/ui/tests/api/system-status-api.test.ts
@@ -1,0 +1,46 @@
+import { describe, expect, it } from "vitest";
+import { releaseUrlFrom } from "../../api/system-status-api";
+
+describe("releaseUrlFrom", () => {
+  it("hands back the release page so the version badge can link to it", () => {
+    expect(
+      releaseUrlFrom({
+        status: "requires_update",
+        localVersion: "2.6.0",
+        remoteVersion: "2.6.1",
+        latest_release: {
+          tag_name: "release-2.6.1-tag",
+          name: "release-2.6.1",
+          published_at: "2026-08-06T19:49:43Z",
+          html_url:
+            "https://github.com/Termix-SSH/Termix/releases/tag/release-2.6.1-tag",
+          body: "",
+        },
+      }),
+    ).toBe(
+      "https://github.com/Termix-SSH/Termix/releases/tag/release-2.6.1-tag",
+    );
+  });
+
+  it("returns an empty string when the response carries no release", () => {
+    // The badge treats "" as "nothing to link to" and stays an inert span, so
+    // a version response without a release must not produce a dead anchor.
+    expect(releaseUrlFrom({ status: "up_to_date", localVersion: "2.6.1" })).toBe(
+      "",
+    );
+  });
+
+  it("returns an empty string when the release carries no URL", () => {
+    expect(
+      releaseUrlFrom({
+        status: "requires_update",
+        latest_release: { tag_name: "release-2.6.1-tag" },
+      }),
+    ).toBe("");
+  });
+
+  it("tolerates a missing response, since the caller's fetch can fail", () => {
+    expect(releaseUrlFrom(undefined)).toBe("");
+    expect(releaseUrlFrom(null)).toBe("");
+  });
+});

--- a/src/ui/tests/components/version-badge.test.tsx
+++ b/src/ui/tests/components/version-badge.test.tsx
@@ -1,0 +1,95 @@
+import { describe, it, expect, vi, afterEach } from "vitest";
+import { render, screen, cleanup } from "@testing-library/react";
+
+vi.mock("react-i18next", () => ({
+  useTranslation: () => ({ t: (key: string) => key }),
+}));
+
+import { VersionBadge } from "../../components/version-badge";
+
+afterEach(cleanup);
+
+// `t` is mocked to the identity above, so every label below is the raw key.
+const RELEASE_URL =
+  "https://github.com/Termix-SSH/Termix/releases/tag/release-2.6.1-tag";
+const LINK_LABEL = "versionCheck.updateLinkLabel";
+const UPDATE_TEXT = "dashboard.updateAvailable".toUpperCase();
+
+describe("VersionBadge", () => {
+  it("links to the release when an update is available", () => {
+    render(<VersionBadge status="requires_update" releaseUrl={RELEASE_URL} />);
+
+    // Queried by its accessible name: the badge text alone ("UPDATE
+    // AVAILABLE") never says where the link goes.
+    const link = screen.getByRole("link", { name: LINK_LABEL });
+    expect(link.getAttribute("href")).toBe(RELEASE_URL);
+    expect(link.getAttribute("target")).toBe("_blank");
+    expect(link.getAttribute("rel")).toContain("noopener");
+    expect(link.getAttribute("title")).toBe(LINK_LABEL);
+    expect(link.textContent).toBe(UPDATE_TEXT);
+  });
+
+  it("keeps the yellow update treatment on the link", () => {
+    render(<VersionBadge status="requires_update" releaseUrl={RELEASE_URL} />);
+
+    const className = screen.getByRole("link").className;
+    expect(className).toContain("bg-yellow-500/20");
+    expect(className).toContain("text-yellow-400");
+    expect(className).toContain("hover:underline");
+  });
+
+  it("stays an inert badge when the response carried no release URL", () => {
+    // A dead anchor is worse than no anchor: it looks actionable and isn't.
+    render(<VersionBadge status="requires_update" />);
+
+    expect(screen.queryByRole("link")).toBeNull();
+    expect(screen.getByText(UPDATE_TEXT)).toBeTruthy();
+  });
+
+  it("stays inert when up to date, even if a release URL is known", () => {
+    render(<VersionBadge status="up_to_date" releaseUrl={RELEASE_URL} />);
+
+    expect(screen.queryByRole("link")).toBeNull();
+    expect(screen.getByText("dashboardTab.stable")).toBeTruthy();
+  });
+
+  it("stays inert on the beta channel, which the release page does not serve", () => {
+    render(<VersionBadge status="beta" releaseUrl={RELEASE_URL} />);
+
+    expect(screen.queryByRole("link")).toBeNull();
+    expect(screen.getByText("dashboard.beta".toUpperCase())).toBeTruthy();
+  });
+
+  // The dashboard's stats bar sits in a flex column, so its badge needs
+  // `w-fit` to stop the background stretching the full column width. The
+  // profile panel's badge does not. Both must come out of one component.
+  it("appends the caller's className without dropping the status classes", () => {
+    render(
+      <VersionBadge
+        status="requires_update"
+        releaseUrl={RELEASE_URL}
+        className="w-fit"
+      />,
+    );
+
+    const className = screen.getByRole("link").className;
+    expect(className).toContain("w-fit");
+    expect(className).toContain("bg-yellow-500/20");
+  });
+
+  it("applies the className on the inert span too", () => {
+    render(<VersionBadge status="up_to_date" className="w-fit" />);
+
+    const badge = screen.getByText("dashboardTab.stable");
+    expect(badge.tagName).toBe("SPAN");
+    expect(badge.className).toContain("w-fit");
+    expect(badge.className).toContain("bg-accent-brand/20");
+  });
+
+  it("emits no stray whitespace class when no className is passed", () => {
+    render(<VersionBadge status="up_to_date" />);
+
+    const badge = screen.getByText("dashboardTab.stable");
+    expect(badge.className).toBe(badge.className.trim());
+  });
+});

--- a/src/ui/tests/user/ElectronVersionCheck.test.tsx
+++ b/src/ui/tests/user/ElectronVersionCheck.test.tsx
@@ -1,0 +1,204 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+import {
+  render,
+  screen,
+  waitFor,
+  cleanup,
+  fireEvent,
+} from "@testing-library/react";
+
+const mainAxios = vi.hoisted(() => ({
+  checkElectronUpdate: vi.fn(),
+}));
+
+vi.mock("@/main-axios.ts", () => mainAxios);
+
+vi.mock("react-i18next", () => ({
+  useTranslation: () => ({
+    t: (key: string, opts?: Record<string, unknown>) =>
+      opts ? `${key}:${JSON.stringify(opts)}` : key,
+  }),
+}));
+
+// The whole component is a no-op outside Electron, so every test here needs the
+// desktop build.
+vi.mock("@/lib/electron", () => ({ isElectron: () => true }));
+
+import { ElectronVersionCheck } from "../../user/ElectronVersionCheck";
+
+const DISMISS_KEY = "electron-version-check-dismissed";
+
+type ElectronTestWindow = Window &
+  typeof globalThis & {
+    electronAPI?: { getAppVersion?: () => Promise<string | undefined> };
+  };
+
+function updateAvailable(localVersion: string, remoteVersion: string) {
+  return {
+    success: true,
+    status: "requires_update" as const,
+    localVersion,
+    remoteVersion,
+    latest_release: {
+      tag_name: `v${remoteVersion}`,
+      name: `Termix ${remoteVersion}`,
+      published_at: "2026-07-01T00:00:00Z",
+      html_url: `https://github.com/Termix-SSH/Termix/releases/tag/v${remoteVersion}`,
+      body: "",
+    },
+  };
+}
+
+function upToDate(version: string) {
+  return {
+    success: true,
+    status: "up_to_date" as const,
+    localVersion: version,
+    remoteVersion: version,
+  };
+}
+
+// Renders and waits until the check has resolved and the modal body is on
+// screen, so that a later `not.toHaveBeenCalled()` is not vacuously true.
+async function renderAndSettle(onContinue: () => void) {
+  render(<ElectronVersionCheck onContinue={onContinue} />);
+  await waitFor(() => {
+    expect(mainAxios.checkElectronUpdate).toHaveBeenCalledTimes(1);
+  });
+  await waitFor(() => {
+    expect(screen.getByText("common.continue")).toBeTruthy();
+  });
+}
+
+beforeEach(() => {
+  localStorage.clear();
+  mainAxios.checkElectronUpdate.mockReset();
+  (window as ElectronTestWindow).electronAPI = {
+    getAppVersion: vi.fn(async () => "2.6.0"),
+  };
+});
+
+afterEach(() => {
+  cleanup();
+  localStorage.clear();
+  delete (window as ElectronTestWindow).electronAPI;
+});
+
+describe("ElectronVersionCheck - dismissal is keyed on the offered version", () => {
+  it("still prompts when the stored dismissal is the local version and a newer release exists", async () => {
+    // Regression: the dismissal used to store the LOCAL version, and the
+    // up-to-date branch wrote it with no user action at all. A user who ran
+    // 2.6.0 while it was current had "2.6.0" stored, so once 2.6.1 shipped the
+    // modal was skipped on every launch - suppressed for exactly the users who
+    // had not updated yet.
+    localStorage.setItem(DISMISS_KEY, "2.6.0");
+    mainAxios.checkElectronUpdate.mockResolvedValue(
+      updateAvailable("2.6.0", "2.6.1"),
+    );
+    const onContinue = vi.fn();
+
+    await renderAndSettle(onContinue);
+
+    expect(onContinue).not.toHaveBeenCalled();
+    expect(screen.getByText("versionCheck.updateRequired")).toBeTruthy();
+  });
+
+  it("stores the remote version when the user dismisses the prompt", async () => {
+    mainAxios.checkElectronUpdate.mockResolvedValue(
+      updateAvailable("2.6.0", "2.6.1"),
+    );
+    const onContinue = vi.fn();
+
+    await renderAndSettle(onContinue);
+    fireEvent.click(screen.getByText("common.continue"));
+
+    await waitFor(() => {
+      expect(localStorage.getItem(DISMISS_KEY)).toBe("2.6.1");
+    });
+    expect(onContinue).toHaveBeenCalledTimes(1);
+  });
+
+  it("skips the prompt on a later launch offering the same remote version", async () => {
+    localStorage.setItem(DISMISS_KEY, "2.6.1");
+    mainAxios.checkElectronUpdate.mockResolvedValue(
+      updateAvailable("2.6.0", "2.6.1"),
+    );
+    const onContinue = vi.fn();
+
+    render(<ElectronVersionCheck onContinue={onContinue} />);
+
+    await waitFor(() => {
+      expect(onContinue).toHaveBeenCalledTimes(1);
+    });
+  });
+
+  it("prompts again once a newer release than the dismissed one appears", async () => {
+    localStorage.setItem(DISMISS_KEY, "2.6.1");
+    mainAxios.checkElectronUpdate.mockResolvedValue(
+      updateAvailable("2.6.0", "2.7.0"),
+    );
+    const onContinue = vi.fn();
+
+    await renderAndSettle(onContinue);
+
+    expect(onContinue).not.toHaveBeenCalled();
+    expect(screen.getByText("versionCheck.updateRequired")).toBeTruthy();
+  });
+
+  it("keys a dismissed beta prompt on the remote version too", async () => {
+    // Local ahead of the published release: dismissing must still record what
+    // was offered, so the next release re-prompts.
+    mainAxios.checkElectronUpdate.mockResolvedValue({
+      success: true,
+      status: "beta" as const,
+      localVersion: "2.7.0-beta",
+      remoteVersion: "2.6.1",
+    });
+    const onContinue = vi.fn();
+
+    await renderAndSettle(onContinue);
+    // Both the modal title and the alert heading use this key.
+    expect(screen.getAllByText("versionCheck.betaVersion").length).toBe(2);
+    fireEvent.click(screen.getByText("common.continue"));
+
+    await waitFor(() => {
+      expect(localStorage.getItem(DISMISS_KEY)).toBe("2.6.1");
+    });
+  });
+
+  it("continues without prompting when up to date, recording the offered version", async () => {
+    mainAxios.checkElectronUpdate.mockResolvedValue(upToDate("2.6.1"));
+    const onContinue = vi.fn();
+
+    render(<ElectronVersionCheck onContinue={onContinue} />);
+
+    await waitFor(() => {
+      expect(onContinue).toHaveBeenCalledTimes(1);
+    });
+    expect(localStorage.getItem(DISMISS_KEY)).toBe("2.6.1");
+  });
+
+  it("does not record a dismissal when the check itself fails", async () => {
+    mainAxios.checkElectronUpdate.mockResolvedValue({
+      success: false,
+      error: "Check failed",
+    });
+    const onContinue = vi.fn();
+
+    await renderAndSettle(onContinue);
+
+    // No offered version exists, so nothing may be written automatically and
+    // nothing may be suppressed.
+    expect(localStorage.getItem(DISMISS_KEY)).toBeNull();
+    expect(onContinue).not.toHaveBeenCalled();
+
+    fireEvent.click(screen.getByText("common.continue"));
+
+    // Dismissing falls back to the local version, which cannot match a later
+    // release and so cannot suppress its prompt.
+    await waitFor(() => {
+      expect(localStorage.getItem(DISMISS_KEY)).toBe("2.6.0");
+    });
+    expect(onContinue).toHaveBeenCalledTimes(1);
+  });
+});

--- a/src/ui/user/ElectronVersionCheck.tsx
+++ b/src/ui/user/ElectronVersionCheck.tsx
@@ -17,9 +17,8 @@ type ElectronWindow = Window & {
 
 export function ElectronVersionCheck({ onContinue }: VersionCheckModalProps) {
   const { t } = useTranslation();
-  const [versionInfo, setVersionInfo] = useState<Record<
-    string,
-    unknown
+  const [versionInfo, setVersionInfo] = useState<Awaited<
+    ReturnType<typeof checkElectronUpdate>
   > | null>(null);
   const [versionChecking, setVersionChecking] = useState(false);
   const [versionDismissed] = useState(false);
@@ -35,23 +34,24 @@ export function ElectronVersionCheck({ onContinue }: VersionCheckModalProps) {
       const updateInfo = await checkElectronUpdate();
       setVersionInfo(updateInfo);
 
-      const currentVersion = await (
-        window as ElectronWindow
-      ).electronAPI?.getAppVersion?.();
+      // Keyed on the remote version being offered, not the local one: keying on
+      // the local version suppressed the prompt for exactly the users who had
+      // not updated yet, and only showed it again once they had.
+      const remoteVersion = updateInfo?.remoteVersion;
       const dismissedVersion = localStorage.getItem(
         "electron-version-check-dismissed",
       );
 
-      if (dismissedVersion === currentVersion) {
+      if (remoteVersion && dismissedVersion === remoteVersion) {
         onContinue();
         return;
       }
 
       if (updateInfo?.status === "up_to_date") {
-        if (currentVersion) {
+        if (remoteVersion) {
           localStorage.setItem(
             "electron-version-check-dismissed",
-            currentVersion,
+            remoteVersion,
           );
         }
         onContinue();
@@ -86,11 +86,16 @@ export function ElectronVersionCheck({ onContinue }: VersionCheckModalProps) {
   };
 
   const handleContinue = async () => {
-    const currentVersion = await (
-      window as ElectronWindow
-    ).electronAPI?.getAppVersion?.();
-    if (currentVersion) {
-      localStorage.setItem("electron-version-check-dismissed", currentVersion);
+    // Without a remote version (the check failed) fall back to the local one,
+    // which never matches a later release and so cannot suppress its prompt.
+    const dismissedVersion =
+      versionInfo?.remoteVersion ??
+      (await (window as ElectronWindow).electronAPI?.getAppVersion?.());
+    if (dismissedVersion) {
+      localStorage.setItem(
+        "electron-version-check-dismissed",
+        dismissedVersion,
+      );
     }
     onContinue();
   };


### PR DESCRIPTION
# Overview

The desktop app's startup update modal is suppressed for exactly the users it exists for, and the "UPDATE AVAILABLE" badge that remains is not clickable. Together they make a new release unreachable from inside the app.

- [x] Fixed: update prompt keyed on the offered remote version instead of the local one
- [x] Fixed: version badge links to the release on both surfaces that render it
- [x] Added: `components/version-badge.tsx`, extracted from two duplicated copies
- [x] Added: tests for both (there were none)

# Changes Made

### The modal never reappears once you are behind

`src/ui/user/ElectronVersionCheck.tsx` stored its dismissal under the **local** app version:

```js
const dismissedVersion = localStorage.getItem("electron-version-check-dismissed");
if (dismissedVersion === currentVersion) { onContinue(); return; }
...
if (updateInfo?.status === "up_to_date") {
  localStorage.setItem("electron-version-check-dismissed", currentVersion);
```

`currentVersion` is `app.getVersion()`, and the `up_to_date` branch writes it with **no user interaction at all**. So anyone who launches the app while current has their own version recorded. When the next release ships, `dismissedVersion === currentVersion` still holds, the modal is skipped on every launch, and it only comes back *after* they have already updated — the inverse of its purpose. This has been the behaviour since v2.3.0.

Confirmed on a real install: the app's leveldb held `electron-version-check-dismissed = 2.6.0` for the whole period 2.6.1 was available, then `= 2.6.1` after a manual update.

This PR keys the dismissal on the remote version being offered. It is backward compatible — an existing key holding `2.6.0` compares unequal against a remote `2.6.1`, so affected installs get prompted on their next launch, with no migration step. When the check fails there is no remote version, so nothing is written and no future prompt is suppressed.

### The badge was the only thing left, and it was inert

With the modal silent, the version badge is the sole signal a release exists. It was a plain `<span>` — no href, no handler, no tooltip — even though the `getVersionInfo()` response behind it already carries `latest_release.html_url`.

There were two near-identical copies of that badge, in `sidebar/UserProfilePanel.tsx` and in `StatsBarCard` in `dashboard/DashboardTab.tsx`. They are now one `VersionBadge` component. In the `requires_update` case it renders an anchor to the release with `target="_blank"`, `rel="noopener noreferrer"`, and an accessible name that says where it leads, since "UPDATE AVAILABLE" alone does not. The `beta` and stable cases are unchanged inert spans, and appearance is preserved on both surfaces (the dashboard's `w-fit` comes through a `className` passthrough).

`getVersionInfo()` returned `Record<string, unknown>`, so the release URL was not reachable without a cast. It now returns a `VersionInfo` interface. The index signature on it is deliberate: `SystemOverviewWidget` reads `updateAvailable` off this response even though `GET /version` does not return such a field, so the type stays as permissive as the one it replaced rather than turning an unrelated stale read into a build error. Worth a separate look — that widget also calls `getVersionInfo(false)`, and `checkRemote=false` short-circuits before any remote comparison, so its update indicator cannot fire either way.

### Tests

Neither `ElectronVersionCheck` nor the badge had any tests. Added 19 across `tests/user/ElectronVersionCheck.test.tsx`, `tests/components/version-badge.test.tsx` and `tests/api/system-status-api.test.ts`, covering dismissal keying, the up-to-date and check-failed paths, the beta channel, the badge's link/inert cases, and the read that supplies the URL.

That last one is deliberate: the badge component is unit-tested, but the line deciding whether it ever gets a URL was duplicated at both call sites and asserted nowhere, and a wrong property there still compiles because the response type keeps an index signature. It is now `releaseUrlFrom`, used by both surfaces and tested directly.

The regression is genuinely captured — reverting only `ElectronVersionCheck.tsx` and re-running its suite fails 5 of 7:

```
 × still prompts when the stored dismissal is the local version and a newer release exists
 × stores the remote version when the user dismisses the prompt
 × skips the prompt on a later launch offering the same remote version
 × keys a dismissed beta prompt on the remote version too
 × continues without prompting when up to date, recording the offered version
 Tests  5 failed | 2 passed (7)
```

Verified against `main` @ `57b2081`:

| | before | after |
|---|---|---|
| `npm run type-check` | clean | clean |
| `npm run lint` | 0 errors, 42 warnings | 0 errors, 42 warnings |
| `npm test` | 202 files, 1453 passed / 1 skipped | 205 files, 1472 passed / 1 skipped |

### Scope

This does not make the app self-updating — the link still opens a browser. Real in-app updates need `electron-updater` plus a `publish` config and release-workflow changes, which is a separate and much larger change; it stays on Termix-SSH/Support#1087. Nothing under `electron/`, `electron-builder.json`, or `.github/workflows/` is touched here.

# Related Issues

- Related to Termix-SSH/Support#1087

# Screenshots / Demos

Not included — the change is a link affordance on an existing badge and a modal that was already implemented but unreachable. The test output above is the demonstrable part.

# Checklist

- [x] Code follows project style guidelines
- [x] Supports mobile and desktop UI/app (if applicable) — both badge surfaces are desktop-shell views; no mobile view renders a version badge
- [x] I have read [Contributing.md](https://github.com/Termix-SSH/Termix/blob/main/CONTRIBUTING.md)
- [x] This is not a translation request. See [docs](https://docs.termix.site/translations)

One note on translations: the single new key is added to `src/ui/locales/en.json` only. Nothing under `src/ui/locales/translated/` is touched, so Crowdin stays authoritative.
