### PR TITLE
Address hosts by syncId when a connection is delegated

### DIFF
--- a/src/backend/database/repositories/host-resolution-repository.ts
+++ b/src/backend/database/repositories/host-resolution-repository.ts
@@ -74,6 +74,24 @@ export class HostResolutionRepository {
     return this.decryptOne("ssh_data", rows[0], userId);
   }
 
+  /**
+   * Translates a sync identity into this database's own row id.
+   *
+   * Deliberately not scoped to a user: `sync_id` is unique across the table,
+   * and a host shared with the caller belongs to someone else. Whether the
+   * caller may reach the row is decided by the permission check that follows,
+   * not here.
+   */
+  async findHostIdBySyncId(syncId: string): Promise<number | null> {
+    const rows = await this.context.drizzle
+      .select({ id: hosts.id })
+      .from(hosts)
+      .where(eq(hosts.syncId, syncId))
+      .limit(1);
+
+    return rows[0]?.id ?? null;
+  }
+
   async findHostByIdForUser(
     hostId: number,
     userId: string,

--- a/src/backend/hosts/docker/console.ts
+++ b/src/backend/hosts/docker/console.ts
@@ -15,6 +15,7 @@ import { resolveSshConnectConfigHost } from "../ssh-dns.js";
 import {
   hostAddressMismatch,
   HOST_ADDRESS_MISMATCH_MESSAGE,
+  HOST_NOT_ON_THIS_SERVER_MESSAGE,
 } from "../terminal/host-identity.js";
 
 const sshLogger = systemLogger;
@@ -391,14 +392,22 @@ wss.on("connection", async (ws: WebSocket, req) => {
 
           try {
             // Resolve host with credentials server-side
-            const { resolveHostById } = await import("../host-resolver.js");
-            const resolvedHost = await resolveHostById(hostId, userId);
+            const { resolveHostById, resolveHostBySyncId } =
+              await import("../host-resolver.js");
+            // syncId names the host on both sides of a sync pair; the numeric
+            // id only names it in the database the client is displaying.
+            const hostSyncId = hostConfig?.syncId;
+            const resolvedHost = hostSyncId
+              ? await resolveHostBySyncId(hostSyncId, userId)
+              : await resolveHostById(hostId, userId);
 
             if (!resolvedHost) {
               ws.send(
                 JSON.stringify({
                   type: "error",
-                  message: "Host not found",
+                  message: hostSyncId
+                    ? HOST_NOT_ON_THIS_SERVER_MESSAGE
+                    : "Host not found",
                 }),
               );
               return;
@@ -407,7 +416,10 @@ wss.on("connection", async (ws: WebSocket, req) => {
             // The connection below dials resolvedHost.ip outright, so if this
             // server has a different machine under the id the client sent, the
             // console opens on that machine's Docker daemon instead.
-            if (hostAddressMismatch(hostConfig?.ip, resolvedHost.ip)) {
+            if (
+              !hostSyncId &&
+              hostAddressMismatch(hostConfig?.ip, resolvedHost.ip)
+            ) {
               sshLogger.error(
                 "Refusing Docker console: host id resolves to a different address here",
                 undefined,

--- a/src/backend/hosts/file-manager/index.ts
+++ b/src/backend/hosts/file-manager/index.ts
@@ -52,6 +52,7 @@ import { resolveSshConnectConfigHost } from "../ssh-dns.js";
 import {
   hostAddressMismatch,
   HostAddressMismatchError,
+  HostNotOnThisServerError,
 } from "../terminal/host-identity.js";
 import { registerFileDownloadRoutes } from "./download-routes.js";
 import { registerFileActionRoutes } from "./action-routes.js";
@@ -65,12 +66,30 @@ import { applyAgentAuth } from "../terminal-auth-helpers.js";
  * user would browse, edit and delete its files believing they are on the host
  * they picked.
  */
-function assertResolvedHostMatches(
+function assertResolvedHost(
   clientIp: unknown,
+  hostSyncId: string | null | undefined,
   resolvedHost: { ip?: string } | null | undefined,
   hostId: number,
   userId: string,
 ): void {
+  // Named by sync identity: it either exists here or it does not. Falling back
+  // to the numeric id is what picks the wrong machine.
+  if (hostSyncId) {
+    if (resolvedHost) return;
+    fileLogger.error(
+      "Refusing SFTP connection: host is not known to this server",
+      undefined,
+      {
+        operation: "file_manager_host_sync_id_unknown",
+        hostId,
+        userId,
+      },
+    );
+    throw new HostNotOnThisServerError();
+  }
+
+  // Older clients send only the numeric id, which means a different host here.
   if (!hostAddressMismatch(clientIp, resolvedHost?.ip)) return;
 
   fileLogger.error(
@@ -673,6 +692,7 @@ app.post("/ssh/file_manager/ssh/connect", async (req, res) => {
   const {
     sessionId,
     hostId,
+    syncId: hostSyncId,
     ip,
     port,
     username,
@@ -785,9 +805,12 @@ app.post("/ssh/file_manager/ssh/connect", async (req, res) => {
   let resolvedSocks5ProxyChain = socks5ProxyChain;
   if (hostId && userId && !password && !sshKey) {
     try {
-      const { resolveHostById } = await import("../host-resolver.js");
-      const resolvedHost = await resolveHostById(hostId, userId);
-      assertResolvedHostMatches(ip, resolvedHost, hostId, userId);
+      const { resolveHostById, resolveHostBySyncId } =
+        await import("../host-resolver.js");
+      const resolvedHost = hostSyncId
+        ? await resolveHostBySyncId(hostSyncId, userId)
+        : await resolveHostById(hostId, userId);
+      assertResolvedHost(ip, hostSyncId, resolvedHost, hostId, userId);
       if (resolvedHost) {
         resolvedIp = resolvedHost.ip;
         resolvedPort = resolvedHost.port;
@@ -835,7 +858,11 @@ app.post("/ssh/file_manager/ssh/connect", async (req, res) => {
         );
       }
     } catch (error) {
-      if (error instanceof HostAddressMismatchError) throw error;
+      if (
+        error instanceof HostAddressMismatchError ||
+        error instanceof HostNotOnThisServerError
+      )
+        throw error;
       fileLogger.warn(`Failed to resolve host credentials for ${hostId}`, {
         operation: "ssh_credentials",
         hostId,
@@ -845,9 +872,12 @@ app.post("/ssh/file_manager/ssh/connect", async (req, res) => {
   } else if (credentialId && hostId && userId) {
     // Legacy: credential resolution from credentialId
     try {
-      const { resolveHostById } = await import("../host-resolver.js");
-      const resolvedHost = await resolveHostById(hostId, userId);
-      assertResolvedHostMatches(ip, resolvedHost, hostId, userId);
+      const { resolveHostById, resolveHostBySyncId } =
+        await import("../host-resolver.js");
+      const resolvedHost = hostSyncId
+        ? await resolveHostBySyncId(hostSyncId, userId)
+        : await resolveHostById(hostId, userId);
+      assertResolvedHost(ip, hostSyncId, resolvedHost, hostId, userId);
       if (resolvedHost) {
         resolvedIp = resolvedHost.ip;
         resolvedPort = resolvedHost.port;
@@ -895,7 +925,11 @@ app.post("/ssh/file_manager/ssh/connect", async (req, res) => {
         );
       }
     } catch (error) {
-      if (error instanceof HostAddressMismatchError) throw error;
+      if (
+        error instanceof HostAddressMismatchError ||
+        error instanceof HostNotOnThisServerError
+      )
+        throw error;
       fileLogger.warn(`Failed to resolve credentials for host ${hostId}`, {
         operation: "ssh_credentials",
         hostId,

--- a/src/backend/hosts/host-resolver.ts
+++ b/src/backend/hosts/host-resolver.ts
@@ -18,6 +18,33 @@ import type { HostAction } from "../utils/permission-manager.js";
 const sshLogger = logger;
 
 /**
+ * Resolve a host the client named by its sync identity.
+ *
+ * `id` is an autoincrement belonging to whichever database produced the row.
+ * When the desktop app delegates a connection to a sync server, the two
+ * sequences have no reason to agree, and resolving the client's id here lands
+ * on whatever host happens to own that number — a different machine, with its
+ * own address, credentials and host key. `syncId` is the same string on both
+ * sides, so it names the host the user actually picked.
+ *
+ * Returns null when the sync id is unknown here, rather than falling back to
+ * the numeric id: an unknown host is exactly the case where guessing picks the
+ * wrong machine.
+ */
+export async function resolveHostBySyncId(
+  syncId: string,
+  userId: string,
+): Promise<SSHHost | null> {
+  const hostId =
+    await createCurrentHostResolutionRepository().findHostIdBySyncId(syncId);
+  if (hostId === null) return null;
+
+  // Permissions, decryption, shared-host handling and auditing all belong to
+  // the id-based path; this only decides which row it is pointed at.
+  return resolveHostById(hostId, userId);
+}
+
+/**
  * Resolve a host with its credentials server-side by hostId.
  * This avoids passing credentials through the frontend.
  */

--- a/src/backend/hosts/terminal/host-identity.ts
+++ b/src/backend/hosts/terminal/host-identity.ts
@@ -47,6 +47,15 @@ export const HOST_ADDRESS_MISMATCH_MESSAGE =
   'Set the connection origin to "This device" for this host, or re-run a full sync, then try again.';
 
 /**
+ * Shown when the client named a host by sync identity that this server does
+ * not have. Distinct from a mismatch: nothing was resolved at all, so the
+ * remedy is to sync the host across rather than to pick a different origin.
+ */
+export const HOST_NOT_ON_THIS_SERVER_MESSAGE =
+  "This host does not exist on the sync server, so the connection was refused. " +
+  'Run a sync so the server knows about it, or set the connection origin to "This device" for this host.';
+
+/**
  * Thrown where a mismatch is reported by rejecting rather than by messaging
  * the socket. Callers whose host-resolution is wrapped in a "failed to resolve
  * credentials, carry on" catch must let this one through: continuing is the
@@ -56,5 +65,13 @@ export class HostAddressMismatchError extends Error {
   constructor() {
     super(HOST_ADDRESS_MISMATCH_MESSAGE);
     this.name = "HostAddressMismatchError";
+  }
+}
+
+/** Counterpart of {@link HostAddressMismatchError} for an unknown sync id. */
+export class HostNotOnThisServerError extends Error {
+  constructor() {
+    super(HOST_NOT_ON_THIS_SERVER_MESSAGE);
+    this.name = "HostNotOnThisServerError";
   }
 }

--- a/src/backend/hosts/terminal/index.ts
+++ b/src/backend/hosts/terminal/index.ts
@@ -49,6 +49,7 @@ import { isRetriableDnsError, resolveHostForSshConnect } from "../ssh-dns.js";
 import {
   hostAddressMismatch,
   HOST_ADDRESS_MISMATCH_MESSAGE,
+  HOST_NOT_ON_THIS_SERVER_MESSAGE,
 } from "./host-identity.js";
 
 interface ConnectToHostData {
@@ -56,6 +57,8 @@ interface ConnectToHostData {
   rows: number;
   hostConfig: {
     id: number;
+    /** Names the host across a sync pair; `id` only names it locally. */
+    syncId?: string | null;
     instanceId?: string;
     ip: string;
     port: number;
@@ -1326,6 +1329,7 @@ wss.on("connection", async (ws: WebSocket, req) => {
     const { hostConfig, initialPath, executeCommand, tmuxAttachSession } = data;
     const {
       id,
+      syncId: hostSyncId,
       ip: rawIp,
       port: clientPort,
       username: clientUsername,
@@ -1475,21 +1479,45 @@ wss.on("connection", async (ws: WebSocket, req) => {
 
     if (id && userId) {
       try {
-        const { resolveHostById } = await import("../host-resolver.js");
-        resolvedHostData = (await resolveHostById(
-          id,
-          userId,
-        )) as unknown as typeof resolvedHostData;
+        const { resolveHostById, resolveHostBySyncId } =
+          await import("../host-resolver.js");
 
-        // A client addresses the host by a numeric row id. When the desktop
-        // app delegates the connection to a remote sync server, that id is
-        // resolved here, against a table whose autoincrement ids need not line
-        // up with the ones the client is displaying. Everything below is then
-        // taken from whichever row happens to own that id -- the address, the
-        // credentials, the jump hosts, the stored host key -- so a mismatch
-        // opens an interactive shell on a machine the user did not choose, and
-        // says nothing about it.
-        if (hostAddressMismatch(clientIp, resolvedHostData?.ip)) {
+        // Prefer the sync identity. A numeric id belongs to whichever database
+        // produced it, so on a sync server it names a different host than the
+        // desktop app meant; syncId is the same string on both sides.
+        resolvedHostData = (hostSyncId
+          ? await resolveHostBySyncId(hostSyncId, userId)
+          : await resolveHostById(id, userId)) as unknown as
+          typeof resolvedHostData | null;
+
+        if (hostSyncId && !resolvedHostData) {
+          sshLogger.error(
+            "Refusing to connect: host is not known to this server",
+            undefined,
+            {
+              operation: "ssh_connect_host_sync_id_unknown",
+              hostId: id,
+              userId,
+            },
+          );
+          ws.send(
+            JSON.stringify({
+              type: "error",
+              message: HOST_NOT_ON_THIS_SERVER_MESSAGE,
+            }),
+          );
+          cleanupAuthState(connectionTimeout);
+          return;
+        }
+
+        // Older clients send only the numeric id, which cannot be trusted to
+        // mean the same host here. Everything below is taken from the row it
+        // lands on -- the address, the credentials, the jump hosts, the stored
+        // host key -- so compare the address before using any of it.
+        if (
+          !hostSyncId &&
+          hostAddressMismatch(clientIp, resolvedHostData?.ip)
+        ) {
           sshLogger.error(
             "Refusing to connect: host id resolves to a different address here",
             undefined,

--- a/src/backend/tests/hosts/host-resolver-sync-id.test.ts
+++ b/src/backend/tests/hosts/host-resolver-sync-id.test.ts
@@ -1,0 +1,85 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+const findHostIdBySyncId = vi.fn();
+const canAccessHost = vi.fn();
+const findHostOwnerId = vi.fn();
+const findHostById = vi.fn();
+
+vi.mock("../../database/repositories/factory.js", () => ({
+  createCurrentHostResolutionRepository: () => ({
+    findHostIdBySyncId,
+    findHostOwnerId,
+    findHostById,
+  }),
+  createCurrentVaultProfileRepository: () => ({}),
+  createCurrentUserRepository: () => ({ findById: vi.fn() }),
+}));
+
+vi.mock("../../utils/permission-manager.js", () => ({
+  PermissionManager: { getInstance: () => ({ canAccessHost }) },
+}));
+
+vi.mock("../../utils/audit-logger.js", () => ({ logAudit: vi.fn() }));
+vi.mock("../../utils/shared-host-auth-resolver.js", () => ({
+  resolveRecipientSharedHostAuthentication: vi.fn(),
+}));
+
+/**
+ * A numeric host id belongs to whichever database produced it. Resolving the
+ * desktop app's id against a sync server's table lands on whatever host owns
+ * that number there — a different machine, with its own address, credentials
+ * and host key. `sync_id` is the same string on both sides.
+ */
+describe("resolveHostBySyncId", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    canAccessHost.mockResolvedValue({ hasAccess: true });
+    findHostOwnerId.mockResolvedValue("user-1");
+  });
+
+  it("resolves the row carrying that sync id, whatever its local id is", async () => {
+    // The client's row is id 3 locally; here the same host is id 41.
+    findHostIdBySyncId.mockResolvedValue(41);
+    findHostById.mockResolvedValue({
+      id: 41,
+      ip: "10.0.0.7",
+      userId: "user-1",
+    });
+
+    const { resolveHostBySyncId } =
+      await import("../../hosts/host-resolver.js");
+    const host = await resolveHostBySyncId("sync-abc", "user-1");
+
+    expect(findHostIdBySyncId).toHaveBeenCalledWith("sync-abc");
+    expect(findHostById).toHaveBeenCalledWith(41, "user-1");
+    expect(host?.ip).toBe("10.0.0.7");
+  });
+
+  it("returns null for a sync id this server does not have", async () => {
+    // Falling back to the numeric id here is what picked the wrong machine.
+    findHostIdBySyncId.mockResolvedValue(null);
+
+    const { resolveHostBySyncId } =
+      await import("../../hosts/host-resolver.js");
+
+    await expect(resolveHostBySyncId("sync-unknown", "user-1")).resolves.toBe(
+      null,
+    );
+    expect(findHostById).not.toHaveBeenCalled();
+  });
+
+  it("still refuses a host the caller may not reach", async () => {
+    // The lookup is unscoped so shared hosts resolve; permission is decided by
+    // the id-based path, which must not be bypassed.
+    findHostIdBySyncId.mockResolvedValue(41);
+    canAccessHost.mockResolvedValue({ hasAccess: false });
+
+    const { resolveHostBySyncId } =
+      await import("../../hosts/host-resolver.js");
+
+    await expect(resolveHostBySyncId("sync-abc", "intruder")).resolves.toBe(
+      null,
+    );
+    expect(findHostById).not.toHaveBeenCalled();
+  });
+});

--- a/src/backend/tests/hosts/terminal/host-identity.test.ts
+++ b/src/backend/tests/hosts/terminal/host-identity.test.ts
@@ -2,7 +2,9 @@ import { describe, expect, it } from "vitest";
 import {
   hostAddressMismatch,
   HOST_ADDRESS_MISMATCH_MESSAGE,
+  HOST_NOT_ON_THIS_SERVER_MESSAGE,
   HostAddressMismatchError,
+  HostNotOnThisServerError,
   normalizeHostAddress,
 } from "../../../hosts/terminal/host-identity.js";
 
@@ -81,6 +83,29 @@ describe("HostAddressMismatchError", () => {
     // to be in it.
     expect(HOST_ADDRESS_MISMATCH_MESSAGE).toContain("This device");
     expect(HOST_ADDRESS_MISMATCH_MESSAGE).toContain("full sync");
+  });
+});
+
+describe("HostNotOnThisServerError", () => {
+  it("is distinguishable from a mismatch, and survives a rethrow", () => {
+    // Different remedies: an unknown host needs syncing across, a mismatched
+    // one needs a different origin. The SFTP catches rethrow both.
+    const thrown = (() => {
+      try {
+        throw new HostNotOnThisServerError();
+      } catch (error) {
+        return error;
+      }
+    })();
+
+    expect(thrown).toBeInstanceOf(HostNotOnThisServerError);
+    expect(thrown).not.toBeInstanceOf(HostAddressMismatchError);
+    expect((thrown as Error).message).toBe(HOST_NOT_ON_THIS_SERVER_MESSAGE);
+  });
+
+  it("tells the user to sync rather than to switch origin", () => {
+    expect(HOST_NOT_ON_THIS_SERVER_MESSAGE).toContain("sync");
+    expect(HOST_NOT_ON_THIS_SERVER_MESSAGE).toContain("This device");
   });
 });
 

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -214,6 +214,13 @@ export interface Host {
   rdpAuthType?: "direct" | "credential" | "none" | null;
   vncAuthType?: "direct" | "credential" | null;
   telnetAuthType?: "direct" | "credential" | null;
+  /**
+   * Stable identity across a desktop/server sync pair. `id` is an
+   * autoincrement local to whichever database produced the row, so it cannot
+   * name the same host on both sides; this can. Absent on hosts that have
+   * never been part of a sync.
+   */
+  syncId?: string | null;
   createdAt: string;
   updatedAt: string;
 

--- a/src/ui/api/ssh-file-operations-api.ts
+++ b/src/ui/api/ssh-file-operations-api.ts
@@ -60,6 +60,8 @@ export async function connectSSH(
   sessionId: string,
   config: {
     hostId?: number;
+    /** Names the host across a sync pair; hostId only names it locally. */
+    syncId?: string | null;
     ip: string;
     port: number;
     username: string;
@@ -830,6 +832,7 @@ export async function ensureSSHSessionForHost(
   try {
     const result = await connectSSH(sessionId, {
       hostId: host.id,
+      syncId: host.syncId ?? null,
       ip: host.ip,
       port: host.port,
       username: host.username,

--- a/src/ui/shell/tabUtils.tsx
+++ b/src/ui/shell/tabUtils.tsx
@@ -125,6 +125,9 @@ function hostToSSHHost(h: Host): SSHHost {
     tunnelConnections: [],
     connectionType: "ssh",
     connectionOrigin: h.connectionOrigin ?? null,
+    // Carries the host's identity to a delegated backend. Without it the
+    // remote side resolves our local row id against its own table.
+    syncId: h.syncId ?? null,
     createdAt: "",
     updatedAt: "",
   } as SSHHost;


### PR DESCRIPTION
Completes Termix-SSH/Support#1092. Builds on #1176 and #1177, which made the wrong-machine case refuse instead of connect — this makes the case stop happening.

## Why refusing was only half of it

A numeric host id belongs to whichever database produced it. The desktop app lists hosts out of its embedded database and names them to the backend by row id; when the connection origin is "Remote server", that id is resolved against the sync server's `ssh_data` instead, and the two autoincrement sequences have no reason to agree. The row it lands on is a different machine, and it supplies the address, the credentials, the jump hosts and the stored host key.

#1176/#1177 compare addresses and refuse on disagreement. That stops the wrong-machine shell, the wrong-fingerprint prompt and the misdirected sudo password — but it leaves "Remote server" **unusable** once the ids have drifted, which is exactly the state the reporter is in. The workaround is still "switch the origin back".

## What was already there

`syncId` names a host identically on both sides. Remote sync is built on it, `ssh_data.sync_id` carries a unique index, and `GET /host/db/host` already returns it — `stripSensitiveFields` only removes credentials.

It just never reached the backend. `hostToSSHHost()` in `tabUtils.tsx` builds its result field by field, and `syncId` was not among them, so it was dropped before the connection payload was ever assembled.

## The change

Carry it through, and prefer it when present:

```
resolveHostBySyncId(syncId, userId)
  -> findHostIdBySyncId(syncId)        // this database's own row id
  -> resolveHostById(hostId, userId)   // unchanged: permissions, decryption,
                                       // shared hosts, auditing
```

Translation then reuse, rather than a second resolver — `resolveHostById` is 300 lines of permission checks, owner-key decryption, shared-host authentication and audit logging, and none of that should exist twice.

Two decisions worth calling out:

**The lookup is not scoped to a user.** `sync_id` is unique across the table, and a host shared with the caller belongs to someone else, so scoping it would break shared hosts. Access is decided by the permission check in the id-based path, which the lookup feeds rather than bypasses. There is a test asserting a caller without access still gets `null`.

**An unknown syncId resolves to nothing** rather than falling back to the numeric id. An unknown host is precisely the case where guessing picks the wrong machine, and the fallback would reintroduce the bug on the exact input that triggers it. The user is told to sync the host across — a different remedy from the mismatch case, so it is a different message and a distinct error type.

**Clients that send no syncId are untouched**, address comparison included. An older desktop app keeps the #1176/#1177 safety net rather than breaking, and web sessions — where client and server share one database — are unaffected either way.

Paths covered: SSH terminal, SFTP, Docker console. `jump-host-chain` and the proxmox routes still take a bare id; they need the same treatment and are noted in #1177.

## Tests

`host-resolver-sync-id.test.ts` (3): resolves the row carrying the sync id even when its local id differs (id 3 on the client, 41 here — the actual failure); returns null for an unknown sync id without consulting the numeric id; still refuses a caller who may not reach the host.

`host-identity.test.ts` grows by 2 for the new error type: distinguishable from a mismatch after being thrown and rethrown, and a message that names the right remedy.

Backend 144 files / 1076 passing, UI 67 files / 440 passing. `tsc -p tsconfig.node.json`, `tsc --noEmit`, `npm run lint` (0 errors), prettier — clean.