### PR TITLE
fix: capture real client IP for SSH login alerts behind reverse proxy

### DIFF
--- a/src/backend/hosts/terminal/index.ts
+++ b/src/backend/hosts/terminal/index.ts
@@ -45,6 +45,7 @@ import {
 import { isWindowsSftpPath, sftpPathToLocalPath } from "../transfer-paths.js";
 import { preparePrivateKeyForSSH2 } from "../../utils/ssh-key-utils.js";
 import { triggerLoginAlert } from "../../utils/alert-trigger.js";
+import { getClientIp } from "../../utils/request-origin.js";
 import { isRetriableDnsError, resolveHostForSshConnect } from "../ssh-dns.js";
 
 interface ConnectToHostData {
@@ -326,7 +327,7 @@ wss.on("connection", async (ws: WebSocket, req) => {
       error,
       {
         operation: "websocket_connection_auth_error",
-        ip: req.socket.remoteAddress,
+        ip: getClientIp(req),
       },
     );
     ws.close(1008, "Authentication required");
@@ -2184,7 +2185,7 @@ wss.on("connection", async (ws: WebSocket, req) => {
               id,
               hostConfig.userId,
               username,
-              req.socket.remoteAddress ?? "unknown",
+              getClientIp(req),
             ).catch(() => {});
           }
 

--- a/src/backend/tests/utils/request-origin.test.ts
+++ b/src/backend/tests/utils/request-origin.test.ts
@@ -1,5 +1,6 @@
 import { afterEach, describe, expect, it } from "vitest";
 import {
+  getClientIp,
   getRequestBasePath,
   getRequestBaseUrl,
   getRequestBaseUrlWithForceHTTPS,
@@ -12,6 +13,18 @@ function request(headers: Record<string, string | string[] | undefined>) {
     headers,
     socket: {},
   } as Parameters<typeof getRequestBasePath>[0];
+}
+
+function requestWithSocket(
+  headers: Record<string, string | string[] | undefined>,
+  socket: { remoteAddress?: string },
+  ip?: string,
+) {
+  return {
+    headers,
+    socket,
+    ip,
+  } as unknown as Parameters<typeof getClientIp>[0];
 }
 
 function restoreEnv(name: string, value: string | undefined) {
@@ -105,6 +118,52 @@ describe("getRequestBasePath", () => {
         }),
       ),
     ).toBe("https://example.com/termix");
+  });
+});
+
+describe("getClientIp", () => {
+  it("prefers the leftmost X-Forwarded-For entry over the socket peer", () => {
+    expect(
+      getClientIp(
+        requestWithSocket(
+          { "x-forwarded-for": "203.0.113.7, 10.0.0.1, 10.0.0.2" },
+          { remoteAddress: "::ffff:127.0.0.1" },
+        ),
+      ),
+    ).toBe("203.0.113.7");
+  });
+
+  it("handles X-Forwarded-For sent as a header array", () => {
+    expect(
+      getClientIp(
+        requestWithSocket(
+          { "x-forwarded-for": ["203.0.113.7", "10.0.0.1"] },
+          { remoteAddress: "::ffff:127.0.0.1" },
+        ),
+      ),
+    ).toBe("203.0.113.7");
+  });
+
+  it("falls back to req.ip when there is no forwarded header", () => {
+    expect(
+      getClientIp(
+        requestWithSocket(
+          {},
+          { remoteAddress: "::ffff:127.0.0.1" },
+          "198.51.100.5",
+        ),
+      ),
+    ).toBe("198.51.100.5");
+  });
+
+  it("falls back to the raw socket peer when nothing else is available", () => {
+    expect(
+      getClientIp(requestWithSocket({}, { remoteAddress: "198.51.100.9" })),
+    ).toBe("198.51.100.9");
+  });
+
+  it("returns unknown when no IP information exists at all", () => {
+    expect(getClientIp(requestWithSocket({}, {}))).toBe("unknown");
   });
 });
 

--- a/src/backend/utils/request-origin.ts
+++ b/src/backend/utils/request-origin.ts
@@ -64,6 +64,20 @@ export function normalizeBasePath(value: unknown): string {
   return basePath.replace(/\/+$/, "");
 }
 
+/**
+ * Real client IP behind a reverse proxy. `X-Forwarded-For`'s leftmost entry is
+ * the original client; socket.remoteAddress is only the immediate peer, which
+ * behind Traefik/Cloudflare is the proxy itself (often a loopback address).
+ */
+export function getClientIp(req: Request | IncomingMessage): string {
+  const forwarded = firstHeaderValue(req.headers["x-forwarded-for"]);
+  if (forwarded) return forwarded;
+
+  if ("ip" in req && req.ip) return req.ip;
+
+  return req.socket?.remoteAddress ?? "unknown";
+}
+
 export function getRequestOrigin(req: Request | IncomingMessage): string {
   let protocol: string;
   const protoHeader = req.headers["x-forwarded-proto"];


### PR DESCRIPTION
## Summary
- The WebSocket terminal handler used `req.socket.remoteAddress` for the "user logged in" alert message, which is the immediate TCP peer (the reverse proxy) rather than the real client IP forwarded via `X-Forwarded-For`. Reconfiguring Traefik's trust-proxy settings had no effect because Termix never read the header on this code path.
- Added `getClientIp` in `request-origin.ts` (forwarded header → `req.ip` → raw socket, in that order) and wired it into both the login-alert trigger and the WS auth-failure log in `terminal/index.ts`.

Fixes Termix-SSH/Support#1100

## Test plan
- [x] `npx vitest run src/backend/tests/utils/request-origin.test.ts` — 17 passed
- [x] `npx tsc --noEmit`