### PR TITLE
Attach user-managed CA certificates over SFTP too

### DIFF
--- a/src/backend/hosts/file-manager/ca-cert-auth.ts
+++ b/src/backend/hosts/file-manager/ca-cert-auth.ts
@@ -1,0 +1,50 @@
+import type { Client as SSHClient, ConnectConfig } from "ssh2";
+import { fileLogger } from "../../utils/logger.js";
+
+/**
+ * Attaches a user-managed CA-signed certificate to an SFTP connection, if the
+ * host carries one.
+ *
+ * The terminal has always done this. The file manager never did: it imports
+ * and calls `setupOPKSSHCertAuth`, but `setupCACertAuth` — the sibling helper
+ * for user-managed `-cert.pub` files — had no call site here at all. A host
+ * whose key is paired with a CA-signed certificate therefore authenticated in
+ * a terminal and failed in the file manager, while OPKSSH certificates worked
+ * in both. That asymmetry is the whole bug.
+ *
+ * `cert_public_key` is a column on `ssh_data` but is not part of the shared
+ * `Host` type, so callers pass whichever record they hold and it is read off
+ * structurally — the same way the terminal reads it.
+ *
+ * A certificate that cannot be applied is logged and skipped rather than
+ * failing the connection: the private key alone may still be accepted, which
+ * is exactly what happened before any of this was wired up.
+ */
+export async function applyCACertIfPresent(
+  config: Record<string, unknown>,
+  client: SSHClient,
+  privateKey: Buffer | string,
+  source: { certPublicKey?: string | null },
+  username: string,
+  passphrase?: string,
+): Promise<void> {
+  const certPublicKey = source.certPublicKey;
+  if (!certPublicKey || !certPublicKey.trim()) return;
+
+  try {
+    const { setupCACertAuth } = await import("../opkssh-cert-auth.js");
+    await setupCACertAuth(
+      config as ConnectConfig,
+      client,
+      privateKey,
+      certPublicKey,
+      username,
+      passphrase,
+    );
+  } catch (certError) {
+    fileLogger.warn("CA certificate setup failed, continuing with key only", {
+      operation: "sftp_ca_cert_auth_failed",
+      error: certError instanceof Error ? certError.message : "Unknown error",
+    });
+  }
+}

