### PR TITLE
Keep already-shared hosts sharing their SSH authentication

### DIFF
--- a/src/backend/database/db/index.ts
+++ b/src/backend/database/db/index.ts
@@ -1683,6 +1683,40 @@ const migrateSchema = () => {
     }
   }
 
+  // share_ssh_auth arrived with 2.6.1 and defaults to 0, but sharing a host
+  // used to pass the owner's SSH authentication along unconditionally. Every
+  // host shared before the upgrade therefore stopped supplying credentials to
+  // its recipients the moment the column appeared, and they were left with
+  // "No valid authentication method provided".
+  //
+  // Turn it on for hosts that are already shared, which is where the previous
+  // behaviour was in effect and consented to. Hosts nobody has shared keep the
+  // new default; the owner decides when they share one.
+  try {
+    if (getRawSettingValue("share_ssh_auth_backfill_v1") === null) {
+      const backfilled = sqlite
+        .prepare(
+          `UPDATE ssh_data SET share_ssh_auth = 1
+           WHERE share_ssh_auth = 0
+             AND id IN (SELECT DISTINCT host_id FROM host_access)`,
+        )
+        .run();
+
+      if (backfilled.changes > 0) {
+        databaseLogger.info(
+          `Restored shared SSH authentication for ${backfilled.changes} already-shared host(s)`,
+          { operation: "share_ssh_auth_backfill_v1" },
+        );
+      }
+      setRawSettingValue("share_ssh_auth_backfill_v1", "true");
+    }
+  } catch (e) {
+    databaseLogger.warn("Failed to backfill share_ssh_auth", {
+      operation: "share_ssh_auth_backfill_v1",
+      error: e,
+    });
+  }
+
   // Migrate legacy authType="warpgate" hosts to useWarpgate=1 with authType="none"
   try {
     const result = sqlite

--- a/src/backend/tests/database/db/share-ssh-auth-backfill.test.ts
+++ b/src/backend/tests/database/db/share-ssh-auth-backfill.test.ts
@@ -1,0 +1,128 @@
+import fs from "fs";
+import os from "os";
+import path from "path";
+import Database from "better-sqlite3";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+/**
+ * Sharing a host used to hand the owner's SSH authentication to the recipient
+ * unconditionally. 2.6.1 put that behind `ssh_data.share_ssh_auth`, added as
+ * `NOT NULL DEFAULT 0` — so every host shared before the upgrade silently
+ * stopped supplying credentials, and recipients hit "No valid authentication
+ * method provided" on hosts that had worked the day before.
+ *
+ * Hosts that are already shared get the flag turned on, because that is where
+ * the old behaviour was in effect. Hosts nobody has shared keep the new
+ * default: their owner decides when they share one.
+ */
+describe("share_ssh_auth backfill", () => {
+  let dataDir: string;
+
+  beforeEach(() => {
+    dataDir = fs.mkdtempSync(path.join(os.tmpdir(), "termix-share-auth-"));
+    vi.resetModules();
+    process.env.DATA_DIR = dataDir;
+    process.env.DB_FILE_ENCRYPTION = "false";
+    process.env.ALLOW_EMPTY_DATA_DIR = "true";
+  });
+
+  afterEach(() => {
+    delete process.env.DATA_DIR;
+    delete process.env.DB_FILE_ENCRYPTION;
+    delete process.env.ALLOW_EMPTY_DATA_DIR;
+    fs.rmSync(dataDir, { recursive: true, force: true });
+  });
+
+  /** A 2.6.0 database: hosts and shares exist, the column does not. */
+  function writePreUpgradeDatabase(): void {
+    const seed = new Database(":memory:");
+    seed.exec(`
+      CREATE TABLE users (
+        id TEXT PRIMARY KEY,
+        username TEXT NOT NULL,
+        password_hash TEXT NOT NULL
+      );
+
+      CREATE TABLE ssh_data (
+        id INTEGER PRIMARY KEY AUTOINCREMENT,
+        user_id TEXT NOT NULL,
+        name TEXT,
+        ip TEXT NOT NULL,
+        port INTEGER NOT NULL,
+        username TEXT NOT NULL,
+        folder TEXT,
+        tags TEXT,
+        pin INTEGER NOT NULL DEFAULT 0,
+        auth_type TEXT NOT NULL DEFAULT 'password',
+        enable_terminal INTEGER NOT NULL DEFAULT 1,
+        enable_tunnel INTEGER NOT NULL DEFAULT 0,
+        enable_file_manager INTEGER NOT NULL DEFAULT 1,
+        default_path TEXT,
+        created_at TEXT NOT NULL DEFAULT CURRENT_TIMESTAMP,
+        updated_at TEXT NOT NULL DEFAULT CURRENT_TIMESTAMP
+      );
+
+      CREATE TABLE host_access (
+        id INTEGER PRIMARY KEY AUTOINCREMENT,
+        host_id INTEGER NOT NULL,
+        user_id TEXT,
+        role_id INTEGER,
+        granted_by TEXT NOT NULL,
+        permission_level TEXT NOT NULL DEFAULT 'use',
+        expires_at TEXT,
+        created_at TEXT NOT NULL DEFAULT CURRENT_TIMESTAMP
+      );
+
+      INSERT INTO users (id, username, password_hash)
+        VALUES ('owner', 'alice', 'hash'), ('recipient', 'bob', 'hash');
+
+      INSERT INTO ssh_data (id, user_id, name, ip, port, username, auth_type)
+        VALUES (1, 'owner', 'shared box', '10.0.0.7', 22, 'root', 'credential'),
+               (2, 'owner', 'private box', '10.0.0.8', 22, 'root', 'credential');
+
+      INSERT INTO host_access (host_id, user_id, granted_by, permission_level)
+        VALUES (1, 'recipient', 'owner', 'use');
+    `);
+    fs.writeFileSync(path.join(dataDir, "db.sqlite"), seed.serialize());
+    seed.close();
+  }
+
+  function shareFlags(
+    sqlite: Database.Database,
+  ): Record<number, number> {
+    const rows = sqlite
+      .prepare("SELECT id, share_ssh_auth FROM ssh_data ORDER BY id")
+      .all() as Array<{ id: number; share_ssh_auth: number }>;
+    return Object.fromEntries(rows.map((r) => [r.id, r.share_ssh_auth]));
+  }
+
+  it("keeps already-shared hosts sharing their authentication", async () => {
+    writePreUpgradeDatabase();
+
+    const db = await import("../../../database/db/index.js");
+    await db.initializeDatabase();
+
+    const flags = shareFlags(db.getSqlite());
+    expect(flags[1]).toBe(1); // shared before the upgrade
+    expect(flags[2]).toBe(0); // never shared, new default stands
+  });
+
+  it("does not undo an owner who later turns it back off", async () => {
+    writePreUpgradeDatabase();
+
+    const first = await import("../../../database/db/index.js");
+    await first.initializeDatabase();
+    first
+      .getSqlite()
+      .prepare("UPDATE ssh_data SET share_ssh_auth = 0 WHERE id = 1")
+      .run();
+    await first.saveMemoryDatabaseToFile?.();
+
+    // Second startup: the backfill is recorded as done and must not re-run.
+    vi.resetModules();
+    const second = await import("../../../database/db/index.js");
+    await second.initializeDatabase();
+
+    expect(shareFlags(second.getSqlite())[1]).toBe(0);
+  });
+});


### PR DESCRIPTION
Fixes Termix-SSH/Support#1095.

## What users see

Hosts shared before upgrading to 2.6.1 stop working for their recipients:

```
Using keyboard-interactive authentication
No valid authentication method provided
SSH connection timeout
```

Reported for hosts using a credential / key pair, and the reporter confirms rolling back to 2.6.0 fixes it. Triage marked it Urgent.

## Root cause

Sharing a host used to pass the owner's SSH authentication to the recipient unconditionally. 2.6.1 put that behind a new column:

```sql
ALTER TABLE ssh_data ADD COLUMN share_ssh_auth INTEGER NOT NULL DEFAULT 0
```

Existing rows take the default. So on the first 2.6.1 startup every host in the database — including every host already shared with someone — became "do not share SSH authentication", silently.

From there the failure is deterministic:

- `collectProtocolSnapshots()` only captures the owner's credentials under `if (enabled.ssh && host.shareSshAuth)`, so nothing is snapshotted;
- `resolveRecipientSharedHostAuthentication()` finds no personal override and no owner snapshot, and falls through to `requiresPersonalHostAuthentication()`, which is true for anything with a `credentialId` — so it returns `{ source: "required" }`;
- the recipient is asked to supply their own credentials, which they do not have, and the connection dies with the message above.

That also explains the two details in the report that would otherwise be puzzling. Hosts with a credential assigned are exactly the ones `requiresPersonalHostAuthentication` returns true for. And 2.6.0 works because that build has no such column to consult — the downgrade fixes it, not the re-created share.

The snapshot code handles `credentialId` correctly, incidentally; it never gets the chance to run.

## The fix

Backfill the flag for hosts that are already shared:

```sql
UPDATE ssh_data SET share_ssh_auth = 1
WHERE share_ssh_auth = 0
  AND id IN (SELECT DISTINCT host_id FROM host_access)
```

Scoped to `host_access` on purpose. Those are the hosts where the old behaviour was in effect and where the owner had already agreed to share; turning the flag on restores what they had. A host nobody has shared keeps the new default and stays off until its owner shares it, so the safer default still applies everywhere it has not already been overtaken by events.

Guarded by a `share_ssh_auth_backfill_v1` settings key, following the `sso_migration_v1` pattern already in `migrateSchema()`. Without it, an owner who deliberately turns sharing back off would find it back on after the next restart.

## Tests

`share-ssh-auth-backfill.test.ts` seeds a 2.6.0-shaped database — two hosts, one of them in `host_access`, no `share_ssh_auth` column at all — then boots the real database:

- the shared host comes up with the flag on, the unshared one stays off;
- turning it back off and restarting leaves it off, so the migration does not re-run.

Each guards a different half: the first fails without the backfill, the second fails if the settings-key guard is removed. I verified both by breaking them in turn.

Backend suite: 145 files, 1078 passing. `tsc -p tsconfig.node.json`, `npm run lint` (0 errors) and prettier clean.