### PR TITLE
Derive the ssh_credentials rebuild from the live schema instead of a stale column list

### DIFF
--- a/src/backend/database/db/index.ts
+++ b/src/backend/database/db/index.ts
@@ -1117,43 +1117,57 @@ const migrateSchema = () => {
 
     if (usernameCol && usernameCol.notnull === 1) {
       const tempTableName = "ssh_credentials_temp_migration";
-      const allColumns = tableInfo.map((col) => col.name).join(", ");
+      const allColumns = tableInfo.map((col) => `"${col.name}"`).join(", ");
+
+      // Derive the replacement table from the live definition instead of
+      // restating it here. The table keeps gaining columns (cert_public_key,
+      // pin, sort_order, sync_id, ...), and a second copy of the column list
+      // falls behind every time one is added — leaving the copy narrower than
+      // the table, so the INSERT below fails and the constraint stays put.
+      const createSql = sqlite
+        .prepare("SELECT sql FROM sqlite_master WHERE type = 'table' AND name = 'ssh_credentials'")
+        .pluck()
+        .get() as string | undefined;
+
+      if (!createSql) {
+        throw new Error("ssh_credentials has no stored table definition");
+      }
+
+      // Only the table name is rewritten; replace() stops at the first match,
+      // and in a CREATE TABLE statement that is the table being defined.
+      const renamedSql = createSql.replace("ssh_credentials", tempTableName);
+      const tempCreateSql = renamedSql.replace(/(["`[]?username["`\]]?\s+TEXT)\s+NOT\s+NULL/i, "$1");
+
+      if (tempCreateSql === renamedSql) {
+        throw new Error("could not derive a nullable-username definition for ssh_credentials");
+      }
+
+      // DROP TABLE takes the table's indexes with it, so replay them afterwards.
+      const indexDefs = sqlite
+        .prepare(
+          "SELECT sql FROM sqlite_master WHERE type = 'index' AND tbl_name = 'ssh_credentials' AND sql IS NOT NULL",
+        )
+        .pluck()
+        .all() as string[];
 
       sqlite.exec(`PRAGMA foreign_keys = OFF`);
       sqlite.exec(`
-        CREATE TABLE ${tempTableName} (
-          id INTEGER PRIMARY KEY AUTOINCREMENT,
-          user_id TEXT NOT NULL,
-          name TEXT NOT NULL,
-          description TEXT,
-          folder TEXT,
-          tags TEXT,
-          auth_type TEXT NOT NULL,
-          username TEXT,
-          password TEXT,
-          key TEXT,
-          key_password TEXT,
-          key_type TEXT,
-          usage_count INTEGER NOT NULL DEFAULT 0,
-          last_used TEXT,
-          created_at TEXT NOT NULL DEFAULT CURRENT_TIMESTAMP,
-          updated_at TEXT NOT NULL DEFAULT CURRENT_TIMESTAMP,
-          private_key TEXT,
-          public_key TEXT,
-          detected_key_type TEXT,
-          FOREIGN KEY (user_id) REFERENCES users (id) ON DELETE CASCADE
-        );
+        ${tempCreateSql};
 
-        INSERT INTO ${tempTableName} SELECT ${allColumns} FROM ssh_credentials;
+        INSERT INTO ${tempTableName} (${allColumns}) SELECT ${allColumns} FROM ssh_credentials;
 
         DROP TABLE ssh_credentials;
 
         ALTER TABLE ${tempTableName} RENAME TO ssh_credentials;
       `);
+      for (const indexSql of indexDefs) {
+        sqlite.exec(indexSql);
+      }
       sqlite.exec(`PRAGMA foreign_keys = ON`);
 
       databaseLogger.info("Successfully migrated ssh_credentials table to remove username NOT NULL constraint", {
         operation: "schema_migration_username_nullable",
+        restoredIndexes: indexDefs.length,
       });
     }
   } catch (migrationError) {

--- a/src/backend/tests/database/db/ssh-credentials-username-rebuild.test.ts
+++ b/src/backend/tests/database/db/ssh-credentials-username-rebuild.test.ts
@@ -1,0 +1,167 @@
+import fs from "fs";
+import os from "os";
+import path from "path";
+import Database from "better-sqlite3";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+/**
+ * `ssh_credentials.username` became nullable when key-only credentials landed,
+ * and databases created before that are rebuilt on startup to drop the
+ * constraint — SQLite cannot ALTER a column.
+ *
+ * The rebuild restated the table's columns as a literal, then copied rows with
+ * `INSERT INTO temp SELECT <every live column>`. The table has gained columns
+ * since (cert_public_key, pin, sort_order, sync_id), so the literal was
+ * narrower than the source: the INSERT failed on a column count mismatch, the
+ * error was swallowed as a warning, and the constraint survived every restart.
+ *
+ * Deriving the replacement table from `sqlite_master` keeps the two in step by
+ * construction. DROP TABLE also discards the table's indexes, so those are
+ * replayed rather than left to whatever runs later.
+ */
+describe("ssh_credentials username rebuild", () => {
+  let dataDir: string;
+
+  beforeEach(() => {
+    dataDir = fs.mkdtempSync(path.join(os.tmpdir(), "termix-cred-rebuild-"));
+    vi.resetModules();
+    process.env.DATA_DIR = dataDir;
+    process.env.DB_FILE_ENCRYPTION = "false";
+    process.env.ALLOW_EMPTY_DATA_DIR = "true";
+  });
+
+  afterEach(() => {
+    delete process.env.DATA_DIR;
+    delete process.env.DB_FILE_ENCRYPTION;
+    delete process.env.ALLOW_EMPTY_DATA_DIR;
+    fs.rmSync(dataDir, { recursive: true, force: true });
+  });
+
+  /**
+   * A database as a 2.6.x run leaves it: the old NOT NULL constraint is still
+   * there, but the columns added since are present, as is the sync_id index.
+   */
+  function writeDatabaseNeedingRebuild(): void {
+    const seed = new Database(":memory:");
+    seed.exec(`
+      CREATE TABLE users (
+        id TEXT PRIMARY KEY,
+        username TEXT NOT NULL,
+        password_hash TEXT NOT NULL
+      );
+
+      INSERT INTO users (id, username, password_hash) VALUES ('user-1', 'alice', 'hash');
+
+      CREATE TABLE ssh_credentials (
+        id INTEGER PRIMARY KEY AUTOINCREMENT,
+        user_id TEXT NOT NULL,
+        name TEXT NOT NULL,
+        description TEXT,
+        folder TEXT,
+        tags TEXT,
+        auth_type TEXT NOT NULL,
+        username TEXT NOT NULL,
+        password TEXT,
+        key TEXT,
+        key_password TEXT,
+        key_type TEXT,
+        usage_count INTEGER NOT NULL DEFAULT 0,
+        last_used TEXT,
+        created_at TEXT NOT NULL DEFAULT CURRENT_TIMESTAMP,
+        updated_at TEXT NOT NULL DEFAULT CURRENT_TIMESTAMP,
+        private_key TEXT,
+        public_key TEXT,
+        detected_key_type TEXT,
+        cert_public_key TEXT,
+        pin INTEGER NOT NULL DEFAULT 0,
+        sort_order INTEGER,
+        sync_id TEXT,
+        FOREIGN KEY (user_id) REFERENCES users (id) ON DELETE CASCADE
+      );
+
+      CREATE UNIQUE INDEX idx_ssh_credentials_sync_id ON ssh_credentials(sync_id);
+    `);
+    seed
+      .prepare(
+        `INSERT INTO ssh_credentials (user_id, name, auth_type, username, pin, sort_order, sync_id)
+         VALUES (?, ?, ?, ?, ?, ?, ?)`,
+      )
+      .run("user-1", "prod box", "password", "root", 1, 3, "sync-abc");
+    fs.writeFileSync(path.join(dataDir, "db.sqlite"), seed.serialize());
+    seed.close();
+  }
+
+  async function bootAndGetSqlite(): Promise<Database.Database> {
+    const db = await import("../../../database/db/index.js");
+    await db.initializeDatabase();
+    return db.getSqlite();
+  }
+
+  function usernameIsNotNull(sqlite: Database.Database): boolean {
+    const columns = sqlite.prepare("PRAGMA table_info(ssh_credentials)").all() as Array<{
+      name: string;
+      notnull: number;
+    }>;
+    return columns.find((col) => col.name === "username")?.notnull === 1;
+  }
+
+  it("drops the constraint even though the table outgrew the old column list", async () => {
+    writeDatabaseNeedingRebuild();
+
+    const sqlite = await bootAndGetSqlite();
+
+    expect(usernameIsNotNull(sqlite)).toBe(false);
+
+    expect(() =>
+      sqlite
+        .prepare(
+          `INSERT INTO ssh_credentials (user_id, name, auth_type, key)
+           VALUES (?, ?, ?, ?)`,
+        )
+        .run("user-1", "key only", "key", "PRIVATE KEY"),
+    ).not.toThrow();
+  });
+
+  it("carries every column across, including the ones added after the rebuild was written", async () => {
+    writeDatabaseNeedingRebuild();
+
+    const sqlite = await bootAndGetSqlite();
+
+    const row = sqlite.prepare("SELECT * FROM ssh_credentials WHERE name = ?").get("prod box") as {
+      user_id: string;
+      username: string;
+      auth_type: string;
+      pin: number;
+      sort_order: number;
+      sync_id: string;
+    };
+
+    expect(row.user_id).toBe("user-1");
+    expect(row.username).toBe("root");
+    expect(row.auth_type).toBe("password");
+    expect(row.pin).toBe(1);
+    expect(row.sort_order).toBe(3);
+    // sync_id identifies the row to remote sync; losing it re-keys the record.
+    expect(row.sync_id).toBe("sync-abc");
+  });
+
+  it("keeps the sync_id uniqueness that DROP TABLE would otherwise discard", async () => {
+    writeDatabaseNeedingRebuild();
+
+    const sqlite = await bootAndGetSqlite();
+
+    const indexes = sqlite
+      .prepare("SELECT name FROM sqlite_master WHERE type = 'index' AND tbl_name = 'ssh_credentials'")
+      .pluck()
+      .all() as string[];
+    expect(indexes).toContain("idx_ssh_credentials_sync_id");
+
+    sqlite
+      .prepare("INSERT INTO ssh_credentials (user_id, name, auth_type, sync_id) VALUES (?, ?, ?, ?)")
+      .run("user-1", "other box", "key", "sync-xyz");
+
+    expect(() =>
+      sqlite.prepare("UPDATE ssh_credentials SET sync_id = ? WHERE name = ?").run("sync-abc", "other box"),
+    ).toThrow(/UNIQUE/i);
+  });
+});


### PR DESCRIPTION
Noticed while working on #1171, which reuses this rebuild pattern. No issue filed for it — it fails silently, so nobody would report it as this.

## The defect

`migrateSchema()` rebuilds `ssh_credentials` on startup to drop the old `username NOT NULL` constraint, since SQLite cannot `ALTER` a column. That rebuild has never been able to complete.

It restated the table as a literal with 19 columns and then copied rows positionally:

```js
INSERT INTO ssh_credentials_temp_migration SELECT ${allColumns} FROM ssh_credentials;
```

where `allColumns` is *every* live column. But the table has gained columns since that literal was written, and all of them are added by `addColumnIfNotExists` immediately **before** the rebuild runs:

- `cert_public_key`
- `pin`
- `sort_order`
- `sync_id`

So the destination is narrower than the source. SQLite rejects the INSERT with a column count mismatch, the `catch` downgrades it to `databaseLogger.warn`, and the constraint is still there on the next boot — every boot, forever. Databases upgraded from before key-only credentials therefore still refuse a credential with no username.

The positional copy is the second half of the trap: had the counts happened to line up after a future column was added, the mismatch would have become a silent column shift instead of an error.

And `DROP TABLE` discards the table's indexes. `idx_ssh_credentials_sync_id` is `UNIQUE` and identifies rows to remote sync; it is only recreated by a `CREATE UNIQUE INDEX IF NOT EXISTS` about 1400 lines further down the same function. Correct today, but only by ordering.

## The fix

- Read the `CREATE TABLE` statement back from `sqlite_master` and rewrite only the table name and the `username` constraint. The replacement table is derived from the real one, so it cannot fall behind it — including for columns added after this code.
- Throw (rather than quietly rebuild an identical table) if the constraint rewrite does not match anything.
- Copy rows by explicit column name, not positionally.
- Replay the table's index definitions after the rename instead of relying on later code to notice.

## Tests

`src/backend/tests/database/db/ssh-credentials-username-rebuild.test.ts` seeds a `db.sqlite` in exactly the state a 2.6.x run leaves behind — old constraint, all the newer columns, the unique `sync_id` index, one row — then boots the real database and asserts:

- the constraint is gone and a key-only credential inserts;
- every column survives, `sync_id` included (losing it would re-key the record for remote sync);
- `idx_ssh_credentials_sync_id` still exists and still rejects a duplicate.

The first and third fail on `dev-2.7.0` today. Full suite: 140 files, 1056 tests passing. `tsc --noEmit`, `npm run lint` (0 errors) and Prettier are clean.

Independent of #1171 — that one targets `audit_logs` and only touches a different block of this file.