### PR TITLE
Install the git hooks the repo already ships

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -13,7 +13,8 @@ dist-ssr
 coverage
 *.local
 
-.vscode/
+.vscode/*
+!.vscode/settings.json
 .idea
 .DS_Store
 *.suo

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,0 +1,22 @@
+{
+  "editor.formatOnSave": true,
+  "editor.defaultFormatter": "esbenp.prettier-vscode",
+  "prettier.prettierPath": "./node_modules/prettier",
+  "editor.codeActionsOnSave": {
+    "source.fixAll.eslint": "explicit"
+  },
+  "eslint.validate": [
+    "javascript",
+    "javascriptreact",
+    "typescript",
+    "typescriptreact"
+  ],
+  "files.eol": "\n",
+  "files.insertFinalNewline": true,
+  "files.trimTrailingWhitespace": true,
+  "[markdown]": {
+    "files.trimTrailingWhitespace": false
+  },
+  "typescript.tsdk": "node_modules/typescript/lib",
+  "typescript.enablePromptUseWorkspaceTsdk": true
+}

--- a/package.json
+++ b/package.json
@@ -15,6 +15,7 @@
     "biome:check": "biome check biome.json package.json",
     "biome:fix": "biome check --write biome.json package.json",
     "postinstall": "node scripts/patch-app-builder-lib.cjs && node scripts/patch-guacamole-lite.cjs && node scripts/patch-guacamole-common-js.cjs && node scripts/patch-better-sqlite3.cjs && node scripts/patch-nan.cjs && node scripts/patch-xterm-android-ime.cjs",
+    "prepare": "husky || true",
     "prebuild": "node scripts/write-electron-build-info.cjs",
     "lint": "node scripts/generate-dialect-schema.cjs --check && eslint .",
     "lint:fix": "eslint --fix .",


### PR DESCRIPTION
Three of the four open pull requests fail `lint-and-build` on Prettier alone — #1158 (5 files), #1170 (4 files), #1167 (1 file). None of them fail a test or the build. The check is the first place anyone finds out, which costs the contributor a round trip for something a hook should have handled before the commit existed.

## What is actually missing

Everything needed to prevent this has been in the repo since v1.8.0 (#429):

| Piece | State |
|---|---|
| `husky` ^9.1.7, `lint-staged` ^17.2.0 | in devDependencies |
| `.husky/pre-commit` → `npx lint-staged` | present |
| `.husky/commit-msg` → commitlint | present |
| `lint-staged` globs | in `package.json` |
| `@commitlint/cli`, `config-conventional` | in devDependencies |
| `.commitlintrc.json` rules | present |
| **`prepare` lifecycle script** | **absent** |

husky only takes effect once it sets `core.hooksPath`, and it does that from `prepare`. Without that script every clone installs the tooling and leaves the hooks unwired — `git config core.hooksPath` comes back empty on a fresh checkout. So the whole apparatus has been dormant since the day it was added.

The fix is one line:

```json
"prepare": "husky || true"
```

`|| true` so a checkout without a `.git` directory cannot break `npm install`. The Docker build passes `--ignore-scripts` (`docker/Dockerfile:13`, `:50`), so it never runs this at all; CI runs `npm ci` with a real checkout, where installing the hooks is harmless.

## Why formatting is the failure that keeps recurring

`prettier` is pinned to an exact `3.9.6` and `npx prettier` prefers `node_modules`, so a contributor who has run `npm ci` gets the right binary. What bypasses that is the editor: the Prettier VS Code extension bundles its own copy, and 3.8.x disagrees with 3.9.6 about wrapping union types. Format on save then produces a file that looks formatted and fails `--check`.

So `.vscode/settings.json` gains one line:

```json
"prettier.prettierPath": "./node_modules/prettier"
```

That file already existed locally but was covered by `.vscode/` in `.gitignore`, so it applied to nobody. Since git will not descend into an excluded directory, the pattern has to become `.vscode/*` with a `!.vscode/settings.json` exception — the standard way to share workspace settings while keeping `launch.json` and the rest personal. The other keys in it are the settings that were already there; only `prettier.prettierPath` is new.

## Note on `commit-msg`

Wiring `prepare` activates the commitlint hook too, since it is the same `core.hooksPath`. That enforces the `.commitlintrc.json` rules that are already checked in — conventional type prefixes from a fixed list, `subject-case` off. Worth calling out explicitly, since it is a behaviour change for anyone committing locally, but it is the configuration this repo already declares and the commit history already follows, so nothing existing becomes invalid.

If you would rather land the formatting half alone, say so and I will drop `.husky/commit-msg` in this PR — but I would keep it, since it was clearly intended.

## Verified end to end

Not just "it builds" — I ran the hooks:

```
$ npm run prepare && git config core.hooksPath
.husky/_

$ git commit -m "WIP hook test"
✖   subject may not be empty [subject-empty]
✖   type may not be empty [type-empty]
husky - commit-msg script failed (code 1)          # commit did not happen
```

The real commit went through with lint-staged running over the staged files. `npx prettier@3.9.6 --check .` is clean across the repo, including the newly tracked `.vscode/settings.json`.

Does not help the three PRs already open — they still need `npx prettier@3.9.6 --write <files>`, which I have noted on each — but it is the last time anyone should have to hear it from CI.