### PR TITLE
Let a single credential disable 2FA again

### DIFF
--- a/src/backend/database/routes/user-totp-routes.ts
+++ b/src/backend/database/routes/user-totp-routes.ts
@@ -325,20 +325,16 @@ export function registerUserTotpRoutes(
         return res.status(404).json({ error: "User not found" });
       }
 
-      if (!totp_code || (!userRecord.isOidc && !password)) {
+      // One re-authentication value, whichever kind it is. The dialog offers a
+      // single field -- "Enter TOTP code or password" -- so it arrives in
+      // whichever of the two body fields the caller happened to use.
+      const credential = totp_code || password;
+      if (!credential) {
         return res.status(400).json({
           error: userRecord.isOidc
             ? "A TOTP code is required"
-            : "Both password and TOTP code are required",
+            : "A TOTP code or password is required",
         });
-      }
-
-      if (
-        !userRecord.isOidc &&
-        (!userRecord.passwordHash ||
-          !(await bcrypt.compare(password, userRecord.passwordHash)))
-      ) {
-        return res.status(401).json({ error: "Incorrect password" });
       }
 
       if (!userRecord.totpEnabled) {
@@ -346,11 +342,18 @@ export function registerUserTotpRoutes(
       }
 
       const userDataKey = authManager.getUserDataKey(userId);
-      const verified = await verifyTotpReauth(
+      // TOTP code or backup code first; verifyTotpReauth deliberately refuses
+      // the account password, so that stays a separate comparison here.
+      let verified = await verifyTotpReauth(
         userRecord,
-        totp_code,
+        credential,
         userDataKey,
       );
+
+      if (!verified && !userRecord.isOidc && userRecord.passwordHash) {
+        verified = await bcrypt.compare(credential, userRecord.passwordHash);
+      }
+
       if (!verified) {
         return res
           .status(401)

--- a/src/backend/tests/database/routes/totp-disable-route.test.ts
+++ b/src/backend/tests/database/routes/totp-disable-route.test.ts
@@ -1,0 +1,153 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import bcrypt from "bcryptjs";
+import speakeasy from "speakeasy";
+
+const userUpdate = vi.fn().mockResolvedValue(null);
+const findById = vi.fn();
+
+vi.mock("../../../database/repositories/factory.js", () => ({
+  createCurrentUserRepository: () => ({ findById, update: userUpdate }),
+  createCurrentTrustedDeviceRepository: () => ({}),
+  createCurrentUserSessionRepository: () => ({}),
+}));
+
+vi.mock("../../../utils/logger.js", () => ({
+  authLogger: {
+    debug: vi.fn(),
+    info: vi.fn(),
+    warn: vi.fn(),
+    error: vi.fn(),
+    success: vi.fn(),
+  },
+}));
+
+vi.mock("../../../utils/database-save-trigger.js", () => ({
+  DatabaseSaveTrigger: { forceSave: vi.fn().mockResolvedValue(undefined) },
+}));
+
+const { registerUserTotpRoutes } =
+  await import("../../../database/routes/user-totp-routes.js");
+
+const secret = speakeasy.generateSecret({ name: "test" }).base32;
+const PASSWORD = "correct-horse";
+
+/**
+ * The disable dialog has one field, labelled "Enter TOTP code or password",
+ * and its caller passes that single value as `disableTOTP(input)` — which
+ * lands in the `password` argument, leaving `totp_code` undefined.
+ *
+ * 2.5.1 changed the route to require both, so from then on the first check
+ * rejected every attempt regardless of what was typed. Nobody could turn 2FA
+ * off, and the client reported it as the generic "Failed to disable 2FA".
+ */
+describe("POST /totp/disable", () => {
+  let handler: (req: unknown, res: unknown) => Promise<void>;
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+
+    const routes = new Map<string, (req: unknown, res: unknown) => unknown>();
+    const router = {
+      post: (path: string, ...rest: unknown[]) => {
+        routes.set(path, rest[rest.length - 1] as never);
+      },
+      get: () => {},
+      put: () => {},
+      delete: () => {},
+    };
+
+    registerUserTotpRoutes(
+      router as never,
+      {
+        authenticateJWT: (() => {}) as never,
+        authManager: { getUserDataKey: () => null } as never,
+        isNativeAppRequest: () => false,
+      } as never,
+    );
+
+    handler = routes.get("/totp/disable") as never;
+    findById.mockResolvedValue({
+      id: "user-1",
+      isOidc: false,
+      passwordHash: bcrypt.hashSync(PASSWORD, 4),
+      totpSecret: secret,
+      totpBackupCodes: JSON.stringify(["BACKUP01"]),
+      totpEnabled: true,
+    });
+  });
+
+  function call(body: Record<string, unknown>) {
+    const res = {
+      statusCode: 200,
+      body: undefined as unknown,
+      status(code: number) {
+        this.statusCode = code;
+        return this;
+      },
+      json(payload: unknown) {
+        this.body = payload;
+        return this;
+      },
+    };
+    return handler({ userId: "user-1", body }, res).then(() => res);
+  }
+
+  it("accepts the TOTP code on its own", async () => {
+    // What the dialog sends: one value, in whichever field the client used.
+    const res = await call({
+      totp_code: speakeasy.totp({ secret, encoding: "base32" }),
+    });
+
+    expect(res.statusCode).toBe(200);
+    expect(userUpdate).toHaveBeenCalledWith(
+      "user-1",
+      expect.objectContaining({ totpEnabled: false, totpSecret: null }),
+    );
+  });
+
+  it("accepts the account password on its own", async () => {
+    // The single field is labelled "TOTP code or password", and the client
+    // passes it as the password argument — this is the exact failing call.
+    const res = await call({ password: PASSWORD });
+
+    expect(res.statusCode).toBe(200);
+    expect(userUpdate).toHaveBeenCalled();
+  });
+
+  it("accepts a backup code", async () => {
+    const res = await call({ totp_code: "BACKUP01" });
+
+    expect(res.statusCode).toBe(200);
+  });
+
+  it("still refuses a wrong value", async () => {
+    const res = await call({ password: "not-my-password" });
+
+    expect(res.statusCode).toBe(401);
+    expect(userUpdate).not.toHaveBeenCalled();
+  });
+
+  it("refuses an empty request rather than disabling anything", async () => {
+    const res = await call({});
+
+    expect(res.statusCode).toBe(400);
+    expect(userUpdate).not.toHaveBeenCalled();
+  });
+
+  it("does not let an OIDC user disable it with a password", async () => {
+    // No password to compare against; only a TOTP or backup code will do.
+    findById.mockResolvedValue({
+      id: "user-1",
+      isOidc: true,
+      passwordHash: null,
+      totpSecret: secret,
+      totpBackupCodes: JSON.stringify([]),
+      totpEnabled: true,
+    });
+
+    const res = await call({ password: "anything" });
+
+    expect(res.statusCode).toBe(401);
+    expect(userUpdate).not.toHaveBeenCalled();
+  });
+});


### PR DESCRIPTION
Fixes Termix-SSH/Support#1093.

Nobody can turn 2FA off. The reporter tried both a TOTP code and their password and got "Failed to disable 2FA" every time, and guessed it was a regression of Support#778. It is a regression, though not of that one.

## Front and back disagree about how many values there are

The disable dialog has **one** field, labelled `"Enter TOTP code or password"`, and its caller passes that value positionally:

```js
await disableTOTP(disableTotpInput);
//    disableTOTP(password?, totp_code?)
```

So it arrives as `password`, with `totp_code` undefined. That call has been unchanged since v2.3.0.

`ddbdd5c4` (release-2.5.1, #1067) changed the route to require both:

```diff
- const credential = password || totp_code;
- .json({ error: "A TOTP code or password is required" })
+ if (!totp_code || (!userRecord.isOidc && !password)) {
+   error: userRecord.isOidc ? "A TOTP code is required"
+                            : "Both password and TOTP code are required",
```

The client was never updated to match. Since 2.5.1 the first check has rejected every attempt, whatever the user typed — which is why trying the TOTP code *and* the password both "fail": neither ever reaches a comparison. The client shows its generic message, so the 400 never surfaces.

The reporter is on 2.6.1, but this has been broken since 2.5.1.

## The fix

Take one credential again, and try it as a TOTP code, a backup code, then the account password:

```js
const credential = totp_code || password;
let verified = await verifyTotpReauth(userRecord, credential, userDataKey);
if (!verified && !userRecord.isOidc && userRecord.passwordHash) {
  verified = await bcrypt.compare(credential, userRecord.passwordHash);
}
```

`verifyTotpReauth` deliberately refuses the account password — there is a test asserting exactly that, and it still passes — so the password comparison stays in the route rather than being folded into the verifier. An OIDC user has no `passwordHash` and reaches neither branch, matching the existing `"A TOTP code is required"` wording for them.

Callers that send both fields keep working; `totp_code` is simply preferred.

Worth being explicit about the security shape, since this loosens a check: the route is behind `authenticateJWT`, so the caller has already completed a full login **including** the 2FA prompt. This is a re-authentication step on top of that, and the UI has described it as "code or password" the whole time. Requiring both would be defensible, but then the dialog needs two fields — and that is a product decision, not something to fix by leaving the feature inoperable. Happy to do it that way instead if you would rather.

## Not touched

`/totp/backup-codes` has the same both-required shape, but no caller in the UI — backup codes are returned when TOTP is enabled — so there is no user-visible failure and I have not changed it blind.

## Tests

`totp-disable-route.test.ts` drives the real route handler through a stub router, 6 cases: TOTP code alone, password alone (the exact failing call), a backup code, a wrong value still refused with 401, an empty body refused with 400 and nothing disabled, and an OIDC user unable to use a password.

Five of the six fail without the fix. Backend suite: 145 files, 1082 passing. `tsc -p tsconfig.node.json`, `npm run lint` (0 errors) and prettier clean.