### PR TITLE
Make audit_logs.user_id nullable so the trail can outlive the account

### DIFF
--- a/src/backend/database/db/index.ts
+++ b/src/backend/database/db/index.ts
@@ -507,7 +507,7 @@ async function initializeCompleteDatabase(): Promise<void> {
 
     CREATE TABLE IF NOT EXISTS audit_logs (
         id INTEGER PRIMARY KEY AUTOINCREMENT,
-        user_id TEXT NOT NULL,
+        user_id TEXT,
         username TEXT NOT NULL,
         action TEXT NOT NULL,
         resource_type TEXT NOT NULL,
@@ -1172,6 +1172,69 @@ const migrateSchema = () => {
     }
   } catch (migrationError) {
     databaseLogger.warn("Failed to migrate ssh_credentials username column", {
+      operation: "schema_migration",
+      error: migrationError,
+    });
+  }
+
+  try {
+    const auditLogColumns = sqlite.prepare("PRAGMA table_info(audit_logs)").all() as Array<{
+      name: string;
+      notnull: number;
+    }>;
+    const auditUserIdCol = auditLogColumns.find((col) => col.name === "user_id");
+
+    if (auditUserIdCol && auditUserIdCol.notnull === 1) {
+      const tempTableName = "audit_logs_temp_migration";
+      const columns = [
+        "id",
+        "user_id",
+        "username",
+        "action",
+        "resource_type",
+        "resource_id",
+        "resource_name",
+        "details",
+        "ip_address",
+        "user_agent",
+        "success",
+        "error_message",
+        "timestamp",
+      ].join(", ");
+
+      sqlite.exec(`PRAGMA foreign_keys = OFF`);
+      sqlite.exec(`
+        CREATE TABLE ${tempTableName} (
+          id INTEGER PRIMARY KEY AUTOINCREMENT,
+          user_id TEXT,
+          username TEXT NOT NULL,
+          action TEXT NOT NULL,
+          resource_type TEXT NOT NULL,
+          resource_id TEXT,
+          resource_name TEXT,
+          details TEXT,
+          ip_address TEXT,
+          user_agent TEXT,
+          success INTEGER NOT NULL,
+          error_message TEXT,
+          timestamp TEXT NOT NULL DEFAULT CURRENT_TIMESTAMP,
+          FOREIGN KEY (user_id) REFERENCES users (id) ON DELETE SET NULL
+        );
+
+        INSERT INTO ${tempTableName} (${columns}) SELECT ${columns} FROM audit_logs;
+
+        DROP TABLE audit_logs;
+
+        ALTER TABLE ${tempTableName} RENAME TO audit_logs;
+      `);
+      sqlite.exec(`PRAGMA foreign_keys = ON`);
+
+      databaseLogger.info("Successfully migrated audit_logs table to remove user_id NOT NULL constraint", {
+        operation: "schema_migration_audit_user_id_nullable",
+      });
+    }
+  } catch (migrationError) {
+    databaseLogger.warn("Failed to migrate audit_logs user_id column", {
       operation: "schema_migration",
       error: migrationError,
     });

--- a/src/backend/tests/database/db/audit-log-user-id-nullable.test.ts
+++ b/src/backend/tests/database/db/audit-log-user-id-nullable.test.ts
@@ -1,0 +1,114 @@
+import fs from "fs";
+import os from "os";
+import path from "path";
+import Database from "better-sqlite3";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+/**
+ * The audit trail outlives the account it belongs to: deleting a user
+ * anonymises their entries by nulling `user_id` and leaving `username` behind.
+ *
+ * The Drizzle schema said so, the repository was written against it, but the
+ * runtime bootstrap still created `user_id TEXT NOT NULL`. A second, corrected
+ * `CREATE TABLE IF NOT EXISTS` further down was a no-op — the table already
+ * existed — so every fresh install got the old constraint and every user
+ * deletion (including the OIDC account-link cleanup) failed once the account
+ * had logged in at least once.
+ */
+describe("audit_logs.user_id is nullable", () => {
+  let dataDir: string;
+
+  beforeEach(() => {
+    dataDir = fs.mkdtempSync(path.join(os.tmpdir(), "termix-audit-schema-"));
+    vi.resetModules();
+    process.env.DATA_DIR = dataDir;
+    process.env.DB_FILE_ENCRYPTION = "false";
+    process.env.ALLOW_EMPTY_DATA_DIR = "true";
+  });
+
+  afterEach(() => {
+    delete process.env.DATA_DIR;
+    delete process.env.DB_FILE_ENCRYPTION;
+    delete process.env.ALLOW_EMPTY_DATA_DIR;
+    fs.rmSync(dataDir, { recursive: true, force: true });
+  });
+
+  function userIdIsNotNull(sqlite: Database.Database): boolean {
+    const columns = sqlite.prepare("PRAGMA table_info(audit_logs)").all() as Array<{
+      name: string;
+      notnull: number;
+    }>;
+    return columns.find((col) => col.name === "user_id")?.notnull === 1;
+  }
+
+  it("lets a fresh install outlive the account it logged", async () => {
+    const db = await import("../../../database/db/index.js");
+    await db.initializeDatabase();
+    const sqlite = db.getSqlite();
+
+    expect(userIdIsNotNull(sqlite)).toBe(false);
+
+    sqlite
+      .prepare("INSERT INTO users (id, username, password_hash) VALUES (?, ?, ?)")
+      .run("user-1", "alice", "hash");
+    sqlite
+      .prepare(
+        `INSERT INTO audit_logs (user_id, username, action, resource_type, success)
+         VALUES (?, ?, ?, ?, ?)`,
+      )
+      .run("user-1", "alice", "login", "auth", 1);
+
+    expect(() => sqlite.prepare("DELETE FROM users WHERE id = ?").run("user-1")).not.toThrow();
+
+    const row = sqlite.prepare("SELECT user_id, username FROM audit_logs").get() as {
+      user_id: string | null;
+      username: string;
+    };
+
+    // The reference goes, the attribution stays.
+    expect(row.user_id).toBeNull();
+    expect(row.username).toBe("alice");
+  });
+
+  it("rebuilds an existing table that still has the constraint, keeping its rows", async () => {
+    const seed = new Database(":memory:");
+    seed.exec(`
+      CREATE TABLE audit_logs (
+        id INTEGER PRIMARY KEY AUTOINCREMENT,
+        user_id TEXT NOT NULL,
+        username TEXT NOT NULL,
+        action TEXT NOT NULL,
+        resource_type TEXT NOT NULL,
+        resource_id TEXT,
+        resource_name TEXT,
+        details TEXT,
+        ip_address TEXT,
+        user_agent TEXT,
+        success INTEGER NOT NULL,
+        error_message TEXT,
+        timestamp TEXT NOT NULL DEFAULT CURRENT_TIMESTAMP
+      );
+    `);
+    seed
+      .prepare(
+        `INSERT INTO audit_logs (user_id, username, action, resource_type, success)
+         VALUES (?, ?, ?, ?, ?)`,
+      )
+      .run("user-1", "alice", "login", "auth", 1);
+    fs.writeFileSync(path.join(dataDir, "db.sqlite"), seed.serialize());
+    seed.close();
+
+    const db = await import("../../../database/db/index.js");
+    await db.initializeDatabase();
+    const sqlite = db.getSqlite();
+
+    expect(userIdIsNotNull(sqlite)).toBe(false);
+
+    const row = sqlite.prepare("SELECT user_id, username FROM audit_logs").get() as {
+      user_id: string | null;
+      username: string;
+    };
+    expect(row.user_id).toBe("user-1");
+    expect(row.username).toBe("alice");
+  });
+});


### PR DESCRIPTION
Fixes Termix-SSH/Support#1097.

## The defect

Deleting a user fails on any account that has ever logged in, because `AuditLogRepository.anonymizeByUserId` tries to null `user_id`:

```
SqliteError: NOT NULL constraint failed: audit_logs.user_id
    at AuditLogRepository.anonymizeByUserId (audit-log-repository.js:90)
    at deleteUserAndRelatedData (delete-user-data.js:15)
```

Two independent call paths hit it: the admin user deletion in `users.js`, and the cleanup step of `POST /users/link-oidc-to-password`.

## Root cause

`src/backend/database/db/index.ts` had two conflicting definitions of `audit_logs`:

- the primary bootstrap (~line 508) created `user_id TEXT NOT NULL`;
- a second `CREATE TABLE IF NOT EXISTS` inside `migrateSchema()` (~line 1732) had the column correctly nullable — but it can never run. The table already exists by then, so `IF NOT EXISTS` is a no-op.

Everything else in the codebase already agreed that the column is nullable: `schema.ts` documents it as deliberate ("the trail outlives the account, and username keeps the entry attributable"), `drizzle/sqlite/0000_clever_hercules.sql` declares `user_id text` with `ON DELETE set null`, and the repository was written against that. Only the runtime bootstrap disagreed — which is why this hits **fresh installs**, not just migrated databases.

## The fix

- Align the primary bootstrap with the schema: `user_id TEXT` with `ON DELETE SET NULL`.
- Rebuild the table on existing databases, using the same create-copy-drop-rename pattern already used in `migrateSchema()` for `ssh_credentials.username` — SQLite has no `ALTER COLUMN`. The copy lists columns explicitly, and rows are preserved.

I left the unreachable second definition alone since it now matches the primary one and no longer conflicts; happy to remove it in a follow-up if you would rather not keep dead code around.

## Tests

`src/backend/tests/database/db/audit-log-user-id-nullable.test.ts` boots the real database twice:

- **fresh install** — insert a user and an audit entry, delete the user, assert `user_id` is `NULL` and `username` survives. This is the exact path that used to throw.
- **existing database** — seed a `db.sqlite` whose `audit_logs.user_id` still has the constraint plus one row, boot, assert the column is nullable and the row is still there.

Both fail on `dev-2.7.0` without the fix and pass with it. Full suite: 141 files, 1055 tests passing. `tsc --noEmit`, `npm run lint` (0 errors) and Prettier are clean.