### PR TITLE
Unblock the Postgres CI job: resyncAutoIncrement assumes every table has an id column

### DIFF
--- a/src/backend/tests/database/repositories/test-support.ts
+++ b/src/backend/tests/database/repositories/test-support.ts
@@ -352,11 +352,20 @@ async function resyncAutoIncrement(
 ): Promise<void> {
   for (const table of tables) {
     // Only tables whose id is generated. A text primary key, like users.id,
-    // has no sequence and no counter to move.
+    // has no sequence and no counter to move, and a table keyed on something
+    // else entirely — host_sidebar_preferences.user_id — has no id at all.
     if (context.dialect === "postgres") {
+      // pg_get_serial_sequence() raises 42703 rather than returning null when
+      // the column is missing, so let information_schema decide whether there
+      // is an id to ask about: no id column yields no row.
       const [seq] = await runSql<{ name: string | null }>(
         context,
-        sql.raw(`SELECT pg_get_serial_sequence('${table}', 'id') AS name`),
+        sql.raw(
+          `SELECT pg_get_serial_sequence('${table}', 'id') AS name ` +
+            `FROM information_schema.columns ` +
+            `WHERE table_schema = current_schema() AND table_name = '${table}' ` +
+            `AND column_name = 'id'`,
+        ),
       );
       if (!seq?.name) continue;
 


### PR DESCRIPTION
The **Postgres and MySQL** job fails on `dev-2.7.0` for every pull request, mine included (#1171, #1172). It is not caused by any of those changes — `lint-and-build` passes and the SQLite suite is green; only the Postgres step breaks, in test support code.

## What fails

```
Error: Failed query: SELECT pg_get_serial_sequence('host_sidebar_preferences', 'id') AS name
Caused by: error: column "id" of relation "host_sidebar_preferences" does not exist   (42703)
 ❯ resyncAutoIncrement src/backend/tests/database/repositories/test-support.ts:357
 ❯ createRepository host-sidebar-preference-repository.test.ts:20
```

## Why

`resyncAutoIncrement` moves each seeded table's id generator past the ids a fixture inserted by hand. On Postgres it asked `pg_get_serial_sequence(table, 'id')` about every table the seed touched, and skipped the ones that answered null.

The comment there says it means to skip tables without a generated id — "A text primary key, like `users.id`, has no sequence and no counter to move" — and for `users` that works, because the column exists and simply has no sequence. But `pg_get_serial_sequence` **raises 42703** when the column does not exist at all; it does not return null. `host_sidebar_preferences` is keyed on `user_id` and has no `id` column, so its fixture dies before the first assertion.

The MySQL branch is unaffected: it reads `information_schema.columns`, which returns no row and falls through the existing guard.

`host_sidebar_preferences` is new on `dev-2.7.0`, which is why this surfaces now. `settings` and `user_preferences` have no `id` either, so the same trap is waiting for the next fixture that seeds one.

## The fix

Select the sequence name *from* `information_schema.columns`, filtered to the `id` column:

```sql
SELECT pg_get_serial_sequence(<table>, id) AS name
FROM information_schema.columns
WHERE table_schema = current_schema() AND table_name = <table> AND column_name = id
```

No `id` column → no row → `seq` is undefined → skipped by the existing `if (!seq?.name) continue`. A text primary key → one row, null sequence → skipped exactly as before. The function only ever calls `pg_get_serial_sequence` on a column that exists, and no new branch is needed.

## Verification

The SQLite repository suite still passes (52 files, 272 tests), as does `tsc --noEmit`, `npm run lint` and Prettier — but the SQLite run never enters this branch, so the real check is this PR's own **Postgres and MySQL** job. I have no Postgres to hand locally.

Worth merging ahead of #1171 and #1172 so their runs go green; neither of them touches this file.