### PR TITLE
Refuse an SSH connection whose host id resolves to a different machine

### DIFF
--- a/src/backend/hosts/terminal/host-identity.ts
+++ b/src/backend/hosts/terminal/host-identity.ts
@@ -1,0 +1,38 @@
+/**
+ * Comparable form of a host address: bracketed IPv6 literals and hostname
+ * casing are presentation, not identity.
+ */
+export function normalizeHostAddress(value: unknown): string {
+  if (typeof value !== "string") return "";
+  return value
+    .replace(/^\[|\]$/g, "")
+    .trim()
+    .toLowerCase();
+}
+
+/**
+ * Whether a host id resolved to a different machine than the client meant.
+ *
+ * A client addresses a host by the numeric row id of the database it is
+ * displaying. When the desktop app delegates a connection to a remote sync
+ * server, the id is resolved against *that* server's table instead, and
+ * autoincrement ids need not line up between the two — they diverge as soon as
+ * the sides accumulate inserts and deletes in a different order.
+ *
+ * The resolved row then supplies the address, the credentials, the jump hosts
+ * and the stored host key, so a mismatch opens an interactive shell on a
+ * machine the user did not pick.
+ *
+ * Returns false when the server has no address to compare: the caller falls
+ * back to what the client supplied, which is the behaviour of every setup that
+ * never stored the host server-side.
+ */
+export function hostAddressMismatch(
+  clientAddress: unknown,
+  resolvedAddress: unknown,
+): boolean {
+  const resolved = normalizeHostAddress(resolvedAddress);
+  if (!resolved) return false;
+
+  return resolved !== normalizeHostAddress(clientAddress);
+}

--- a/src/backend/hosts/terminal/index.ts
+++ b/src/backend/hosts/terminal/index.ts
@@ -46,6 +46,7 @@ import { isWindowsSftpPath, sftpPathToLocalPath } from "../transfer-paths.js";
 import { preparePrivateKeyForSSH2 } from "../../utils/ssh-key-utils.js";
 import { triggerLoginAlert } from "../../utils/alert-trigger.js";
 import { isRetriableDnsError, resolveHostForSshConnect } from "../ssh-dns.js";
