### PR TITLE
Refuse SFTP and Docker console on a mismatched host id too

### DIFF
--- a/src/backend/hosts/docker/console.ts
+++ b/src/backend/hosts/docker/console.ts
@@ -12,6 +12,10 @@ import {
   type ContainerRuntime,
 } from "./container-runtime.js";
 import { resolveSshConnectConfigHost } from "../ssh-dns.js";
+import {
+  hostAddressMismatch,
+  HOST_ADDRESS_MISMATCH_MESSAGE,
+} from "../terminal/host-identity.js";
 
 const sshLogger = systemLogger;
 
@@ -395,6 +399,30 @@ wss.on("connection", async (ws: WebSocket, req) => {
                 JSON.stringify({
                   type: "error",
                   message: "Host not found",
+                }),
+              );
+              return;
+            }
+
+            // The connection below dials resolvedHost.ip outright, so if this
+            // server has a different machine under the id the client sent, the
+            // console opens on that machine's Docker daemon instead.
+            if (hostAddressMismatch(hostConfig?.ip, resolvedHost.ip)) {
+              sshLogger.error(
+                "Refusing Docker console: host id resolves to a different address here",
+                undefined,
+                {
+                  operation: "docker_console_host_id_mismatch",
+                  hostId,
+                  userId,
+                  clientIp: hostConfig?.ip,
+                  resolvedIp: resolvedHost.ip,
+                },
+              );
+              ws.send(
+                JSON.stringify({
+                  type: "error",
+                  message: HOST_ADDRESS_MISMATCH_MESSAGE,
                 }),
               );
               return;

--- a/src/backend/hosts/file-manager/index.ts
+++ b/src/backend/hosts/file-manager/index.ts
@@ -49,9 +49,43 @@ import {
 import { registerFileListingRoutes } from "./list-routes.js";
 import { registerFileOperationRoutes } from "./operation-routes.js";
 import { resolveSshConnectConfigHost } from "../ssh-dns.js";
+import {
+  hostAddressMismatch,
+  HostAddressMismatchError,
+} from "../terminal/host-identity.js";
 import { registerFileDownloadRoutes } from "./download-routes.js";
 import { registerFileActionRoutes } from "./action-routes.js";
 import { applyAgentAuth } from "../terminal-auth-helpers.js";
+
+/**
+ * The host id came from whichever database the client is displaying. If this
+ * server has a different machine under that id — desktop and sync server
+ * autoincrement sequences drift apart — then the address, the credentials and
+ * the jump hosts resolved from it all belong to that other machine, and the
+ * user would browse, edit and delete its files believing they are on the host
+ * they picked.
+ */
+function assertResolvedHostMatches(
+  clientIp: unknown,
+  resolvedHost: { ip?: string } | null | undefined,
+  hostId: number,
+  userId: string,
+): void {
+  if (!hostAddressMismatch(clientIp, resolvedHost?.ip)) return;
+
+  fileLogger.error(
+    "Refusing SFTP connection: host id resolves to a different address here",
+    undefined,
+    {
+      operation: "file_manager_host_id_mismatch",
+      hostId,
+      userId,
+      clientIp,
+      resolvedIp: resolvedHost?.ip,
+    },
+  );
+  throw new HostAddressMismatchError();
+}
 
 const app = express();
 
@@ -753,6 +787,7 @@ app.post("/ssh/file_manager/ssh/connect", async (req, res) => {
     try {
       const { resolveHostById } = await import("../host-resolver.js");
       const resolvedHost = await resolveHostById(hostId, userId);
+      assertResolvedHostMatches(ip, resolvedHost, hostId, userId);
       if (resolvedHost) {
         resolvedIp = resolvedHost.ip;
         resolvedPort = resolvedHost.port;
@@ -800,6 +835,7 @@ app.post("/ssh/file_manager/ssh/connect", async (req, res) => {
         );
       }
     } catch (error) {
+      if (error instanceof HostAddressMismatchError) throw error;
       fileLogger.warn(`Failed to resolve host credentials for ${hostId}`, {
         operation: "ssh_credentials",
         hostId,
@@ -811,6 +847,7 @@ app.post("/ssh/file_manager/ssh/connect", async (req, res) => {
     try {
       const { resolveHostById } = await import("../host-resolver.js");
       const resolvedHost = await resolveHostById(hostId, userId);
+      assertResolvedHostMatches(ip, resolvedHost, hostId, userId);
       if (resolvedHost) {
         resolvedIp = resolvedHost.ip;
         resolvedPort = resolvedHost.port;
@@ -858,6 +895,7 @@ app.post("/ssh/file_manager/ssh/connect", async (req, res) => {
         );
       }
     } catch (error) {
+      if (error instanceof HostAddressMismatchError) throw error;
       fileLogger.warn(`Failed to resolve credentials for host ${hostId}`, {
         operation: "ssh_credentials",
         hostId,

--- a/src/backend/hosts/terminal/host-identity.ts
+++ b/src/backend/hosts/terminal/host-identity.ts
@@ -36,3 +36,25 @@ export function hostAddressMismatch(
 
   return resolved !== normalizeHostAddress(clientAddress);
 }
+
+/**
+ * Shown to the user on every path that refuses a mismatch, so the wording of
+ * the one thing they can act on does not depend on which feature they used.
+ */
+export const HOST_ADDRESS_MISMATCH_MESSAGE =
+  "Host mismatch: this server resolved the selected host to a different machine, so the connection was refused. " +
+  "The host ids on this device and on the sync server have drifted apart. " +
+  'Set the connection origin to "This device" for this host, or re-run a full sync, then try again.';
+
+/**
+ * Thrown where a mismatch is reported by rejecting rather than by messaging
+ * the socket. Callers whose host-resolution is wrapped in a "failed to resolve
+ * credentials, carry on" catch must let this one through: continuing is the
+ * behaviour being prevented.
+ */
+export class HostAddressMismatchError extends Error {
+  constructor() {
+    super(HOST_ADDRESS_MISMATCH_MESSAGE);
+    this.name = "HostAddressMismatchError";
+  }
+}

--- a/src/backend/hosts/terminal/index.ts
+++ b/src/backend/hosts/terminal/index.ts
@@ -46,7 +46,10 @@ import { isWindowsSftpPath, sftpPathToLocalPath } from "../transfer-paths.js";
 import { preparePrivateKeyForSSH2 } from "../../utils/ssh-key-utils.js";
 import { triggerLoginAlert } from "../../utils/alert-trigger.js";
 import { isRetriableDnsError, resolveHostForSshConnect } from "../ssh-dns.js";
-import { hostAddressMismatch } from "./host-identity.js";
+import {
+  hostAddressMismatch,
+  HOST_ADDRESS_MISMATCH_MESSAGE,
+} from "./host-identity.js";
 
 interface ConnectToHostData {
   cols: number;
@@ -1501,10 +1504,7 @@ wss.on("connection", async (ws: WebSocket, req) => {
           ws.send(
             JSON.stringify({
               type: "error",
-              message:
-                "Host mismatch: this server resolved the selected host to a different machine, so the connection was refused. " +
-                "The host ids on this device and on the sync server have drifted apart. " +
-                'Set the connection origin to "This device" for this host, or re-run a full sync, then try again.',
+              message: HOST_ADDRESS_MISMATCH_MESSAGE,
             }),
           );
           cleanupAuthState(connectionTimeout);

--- a/src/backend/tests/hosts/terminal/host-identity.test.ts
+++ b/src/backend/tests/hosts/terminal/host-identity.test.ts
@@ -1,6 +1,8 @@
 import { describe, expect, it } from "vitest";
 import {
   hostAddressMismatch,
+  HOST_ADDRESS_MISMATCH_MESSAGE,
+  HostAddressMismatchError,
   normalizeHostAddress,
 } from "../../../hosts/terminal/host-identity.js";
 
@@ -52,6 +54,33 @@ describe("hostAddressMismatch", () => {
     // An id alone must not be enough to pick a machine.
     expect(hostAddressMismatch(undefined, "10.0.0.9")).toBe(true);
     expect(hostAddressMismatch("", "10.0.0.9")).toBe(true);
+  });
+});
+
+describe("HostAddressMismatchError", () => {
+  it("survives the catch blocks that swallow resolution failures", () => {
+    // SFTP host resolution sits inside "failed to resolve credentials, carry
+    // on" handlers. Continuing is precisely what must not happen here, so
+    // those catches rethrow this type -- which only works if it is
+    // recognisable with instanceof after being thrown.
+    const rethrow = () => {
+      try {
+        throw new HostAddressMismatchError();
+      } catch (error) {
+        if (error instanceof HostAddressMismatchError) throw error;
+        return "swallowed";
+      }
+    };
+
+    expect(rethrow).toThrow(HostAddressMismatchError);
+    expect(rethrow).toThrow(HOST_ADDRESS_MISMATCH_MESSAGE);
+  });
+
+  it("tells the user which of their settings to change", () => {
+    // The message is the only actionable thing they get; the workaround has
+    // to be in it.
+    expect(HOST_ADDRESS_MISMATCH_MESSAGE).toContain("This device");
+    expect(HOST_ADDRESS_MISMATCH_MESSAGE).toContain("full sync");
   });
 });
 


### PR DESCRIPTION
Follow-up to #1176, same defect on the paths it did not reach. Still Termix-SSH/Support#1092.

#1176 stopped SSH from opening a shell on the wrong machine when the desktop app's host id resolves to a different row on the sync server. But SSH is one of several places that take a client-supplied id and resolve it against this server's `ssh_data`. The others were left connecting.

## What was still exposed

**File manager** (`hosts/file-manager/index.ts`, two sites — the no-credentials branch and the legacy `credentialId` branch) overwrites the client's details from the resolved row exactly like the SSH handler did:

```js
const resolvedHost = await resolveHostById(hostId, userId);
if (resolvedHost) {
  resolvedIp = resolvedHost.ip;
  resolvedPort = resolvedHost.port;
  resolvedUsername = resolvedHost.username;
```

So the user browses, edits and **deletes files** on a machine they did not pick, while the UI shows the one they did. For a file manager that is arguably worse than a wrong shell — a deletion needs no confirmation from the remote end.

**Docker console** (`hosts/docker/console.ts`) never uses the client's address at all; it dials the resolved row outright:

```js
host: resolvedHost.ip?.replace(/^\[|\]$/g, "") || resolvedHost.ip,
```

and attaches to that machine's Docker daemon.

## This change

`hostAddressMismatch` from #1176, applied where each row is loaded.

One wrinkle worth explaining. Both file manager sites sit inside handlers shaped like this:

```js
} catch (error) {
  fileLogger.warn(`Failed to resolve host credentials for ${hostId}`, ...);
  // and carry on with whatever the client sent
}
```

Carrying on is exactly the behaviour being prevented, so a plain `throw` would be swallowed and the connection would proceed. The refusal is therefore a distinct `HostAddressMismatchError` that those two catches rethrow, leaving the "resolution failed, fall back" behaviour intact for every other error. The Docker console has no such handler and reports over its socket, matching its existing refusals.

The user-facing wording moved into `host-identity.ts` next to the check, rather than being spelled out at each of the three sites — the same reason the lookup itself is shared.

## Tests

`host-identity.test.ts` grows from 7 cases to 9: that `HostAddressMismatchError` is still recognisable with `instanceof` after being thrown and rethrown (the property the catches depend on), and that the message actually names the workaround. The existing cases already cover the comparison itself.

Backend suite: 143 files, 1071 passing. `tsc -p tsconfig.node.json`, `tsc --noEmit`, `npm run lint` (0 errors), prettier — all clean.

## Still not covered

Three call sites resolve a host id with **no client-supplied address to compare against**, so this technique does not apply:

| Site | Why |
|---|---|
| `file-manager/index.ts:366` (transfer session) | derives `hostId` from the browse session id; the client never states an address |
| `jump-host-chain.ts` | jump hosts travel as `{ hostId }` and nothing else |
| `routes/proxmox.ts` | host id comes from the URL |

These need the host addressed by `syncId` across the desktop/server boundary — the protocol change noted in #1176 and in Support#1092. Recording them here so the remaining surface is written down rather than assumed handled.