### PR TITLE
Authenticate the desktop Docker console WebSocket

### DIFF
--- a/src/ui/features/docker/components/ConsoleTerminal.tsx
+++ b/src/ui/features/docker/components/ConsoleTerminal.tsx
@@ -304,7 +304,6 @@ export function ConsoleTerminal({
           localPort: 30009,
           localPath: "/docker/console/",
           remotePath: "/docker/console/",
-          includeLocalJwt: false,
         });
         if (!resolvedUrl) {
           setIsConnecting(false);

--- a/src/ui/tests/lib/connection-origin.test.ts
+++ b/src/ui/tests/lib/connection-origin.test.ts
@@ -1,5 +1,8 @@
-import { describe, it, expect, afterEach } from "vitest";
-import { resolveConnectionOrigin } from "../../lib/connection-origin.js";
+import { describe, it, expect, afterEach, beforeEach, vi } from "vitest";
+import {
+  buildOriginWsUrl,
+  resolveConnectionOrigin,
+} from "../../lib/connection-origin.js";
 
 const win = window as unknown as Record<string, unknown>;
 
@@ -84,5 +87,67 @@ describe("resolveConnectionOrigin", () => {
         connectionOrigin: null,
       }),
     ).resolves.toBe("local");
+  });
+});
+
+/**
+ * The embedded backend authenticates a local WebSocket from `?token=`, because
+ * the browser WebSocket API cannot set an Authorization header. Electron's main
+ * process does inject a JWT cookie, but only on an exact origin match, and the
+ * remembered cookie belongs to the API origin (`localhost:30001`) — so nothing
+ * is attached to a `127.0.0.1:30009` connection.
+ *
+ * The Docker console opted out of the query token and had no other credential
+ * left, so its handshake was closed with 1008 while logs and stats kept working.
+ */
+describe("buildOriginWsUrl", () => {
+  const store: Record<string, string> = {};
+
+  beforeEach(() => {
+    store.jwt = "local-jwt";
+    vi.stubGlobal("localStorage", {
+      getItem: (k: string) => store[k] ?? null,
+    });
+  });
+
+  afterEach(() => {
+    vi.unstubAllGlobals();
+  });
+
+  it("carries the local JWT by default", async () => {
+    // Every interactive channel on the embedded backend relies on this.
+    const url = await buildOriginWsUrl({
+      origin: "local",
+      localPort: 30009,
+      localPath: "/docker/console/",
+      remotePath: "/docker/console/",
+    });
+
+    expect(url).toBe("ws://127.0.0.1:30009/docker/console/?token=local-jwt");
+  });
+
+  it("omits it only when a caller asks", async () => {
+    const url = await buildOriginWsUrl({
+      origin: "local",
+      localPort: 30009,
+      localPath: "/docker/console/",
+      remotePath: "/docker/console/",
+      includeLocalJwt: false,
+    });
+
+    expect(url).toBe("ws://127.0.0.1:30009/docker/console/");
+  });
+
+  it("leaves the URL alone when there is no token stored", async () => {
+    delete store.jwt;
+
+    const url = await buildOriginWsUrl({
+      origin: "local",
+      localPort: 30002,
+      localPath: "",
+      remotePath: "/ssh/websocket/",
+    });
+
+    expect(url).toBe("ws://127.0.0.1:30002");
   });
 });


### PR DESCRIPTION
Fixes Termix-SSH/Support#1086.

Opening a container console in the desktop app never connects. Logs and stats work on the same host, in the same view, and the web build opens the console fine.

## Why

`ConsoleTerminal` opted out of the query token:

```js
buildOriginWsUrl({ ..., includeLocalJwt: false })
```

which left the connection with no credential at all on the desktop:

- the browser `WebSocket` API cannot set an `Authorization` header;
- Electron's main process does inject a remembered JWT cookie, but on an **exact origin match** — the cookie is stored against the API origin `http://localhost:30001`, while the console connects to `ws://127.0.0.1:30009`, so nothing is attached;
- the backend finds no cookie, no header and no query parameter, and closes with `1008 Authentication required`.

That close happens **before** the `"Docker console WebSocket connected"` log line, which is exactly why the reporter sees zero `docker-console` entries while `docker_command_success` streams in from the stats and logs pollers. The web build is unaffected because it connects same-origin and its cookie is sent normally.

Verified against the source: the opt-out is the only local-origin caller that has one besides Guacamole, and `src/backend/hosts/docker/console.ts` already reads `?token=` (cookie → `Authorization` → query, in that order).

## The change

Remove the opt-out. The console then carries the local JWT exactly like the SSH terminal, which omits the flag and takes the `true` default — same token, same query parameter, same backend code path that already accepts it.

Nothing new is exposed: this is the mechanism every other interactive channel on the embedded backend already uses, over a loopback connection.

The reporter also suggested relaxing `getRememberedElectronAuthCookie` to match across the embedded ports. That would work, but it widens an origin check that looks deliberately strict, and it would leave the console as the only channel authenticating differently from the rest. Aligning with the SSH terminal is the smaller change.

`GuacamoleDisplay` passes `includeLocalJwt: false` too, but `rdp`/`vnc`/`telnet` always resolve to `"remote"` in `resolveConnectionOrigin`, so that call never reaches the local branch. Left alone.

## Tests

`buildOriginWsUrl` had no coverage of the token behaviour at all — the contract this fix depends on. Three cases added: the local JWT is appended by default, it is omitted only when a caller explicitly asks, and a missing token leaves the URL untouched rather than producing `?token=null`.

UI suite: 67 files, 443 passing. `tsc --noEmit`, `npm run lint` (0 errors) and prettier clean.