--- a/src/backend/hosts/file-manager/index.ts
+++ b/src/backend/hosts/file-manager/index.ts
@@ -57,6 +57,7 @@ import {
 import { registerFileDownloadRoutes } from "./download-routes.js";
 import { registerFileActionRoutes } from "./action-routes.js";
 import { applyAgentAuth } from "../terminal-auth-helpers.js";
+import { applyCACertIfPresent } from "./ca-cert-auth.js";
 
 /**
  * The host id came from whichever database the client is displaying. If this
@@ -264,6 +265,15 @@ async function buildDedicatedTransferConnectConfig(
       .replace(/\r/g, "\n");
     config.privateKey = Buffer.from(cleanKey, "utf8");
     if (host.keyPassword) config.passphrase = host.keyPassword;
+
+    await applyCACertIfPresent(
+      config,
+      client,
+      config.privateKey as Buffer,
+      host as { certPublicKey?: string | null },
+      username,
+      host.keyPassword,
+    );
   } else if (authType === "password") {
     if (!host.password) {
       throw new Error("Password required for transfer connection");
@@ -788,6 +798,7 @@ app.post("/ssh/file_manager/ssh/connect", async (req, res) => {
     keyPassword,
     authType,
     sudoPassword: undefined as string | undefined,
+    certPublicKey: undefined as string | undefined,
   };
   let hostKeepaliveInterval: number | undefined;
   let hostKeepaliveCountMax: number | undefined;
@@ -821,6 +832,8 @@ app.post("/ssh/file_manager/ssh/connect", async (req, res) => {
           keyPassword: resolvedHost.keyPassword,
           authType: resolvedHost.authType,
           sudoPassword: resolvedHost.sudoPassword as string | undefined,
+          certPublicKey: (resolvedHost as { certPublicKey?: string })
+            .certPublicKey,
         };
         resolvedTerminalConfig = resolvedHost.terminalConfig as unknown as
           Record<string, unknown> | undefined;
@@ -888,6 +901,8 @@ app.post("/ssh/file_manager/ssh/connect", async (req, res) => {
           keyPassword: resolvedHost.keyPassword,
           authType: resolvedHost.authType,
           sudoPassword: resolvedHost.sudoPassword as string | undefined,
+          certPublicKey: (resolvedHost as { certPublicKey?: string })
+            .certPublicKey,
         };
         resolvedTerminalConfig = resolvedHost.terminalConfig as unknown as
           Record<string, unknown> | undefined;
@@ -1026,11 +1041,23 @@ app.post("/ssh/file_manager/ssh/connect", async (req, res) => {
 
       if (resolvedCredentials.keyPassword)
         config.passphrase = resolvedCredentials.keyPassword;
+
+      await applyCACertIfPresent(
+        config,
+        client,
+        config.privateKey as Buffer,
+        resolvedCredentials,
+        resolvedUsername,
+        resolvedCredentials.keyPassword,
+      );
+
       connectionLogs.push(
         createConnectionLog(
           "info",
           "sftp_auth",
-          "Using SSH key authentication",
+          resolvedCredentials.certPublicKey?.trim()
+            ? "Using SSH key authentication with CA certificate"
+            : "Using SSH key authentication",
         ),
       );
     } catch (keyError) {

--- a/src/backend/tests/hosts/file-manager/ca-cert-auth.test.ts
+++ b/src/backend/tests/hosts/file-manager/ca-cert-auth.test.ts
@@ -1,0 +1,92 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+const setupCACertAuth = vi.fn();
+const warn = vi.fn();
+
+vi.mock("../../../hosts/opkssh-cert-auth.js", () => ({
+  setupCACertAuth: (...args: unknown[]) => setupCACertAuth(...args),
+}));
+
+vi.mock("../../../utils/logger.js", () => ({
+  fileLogger: { warn, info: vi.fn(), error: vi.fn(), debug: vi.fn() },
+}));
+
+const { applyCACertIfPresent } =
+  await import("../../../hosts/file-manager/ca-cert-auth.js");
+
+/**
+ * `setupCACertAuth` had no call site in the file manager at all, while its
+ * sibling `setupOPKSSHCertAuth` had two. So a host whose key is paired with a
+ * user-managed CA-signed certificate authenticated in the terminal and failed
+ * over SFTP, and OPKSSH certificates — going through the other helper — worked
+ * in both places.
+ */
+describe("applyCACertIfPresent", () => {
+  const client = {} as never;
+  const key = Buffer.from("private-key");
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("attaches a certificate the host carries", async () => {
+    const config: Record<string, unknown> = {};
+
+    await applyCACertIfPresent(
+      config,
+      client,
+      key,
+      { certPublicKey: "ssh-rsa-cert-v01@openssh.com AAAA" },
+      "root",
+      "passphrase",
+    );
+
+    expect(setupCACertAuth).toHaveBeenCalledWith(
+      config,
+      client,
+      key,
+      "ssh-rsa-cert-v01@openssh.com AAAA",
+      "root",
+      "passphrase",
+    );
+  });
+
+  it("does nothing when there is no certificate", async () => {
+    // Most hosts. Touching the connection here would change key-only auth.
+    for (const certPublicKey of [undefined, null, "", "   "]) {
+      await applyCACertIfPresent(
+        {},
+        client,
+        key,
+        { certPublicKey },
+        "root",
+        undefined,
+      );
+    }
+
+    expect(setupCACertAuth).not.toHaveBeenCalled();
+  });
+
+  it("leaves the connection usable when the certificate is unusable", async () => {
+    // The private key on its own may still be accepted — which is what
+    // happened before this was wired up. Failing the connection here would
+    // turn a working setup into a broken one.
+    setupCACertAuth.mockRejectedValueOnce(new Error("bad cert format"));
+
+    await expect(
+      applyCACertIfPresent(
+        {},
+        client,
+        key,
+        { certPublicKey: "garbage" },
+        "root",
+        undefined,
+      ),
+    ).resolves.toBeUndefined();
+
+    expect(warn).toHaveBeenCalledWith(
+      expect.stringContaining("CA certificate setup failed"),
+      expect.objectContaining({ operation: "sftp_ca_cert_auth_failed" }),
+    );
+  });
+});


### PR DESCRIPTION
Fixes #1160.

## The asymmetry

`opkssh-cert-auth.ts` exports two helpers that both end in the same `_applyCertToConnection`:

- `setupOPKSSHCertAuth` — OPKSSH tokens
- `setupCACertAuth` — user-managed CA-signed `-cert.pub` files

Call sites on `dev-2.7.0`:

| helper | `terminal/index.ts` | `file-manager/index.ts` |
| --- | --- | --- |
| `setupOPKSSHCertAuth` | 2951, 3000 | 280, 1094 |
| `setupCACertAuth` | 2868 | **none** |

So the file manager was never missing certificate support in general — it was missing one of the two paths into it. A host whose key is paired with a CA-signed certificate authenticates in a terminal and fails over SFTP; an OPKSSH certificate works in both. That is exactly the split #1160 describes.

There is a second half the report could not see from call sites alone: `cert_public_key` was not among the fields copied into `resolvedCredentials`, so even at the point where the key is prepared, the certificate was not in hand. Both halves had to be fixed for either to matter.

## The change

`applyCACertIfPresent` in a new `file-manager/ca-cert-auth.ts`, called from both places that build an SFTP connection:

- `buildDedicatedTransferConnectConfig` — the dedicated transfer session, which already receives the `client` it needs
- the main `/ssh/connect` route, in the branch that prepares the private key

`cert_public_key` is now read into `resolvedCredentials` in both resolution branches, structurally, the same way the terminal reads it — the column exists on `ssh_data` but is not part of the shared `Host` type.

Split into its own module so it is testable without importing `file-manager/index.ts`, which calls `app.listen` at module scope. Same reason `host-identity.ts` and `terminal-image-utils.ts` are separate.

**A certificate that cannot be applied is logged and skipped, not fatal.** The private key alone may still be accepted — that is precisely what has been happening while this was unwired — so failing the connection would turn working setups into broken ones on a malformed cert.

## On the report's honesty about confidence

The reporter verified the call-site asymmetry by reading the source but explicitly did not confirm it caused their failure, having moved off SSH CAs. That caution was fair. The asymmetry is real on current `main`, and it produces exactly the observed split: certificate presented in the terminal, absent over SFTP, with `sshd` trusting the CA the whole time. I have not reproduced against a live CA-backed host either — no such setup here — so the same caveat carries forward, narrowed: the missing call and the missing field are both verified in source and both now closed.

## Tests

`ca-cert-auth.test.ts`, 3 cases: a certificate on the host is passed through to `setupCACertAuth` with the right arguments; nothing happens for the four empty shapes (`undefined`, `null`, `""`, whitespace) so key-only auth is untouched; and an unusable certificate leaves the connection alive with a warning rather than throwing.

Backend suite: 145 files, 1079 passing. `tsc -p tsconfig.node.json`, `npm run lint` (0 errors) and prettier clean.