### PR TITLE
Key the sync upsert on the row it just looked up

### DIFF
--- a/src/backend/database/routes/sync.ts
+++ b/src/backend/database/routes/sync.ts
@@ -1,6 +1,6 @@
 import type { Request, Response } from "express";
 import express from "express";
-import { and, eq } from "drizzle-orm";
+import { and, eq, type SQL } from "drizzle-orm";
 import {
   hosts,
   sshCredentials,
@@ -83,6 +83,31 @@ type RepositoryContext = ReturnType<typeof createCurrentRepositoryContext>;
 
 export function isValidEntityType(value: unknown): value is SyncEntityType {
   return typeof value === "string" && VALID_ENTITY_TYPES.has(value);
+}
+
+/**
+ * Locates the stored row a sync payload corresponds to.
+ *
+ * Read and write have to agree on this. A singleton entity is keyed on its
+ * owner rather than a sync id, and `user_preferences` — the only singleton —
+ * has no `id` column at all, so an update cannot fall back to one: `table.id`
+ * is undefined there and drizzle emits `WHERE  = ?`.
+ */
+export function locateSyncRow(
+  entityType: SyncEntityType,
+  userId: string,
+  syncId: string,
+): SQL {
+  const { table, singleton } = ENTITY_CONFIG[entityType];
+
+  if (singleton) {
+    return eq(table.userId, userId);
+  }
+
+  return and(
+    eq((table as typeof hosts).syncId, syncId),
+    eq(table.userId, userId),
+  )!;
 }
 
 async function findReferenceSyncId(
@@ -301,19 +326,12 @@ router.post(
     }
 
     try {
-      const { table, singleton } = ENTITY_CONFIG[entityType];
+      const { table } = ENTITY_CONFIG[entityType];
       const context = createCurrentRepositoryContext();
 
       await context.drizzle
         .delete(table as typeof hosts)
-        .where(
-          singleton
-            ? eq(table.userId, userId)
-            : and(
-                eq((table as typeof hosts).syncId, syncId),
-                eq(table.userId, userId),
-              ),
-        );
+        .where(locateSyncRow(entityType, userId, syncId));
 
       await createCurrentSyncTombstoneRepository().record(
         userId,
@@ -372,20 +390,17 @@ router.post(
     }
 
     try {
+      // singleton is still needed below: those tables have no sync_id column
+      // for the insert to populate.
       const { table, singleton } = ENTITY_CONFIG[entityType];
       const context = createCurrentRepositoryContext();
+
+      const locateRow = locateSyncRow(entityType, userId, syncId);
 
       const existingRows = await context.drizzle
         .select()
         .from(table as typeof hosts)
-        .where(
-          singleton
-            ? eq(table.userId, userId)
-            : and(
-                eq((table as typeof hosts).syncId, syncId),
-                eq(table.userId, userId),
-              ),
-        )
+        .where(locateRow)
         .limit(1);
       const existing = existingRows[0] as Record<string, unknown> | undefined;
 
@@ -407,12 +422,7 @@ router.post(
         const updatedRows = await context.drizzle
           .update(table as typeof hosts)
           .set(encryptedPayload)
-          .where(
-            and(
-              eq((table as typeof hosts).id, existing.id as number),
-              eq(table.userId, userId),
-            ),
-          )
+          .where(locateRow)
           .returning();
         resultRow = updatedRows[0] as Record<string, unknown>;
       } else {

--- a/src/backend/tests/database/routes/sync-locate-row.test.ts
+++ b/src/backend/tests/database/routes/sync-locate-row.test.ts
@@ -1,0 +1,83 @@
+import Database from "better-sqlite3";
+import { drizzle } from "drizzle-orm/better-sqlite3";
+import { and, eq } from "drizzle-orm";
+import { SQLiteSyncDialect } from "drizzle-orm/sqlite-core";
+import { describe, expect, it } from "vitest";
+import { locateSyncRow } from "../../../database/routes/sync.js";
+import { hosts, userPreferences } from "../../../database/db/schema.js";
+
+/**
+ * A sync push locates the stored row twice: once to see whether it exists,
+ * once to write it. Those lookups used to be spelled out separately, and only
+ * the read knew about singleton entities — the write always keyed on
+ * `table.id`.
+ *
+ * `user_preferences` is the only singleton, and the one synced table whose
+ * primary key is `user_id` with no `id` column at all. `table.id` was
+ * therefore `undefined` and drizzle emitted a comparison with nothing on its
+ * left: `( = ? and "user_preferences"."user_id" = ?)`. The insert branch was
+ * fine, so the first push of preferences succeeded and every push after it —
+ * the steady state — failed with `SqliteError: near "=": syntax error`.
+ */
+describe("locateSyncRow", () => {
+  const dialect = new SQLiteSyncDialect();
+
+  const toSql = (condition: Parameters<typeof dialect.sqlToQuery>[0]): string =>
+    dialect.sqlToQuery(condition).sql;
+
+  /** `= ?` with no operand to its left — what used to reach SQLite. */
+  const EMPTY_LEFT_OPERAND = /(^|\(|\band\b|\bor\b)\s*=\s*\?/;
+
+  it("keys a singleton entity on its owner", () => {
+    const sql = toSql(locateSyncRow("userPreferences", "user-1", "ignored"));
+
+    expect(sql).toContain('"user_id"');
+    expect(sql).not.toContain('"sync_id"');
+    expect(sql).not.toMatch(EMPTY_LEFT_OPERAND);
+  });
+
+  it("keys a regular entity on its sync id and owner", () => {
+    const sql = toSql(locateSyncRow("hosts", "user-1", "sync-abc"));
+
+    expect(sql).toContain('"sync_id"');
+    expect(sql).toContain('"user_id"');
+    expect(sql).not.toMatch(EMPTY_LEFT_OPERAND);
+  });
+
+  it("is the shape the id-keyed lookup could not produce", () => {
+    // Guards the assertions above: the pattern really does catch the old SQL.
+    const previous = and(
+      eq((userPreferences as unknown as typeof hosts).id, 1),
+      eq(userPreferences.userId, "user-1"),
+    )!;
+
+    expect(toSql(previous)).toMatch(EMPTY_LEFT_OPERAND);
+  });
+
+  it("updates a preferences row that already exists", () => {
+    const sqlite = new Database(":memory:");
+    sqlite.exec(`
+      CREATE TABLE user_preferences (
+        user_id TEXT PRIMARY KEY,
+        theme TEXT
+      );
+    `);
+    const db = drizzle(sqlite, { schema: { userPreferences } });
+
+    // The steady state: a row exists, so the push takes the update path.
+    sqlite
+      .prepare("INSERT INTO user_preferences (user_id, theme) VALUES (?, ?)")
+      .run("user-1", "dark");
+
+    const updated = db
+      .update(userPreferences)
+      .set({ theme: "light" })
+      .where(locateSyncRow("userPreferences", "user-1", "ignored"))
+      .returning({ theme: userPreferences.theme })
+      .all();
+
+    expect(updated).toEqual([{ theme: "light" }]);
+
+    sqlite.close();
+  });
+});


### PR DESCRIPTION
Fixes Termix-SSH/Support#1089.
Fixes Termix-SSH/Support#1082 — same defect, reported first, with 5 comments of back-and-forth.

## The defect

Every remote sync push of user preferences after the first one fails with a 500:

```
[ERROR] [🗄️] Failed to upsert sync row for userPreferences [op:sync_upsert,user:<id>]
SqliteError: near "=": syntax error
```

`POST /sync/:entityType` locates the stored row twice — once to decide insert vs update, once to write it — and the two lookups were spelled out separately. Only the read knew about singleton entities:

```js
.where(singleton
  ? eq(table.userId, userId)                                    // read: handles it
  : and(eq(table.syncId, syncId), eq(table.userId, userId)))

// ...

.where(and(
  eq((table as typeof hosts).id, existing.id as number),         // write: does not
  eq(table.userId, userId)))
```

`userPreferences` is the only entity in `ENTITY_CONFIG` marked `singleton: true`, and `user_preferences` is the one synced table with no `id` column — its primary key is `user_id`. So `table.id` is `undefined`, and drizzle emits a comparison with nothing on its left. The exact SQL:

```
( = ? and "user_preferences"."user_id" = ?)
```

The insert branch is unaffected, which is what makes this awkward to spot: the *first* push of preferences succeeds, and the steady state — row exists, so the update path runs — fails on every single sync cycle afterwards. #1082 pins it down from the user side: with preference storage set to `browser` sync is fine, and it breaks the moment it is set to `database`. Both sides ship this handler, so the desktop app's embedded backend fails the same way.

## The fix

No new branch — the same lookup, named once and reused:

```js
export function locateSyncRow(entityType, userId, syncId): SQL
```

The read, the update, and the tombstone delete all call it. The tombstone path already handled singletons correctly, but it was a third copy of the same expression; sharing it is why the three cannot drift apart again — that drift is the whole bug.

`as typeof hosts` is worth a note: casting an arbitrary entity table to `hosts` makes `.id` exist as far as the type checker is concerned. The compiler could have caught this one, and the assertion is what held it down.

## Tests

`src/backend/tests/database/routes/sync-locate-row.test.ts`, four cases:

- a singleton is keyed on its owner — `"user_id"`, no `"sync_id"`
- a regular entity is keyed on both
- **a guard**: the previous id-keyed expression is built directly and asserted to produce the empty-left-operand shape, so the pattern the other cases check against is known to catch the real SQL rather than passing vacuously
- an update against a real in-memory SQLite `user_preferences` row succeeds and returns the new value — the path that used to throw

The three that exercise `locateSyncRow` fail without it; the guard passes independently by design, since it constructs the old shape itself.

Full backend suite: 142 files, 1062 passing. `tsc --noEmit`, `npm run lint` (0 errors) and prettier 3.9.6 clean.

## Related

This is the third place the assumption "every table has an `id` column" has cost something. `migrateSchema()` probes tables with `SELECT id FROM <table>`, `resyncAutoIncrement` asked `pg_get_serial_sequence(table, 'id')` about all of them (#1173), and this. Tables without an `id`: `user_preferences`, `settings`, `host_sidebar_preferences`, `credential_sidebar_preferences` — the last two are new on `dev-2.7.0`, so the assumption is getting more expensive, not less.