+import { hostAddressMismatch } from "./host-identity.js";
 
 interface ConnectToHostData {
   cols: number;
@@ -1476,6 +1477,39 @@ wss.on("connection", async (ws: WebSocket, req) => {
           id,
           userId,
         )) as unknown as typeof resolvedHostData;
+
+        // A client addresses the host by a numeric row id. When the desktop
+        // app delegates the connection to a remote sync server, that id is
+        // resolved here, against a table whose autoincrement ids need not line
+        // up with the ones the client is displaying. Everything below is then
+        // taken from whichever row happens to own that id -- the address, the
+        // credentials, the jump hosts, the stored host key -- so a mismatch
+        // opens an interactive shell on a machine the user did not choose, and
+        // says nothing about it.
+        if (hostAddressMismatch(clientIp, resolvedHostData?.ip)) {
+          sshLogger.error(
+            "Refusing to connect: host id resolves to a different address here",
+            undefined,
+            {
+              operation: "ssh_connect_host_id_mismatch",
+              hostId: id,
+              userId,
+              clientIp,
+              resolvedIp: resolvedHostData?.ip,
+            },
+          );
+          ws.send(
+            JSON.stringify({
+              type: "error",
+              message:
+                "Host mismatch: this server resolved the selected host to a different machine, so the connection was refused. " +
+                "The host ids on this device and on the sync server have drifted apart. " +
+                'Set the connection origin to "This device" for this host, or re-run a full sync, then try again.',
+            }),
+          );
+          cleanupAuthState(connectionTimeout);
+          return;
+        }
 
         if (resolvedHostData) {
           if (

--- a/src/backend/tests/hosts/terminal/host-identity.test.ts
+++ b/src/backend/tests/hosts/terminal/host-identity.test.ts
@@ -1,0 +1,69 @@
+import { describe, expect, it } from "vitest";
+import {
+  hostAddressMismatch,
+  normalizeHostAddress,
+} from "../../../hosts/terminal/host-identity.js";
+
+/**
+ * The desktop app lists hosts out of its own embedded database and identifies
+ * them to the backend by numeric row id. With the connection origin set to
+ * "Remote server" that id is resolved against the sync server's `ssh_data`
+ * instead, whose autoincrement ids drift apart from the client's as soon as
+ * the two sides accumulate inserts and deletes in a different order.
+ *
+ * The resolved row supplies the address, the credentials, the jump hosts and
+ * the stored host key, so the session opened on whichever machine owned that
+ * id on the server — the host list stayed correct the whole time, and nothing
+ * announced the substitution.
+ */
+describe("hostAddressMismatch", () => {
+  it("refuses an id that resolves to a different machine", () => {
+    expect(hostAddressMismatch("10.0.0.7", "10.0.0.9")).toBe(true);
+    expect(hostAddressMismatch("aeza.example.com", "rpi.example.com")).toBe(
+      true,
+    );
+  });
+
+  it("allows the ordinary case where both sides agree", () => {
+    expect(hostAddressMismatch("10.0.0.7", "10.0.0.7")).toBe(false);
+  });
+
+  it("does not trip over how an address is written", () => {
+    // The client strips brackets off IPv6 literals before connecting; the
+    // stored row keeps them. Same machine either way.
+    expect(hostAddressMismatch("2001:db8::1", "[2001:db8::1]")).toBe(false);
+    expect(hostAddressMismatch("Host.Example.COM", "host.example.com")).toBe(
+      false,
+    );
+    expect(hostAddressMismatch("10.0.0.7", " 10.0.0.7 ")).toBe(false);
+  });
+
+  it("stays out of the way when the server has no address to compare", () => {
+    // Nothing stored server-side: the caller falls back to what the client
+    // supplied, as it always has. Refusing here would break every setup that
+    // passes host details inline.
+    expect(hostAddressMismatch("10.0.0.7", undefined)).toBe(false);
+    expect(hostAddressMismatch("10.0.0.7", null)).toBe(false);
+    expect(hostAddressMismatch("10.0.0.7", "")).toBe(false);
+    expect(hostAddressMismatch("10.0.0.7", "   ")).toBe(false);
+  });
+
+  it("refuses when the client sent nothing but the server resolved a host", () => {
+    // An id alone must not be enough to pick a machine.
+    expect(hostAddressMismatch(undefined, "10.0.0.9")).toBe(true);
+    expect(hostAddressMismatch("", "10.0.0.9")).toBe(true);
+  });
+});
+
+describe("normalizeHostAddress", () => {
+  it("keeps only what identifies the host", () => {
+    expect(normalizeHostAddress("[2001:db8::1]")).toBe("2001:db8::1");
+    expect(normalizeHostAddress("  Example.COM ")).toBe("example.com");
+  });
+
+  it("treats anything that is not a string as no address", () => {
+    expect(normalizeHostAddress(undefined)).toBe("");
+    expect(normalizeHostAddress(null)).toBe("");
+    expect(normalizeHostAddress(42)).toBe("");
+  });
+});


### PR DESCRIPTION
Addresses Termix-SSH/Support#1092 — **partially**. Read the last section before merging: this stops the dangerous behaviour but does not restore the feature, so the issue stays open.

## What happens today

With Remote Sync connected and the desktop connection origin set to "Remote server", clicking a host opens a shell **on a different host**. From the report: click "Aeza", land on "Raspberry Pi".

A client identifies a host by the numeric row id of the database it is displaying — the desktop app's embedded one. When the connection is delegated to the sync server, `resolveHostById(id, userId)` resolves that id against *that* server's `ssh_data`. The two autoincrement sequences need not line up, and they diverge as soon as each side accumulates inserts and deletes in a different order.

The handler then overwrites the client's details from the row it found:

```js
resolvedHostData = await resolveHostById(id, userId);
// ...
ip = resolvedHostData.ip || ip;
port = resolvedHostData.port || port;
username = resolvedHostData.username || username;
```

and the same row also supplies the credentials, the jump hosts, the SOCKS5 chain, the port-knock sequence, and — via `SSHHostKeyVerifier.preloadHostData(id)` — the stored host key. The host list, host details and export keep displaying the correct machine throughout, so nothing on screen contradicts what the user expected.

Why it matters, beyond connecting to the wrong box:

- commands, including destructive ones, run on a machine the user did not choose
- the host key check fires "SECURITY WARNING — mismatch" for the wrong reason, and accepting it stores the wrong machine's fingerprint against the clicked host
- anything typed at the prompt — sudo passwords especially — goes to the wrong machine

## This change

Compare the resolved address against the one the client sent, and refuse when they disagree:

```js
if (hostAddressMismatch(clientIp, resolvedHostData?.ip)) { /* log, tell the client, stop */ }
```

Checking where the row is loaded, rather than at each place it is consumed, is deliberate — one check covers the address, the credentials, the jump hosts and the host key, and a future consumer is covered without anyone remembering to add a guard.

`hostAddressMismatch` lives in a new `hosts/terminal/host-identity.ts` so it is testable without loading the 3k-line WebSocket module, matching how `request-origin.ts` and `terminal-image-utils.ts` are already split out.

Deliberately conservative about what counts as a mismatch:

- brackets are stripped and casing folded, so `[2001:db8::1]` and `2001:db8::1`, or `Host.Example.COM` and `host.example.com`, are the same machine
- when the server has **no** stored address, nothing is refused and the client's own details are used exactly as before — that is the normal path for setups that pass host details inline, and refusing there would break them

The error tells the user what to do: set the origin to "This device" for that host (the workaround confirmed in the issue), or re-run a full sync.

## Tests

`src/backend/tests/hosts/terminal/host-identity.test.ts`, 7 cases: differing addresses refused; matching addresses allowed; bracket / casing / whitespace variants not treated as different; missing server-side address not refused (all four falsy shapes); and an id alone never sufficient to pick a machine.

Backend suite: 142 files, 1065 passing. `tsc -p tsconfig.node.json`, `tsc --noEmit`, `npm run lint` (0 errors) and prettier all clean.

## What this does not do

**Delegated connections still will not work when the ids have drifted** — they now fail loudly instead of silently connecting elsewhere. That is the right trade for a security defect, but it is half the fix.

The real repair is to address hosts by `syncId` across the desktop/server boundary. The connection protocol has no room for it today: `ConnectToHostData.hostConfig` carries `id`, `credentialId` and `jumpHosts[].hostId`, and neither `TerminalHostConfig` on the client nor the wire format has a `syncId` field at all. Doing it properly means a protocol change plus a compatibility story for older clients that keep sending only an id.

The same id-crossing exists on other paths that call `resolveHostById` with an id chosen by the client — `hosts/file-manager/index.ts` (two call sites), `hosts/docker/console.ts`, `hosts/jump-host-chain.ts`, `database/routes/proxmox.ts`. I have not touched those here; they deserve the same treatment and are worth their own issue rather than being folded into this one.

This is the same family as Support#1070 (sync FK ids not remapped) and Support#1089 (singleton upsert keyed on a missing `id`): raw autoincrement ids crossing a database boundary they were never scoped to.