### PR TITLE
fix(homepage): make the System Overview update indicator able to fire

### DIFF
--- a/src/ui/features/homepage/widgets/SystemOverviewWidget.tsx
+++ b/src/ui/features/homepage/widgets/SystemOverviewWidget.tsx
@@ -47,9 +47,14 @@ function SystemOverviewWidget({
   const fetchData = async () => {
     try {
       if (showVersion) {
-        const info = await getVersionInfo(false);
+        // `checkRemote=false` makes /version return early with just
+        // {localVersion, status: "update_check_disabled"}, and the response has
+        // no `updateAvailable` field in either mode -- so the previous read was
+        // false twice over. `status` is what the endpoint actually answers with,
+        // and what the dashboard and profile badges already read.
+        const info = await getVersionInfo();
         setVersion((info?.localVersion as string) ?? null);
-        setUpdateAvailable(Boolean(info?.updateAvailable));
+        setUpdateAvailable(info?.status === "requires_update");
       }
       if (showDbHealth) {
         const health = await getDatabaseHealth();
@@ -93,7 +98,7 @@ function SystemOverviewWidget({
         )}
         {showVersion && updateAvailable && (
           <InfoRow
-            label={t("homepage.overviewUpdate")}
+            label={t("homepage.overviewUpdateLabel")}
             value={t("homepage.overviewUpdateAvailable")}
             valueColor="#f97316"
           />

--- a/src/ui/locales/en.json
+++ b/src/ui/locales/en.json
@@ -211,6 +211,7 @@
     "uptimeLabel": "Uptime",
     "overviewVersion": "Version",
     "overviewUpdate": "Up to date",
+    "overviewUpdateLabel": "Update",
     "overviewUpdateAvailable": "Update available",
     "overviewDatabase": "Database",
     "overviewUptime": "Uptime",

--- a/src/ui/tests/features/homepage/SystemOverviewWidget.test.tsx
+++ b/src/ui/tests/features/homepage/SystemOverviewWidget.test.tsx
@@ -1,0 +1,126 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+import { render, screen, cleanup, waitFor } from "@testing-library/react";
+
+vi.mock("react-i18next", () => ({
+  useTranslation: () => ({ t: (key: string) => key }),
+}));
+
+const getVersionInfo = vi.fn();
+const getDatabaseHealth = vi.fn(async () => ({ status: "ok" }));
+vi.mock("@/api/system-status-api", () => ({
+  getVersionInfo: (...args: unknown[]) => getVersionInfo(...args),
+  getDatabaseHealth: () => getDatabaseHealth(),
+}));
+vi.mock("@/api/dashboard-api", () => ({
+  getUptime: vi.fn(async () => ({ formatted: "1d 2h" })),
+}));
+
+// The real one installs an interval and a visibilitychange listener; the
+// component's first fetch happens outside it, which is all these tests need.
+vi.mock("../../../features/homepage/use-visible-interval", () => ({
+  runVisibleInterval: () => () => {},
+}));
+
+import { SystemOverviewWidget } from "../../../features/homepage/widgets/SystemOverviewWidget";
+import type { CanvasWidget } from "@/types/homepage-types";
+
+const widget: CanvasWidget = {
+  id: 1,
+  typeId: "system_overview",
+  title: "Termix",
+  config: {},
+  x: 0,
+  y: 0,
+  w: 10,
+  h: 6,
+  zOrder: 0,
+};
+
+function renderWidget() {
+  render(
+    <SystemOverviewWidget
+      widget={widget}
+      config={{ showVersion: true, showDbHealth: false, showUptime: false }}
+    />,
+  );
+}
+
+beforeEach(() => {
+  getVersionInfo.mockReset();
+});
+
+afterEach(cleanup);
+
+describe("SystemOverviewWidget update indicator", () => {
+  it("asks /version to actually check the remote release", async () => {
+    // Regression: it used to pass checkRemote=false, which makes the endpoint
+    // return early without ever comparing against the latest release.
+    getVersionInfo.mockResolvedValue({
+      status: "up_to_date",
+      localVersion: "2.6.1",
+    });
+
+    renderWidget();
+
+    await waitFor(() => expect(getVersionInfo).toHaveBeenCalledTimes(1));
+    expect(getVersionInfo).toHaveBeenCalledWith();
+  });
+
+  it("flags an available update from the status the endpoint returns", async () => {
+    // Regression: it used to read `updateAvailable`, a field /version does not
+    // return in either mode, so the row could never appear.
+    getVersionInfo.mockResolvedValue({
+      status: "requires_update",
+      localVersion: "2.6.0",
+      remoteVersion: "2.6.1",
+    });
+
+    renderWidget();
+
+    await waitFor(() =>
+      expect(screen.getByText("homepage.overviewUpdateAvailable")).toBeTruthy(),
+    );
+  });
+
+  it("labels that row 'Update' rather than 'Up to date'", async () => {
+    // homepage.overviewUpdate is the string "Up to date", which read as the
+    // label of an update-available row said "Up to date  Update available".
+    getVersionInfo.mockResolvedValue({
+      status: "requires_update",
+      localVersion: "2.6.0",
+    });
+
+    renderWidget();
+
+    await waitFor(() =>
+      expect(screen.getByText("homepage.overviewUpdateLabel")).toBeTruthy(),
+    );
+    expect(screen.queryByText("homepage.overviewUpdate")).toBeNull();
+  });
+
+  it("shows no update row when the server is current", async () => {
+    getVersionInfo.mockResolvedValue({
+      status: "up_to_date",
+      localVersion: "2.6.1",
+    });
+
+    renderWidget();
+
+    await waitFor(() => expect(screen.getByText("2.6.1")).toBeTruthy());
+    expect(screen.queryByText("homepage.overviewUpdateAvailable")).toBeNull();
+    expect(screen.queryByText("homepage.overviewUpdateLabel")).toBeNull();
+  });
+
+  it("shows no update row on a beta build, which is ahead rather than behind", async () => {
+    getVersionInfo.mockResolvedValue({
+      status: "beta",
+      localVersion: "2.7.0",
+      remoteVersion: "2.6.1",
+    });
+
+    renderWidget();
+
+    await waitFor(() => expect(screen.getByText("2.7.0")).toBeTruthy());
+    expect(screen.queryByText("homepage.overviewUpdateAvailable")).toBeNull();
+  });
+});


### PR DESCRIPTION
# Overview

The System Overview homepage widget has an update indicator that can never fire.

- [x] Fixed: widget asks `/version` to actually perform the remote check
- [x] Fixed: reads `status`, the field the endpoint returns, instead of one it does not
- [x] Fixed: the row is no longer labelled "Up to date"
- [x] Added: tests for the widget (there were none)

# Changes Made

`src/ui/features/homepage/widgets/SystemOverviewWidget.tsx` did this:

```js
const info = await getVersionInfo(false);
setVersion((info?.localVersion as string) ?? null);
setUpdateAvailable(Boolean(info?.updateAvailable));
```

Two independent faults, either of which alone would have been enough to make the indicator dead:

**`checkRemote=false` short-circuits the endpoint.** `src/backend/database/database.ts` returns before any remote work:

```js
if (req.query.checkRemote === "false") {
  return res.json({ localVersion, status: "update_check_disabled" });
}
```

**`updateAvailable` is not a field `/version` returns.** The success response is assembled as `{status, localVersion, version, remoteVersion, latest_release, cached, cache_age}`. `Boolean(undefined)` is `false`, permanently. Against a live 2.6.1 server:

```console
$ curl -s "$URL/version?checkRemote=false" -H "Authorization: Bearer $TOKEN"
{"localVersion":"2.6.1","status":"update_check_disabled"}

$ curl -s "$URL/version" -H "Authorization: Bearer $TOKEN" | jq 'keys'
["cached","latest_release","localVersion","remoteVersion","status","version"]
```

It type-checked only because `getVersionInfo()` is declared `Record<string, unknown>`, which accepts any property name — a field that does not exist is indistinguishable from one that does.

The fix lets the endpoint do its comparison and reads `status === "requires_update"`, which is what the dashboard stats bar and the profile panel badge already read off the same call.

### The label

The row was built as label `homepage.overviewUpdate` — English string **"Up to date"** — with value `homepage.overviewUpdateAvailable`. So the first thing it would have rendered once working is:

```
Up to date        Update available
```

No one has seen this, because the row has never rendered. Fixing the indicator without the label would have shipped it. The label now has its own key. `homepage.overviewUpdate` is deliberately left in place rather than deleted: "Up to date" is the natural *value* for an always-visible status row, and whether the widget should show one is a product decision rather than part of this fix.

Only `src/ui/locales/en.json` is touched; nothing under `src/ui/locales/translated/`.

### Tests

The widget had none. Added 5 covering both regressions and the label, plus the up-to-date and beta paths. Reverting only the component and re-running fails 3 of 5:

```
 × asks /version to actually check the remote release
 × flags an available update from the status the endpoint returns
 × labels that row 'Update' rather than 'Up to date'
 Tests  3 failed | 2 passed (5)
```

Verified against `main` @ `57b2081`:

| | before | after |
|---|---|---|
| `npm run type-check` | clean | clean |
| `npm run lint` | 0 errors, 42 warnings | 0 errors, 42 warnings |
| `npm test` | 202 files, 1453 passed / 1 skipped | 203 files, 1458 passed / 1 skipped |

### Relationship to #1167

Independent, and deliberately so — no shared files, so the two can merge in either order without conflict. #1167 fixes a different set of version surfaces (the startup update prompt suppressing itself, and the two badges having no link). This one is the third surface, broken a different way.

One sequencing note if both land: #1167 gives `getVersionInfo()` a `VersionInfo` return type whose permissive index signature exists specifically so *this* widget's `updateAvailable` read keeps compiling. Once this PR removes that read, nothing depends on the index signature any more and it can be tightened — worth a follow-up, not something either PR should do to the other.

# Related Issues

- Closes Termix-SSH/Support#1088

# Screenshots / Demos

Not included — the visible change is a row that previously could not render. The test output above is the demonstrable part.

# Checklist

- [x] Code follows project style guidelines
- [x] Supports mobile and desktop UI/app (if applicable) — homepage widget, unchanged layout behaviour
- [x] I have read [Contributing.md](https://github.com/Termix-SSH/Termix/blob/main/CONTRIBUTING.md)
- [x] This is not a translation request. See [docs](https://docs.termix.site/translations)
