### PR TITLE
fix: use getClientIp in getRequestMeta for correct audit-log IPs

### DIFF
--- a/src/backend/hosts/terminal/index.ts
+++ b/src/backend/hosts/terminal/index.ts
@@ -45,6 +45,7 @@ import {
 import { isWindowsSftpPath, sftpPathToLocalPath } from "../transfer-paths.js";
 import { preparePrivateKeyForSSH2 } from "../../utils/ssh-key-utils.js";
 import { triggerLoginAlert } from "../../utils/alert-trigger.js";
+import { getClientIp } from "../../utils/request-origin.js";
 import { isRetriableDnsError, resolveHostForSshConnect } from "../ssh-dns.js";
 
 interface ConnectToHostData {
@@ -326,7 +327,7 @@ wss.on("connection", async (ws: WebSocket, req) => {
       error,
       {
         operation: "websocket_connection_auth_error",
-        ip: req.socket.remoteAddress,
+        ip: getClientIp(req),
       },
     );
     ws.close(1008, "Authentication required");
@@ -2184,7 +2185,7 @@ wss.on("connection", async (ws: WebSocket, req) => {
               id,
               hostConfig.userId,
               username,
-              req.socket.remoteAddress ?? "unknown",
+              getClientIp(req),
             ).catch(() => {});
           }
 

--- a/src/backend/tests/utils/audit-logger.test.ts
+++ b/src/backend/tests/utils/audit-logger.test.ts
@@ -68,6 +68,7 @@ describe("getRequestMeta", () => {
         "user-agent": "TestAgent/1.0",
       },
       ip: "127.0.0.1",
+      socket: {},
     };
     const meta = getRequestMeta(req as never);
     expect(meta.ipAddress).toBe("10.0.0.1");
@@ -78,8 +79,39 @@ describe("getRequestMeta", () => {
     const req = {
       headers: { "user-agent": "Bot/2" },
       ip: "192.168.1.1",
+      socket: {},
     };
     const meta = getRequestMeta(req as never);
     expect(meta.ipAddress).toBe("192.168.1.1");
+  });
+
+  it("splits and trims a forwarded header sent as an array", () => {
+    const req = {
+      headers: {
+        "x-forwarded-for": ["10.0.0.1, 10.0.0.2"],
+        "user-agent": "TestAgent/1.0",
+      },
+      socket: {},
+    };
+    const meta = getRequestMeta(req as never);
+    expect(meta.ipAddress).toBe("10.0.0.1");
+  });
+
+  it("falls back to the socket peer when there is no forwarded header or req.ip", () => {
+    const req = {
+      headers: {},
+      socket: { remoteAddress: "203.0.113.9" },
+    };
+    const meta = getRequestMeta(req as never);
+    expect(meta.ipAddress).toBe("203.0.113.9");
+  });
+
+  it("returns 'unknown' rather than an empty string when no IP info exists", () => {
+    const req = {
+      headers: {},
+      socket: {},
+    };
+    const meta = getRequestMeta(req as never);
+    expect(meta.ipAddress).toBe("unknown");
   });
 });

--- a/src/backend/tests/utils/request-origin.test.ts
+++ b/src/backend/tests/utils/request-origin.test.ts
@@ -1,5 +1,6 @@
 import { afterEach, describe, expect, it } from "vitest";
 import {
+  getClientIp,
   getRequestBasePath,
   getRequestBaseUrl,
   getRequestBaseUrlWithForceHTTPS,
@@ -12,6 +13,18 @@ function request(headers: Record<string, string | string[] | undefined>) {
     headers,
     socket: {},
   } as Parameters<typeof getRequestBasePath>[0];
+}
+
+function requestWithSocket(
+  headers: Record<string, string | string[] | undefined>,
+  socket: { remoteAddress?: string },
+  ip?: string,
+) {
+  return {
+    headers,
+    socket,
+    ip,
+  } as unknown as Parameters<typeof getClientIp>[0];
 }
 
 function restoreEnv(name: string, value: string | undefined) {
@@ -105,6 +118,52 @@ describe("getRequestBasePath", () => {
         }),
       ),
     ).toBe("https://example.com/termix");
+  });
+});
+
+describe("getClientIp", () => {
+  it("prefers the leftmost X-Forwarded-For entry over the socket peer", () => {
+    expect(
+      getClientIp(
+        requestWithSocket(
+          { "x-forwarded-for": "203.0.113.7, 10.0.0.1, 10.0.0.2" },
+          { remoteAddress: "::ffff:127.0.0.1" },
+        ),
+      ),
+    ).toBe("203.0.113.7");
+  });
+
+  it("handles X-Forwarded-For sent as a header array", () => {
+    expect(
+      getClientIp(
+        requestWithSocket(
+          { "x-forwarded-for": ["203.0.113.7", "10.0.0.1"] },
+          { remoteAddress: "::ffff:127.0.0.1" },
+        ),
+      ),
+    ).toBe("203.0.113.7");
+  });
+
+  it("falls back to req.ip when there is no forwarded header", () => {
+    expect(
+      getClientIp(
+        requestWithSocket(
+          {},
+          { remoteAddress: "::ffff:127.0.0.1" },
+          "198.51.100.5",
+        ),
+      ),
+    ).toBe("198.51.100.5");
+  });
+
+  it("falls back to the raw socket peer when nothing else is available", () => {
+    expect(
+      getClientIp(requestWithSocket({}, { remoteAddress: "198.51.100.9" })),
+    ).toBe("198.51.100.9");
+  });
+
+  it("returns unknown when no IP information exists at all", () => {
+    expect(getClientIp(requestWithSocket({}, {}))).toBe("unknown");
   });
 });
 

--- a/src/backend/utils/audit-logger.ts
+++ b/src/backend/utils/audit-logger.ts
@@ -4,6 +4,7 @@ import {
   createCurrentAuditLogRepository,
   createCurrentUserRepository,
 } from "../database/repositories/factory.js";
+import { getClientIp } from "./request-origin.js";
 
 /**
  * Resolves the display name to store alongside the entry. It is denormalised on
@@ -60,11 +61,6 @@ export function getRequestMeta(req: Request): {
   ipAddress: string;
   userAgent: string;
 } {
-  const forwarded = req.headers["x-forwarded-for"];
-  const ipAddress =
-    (Array.isArray(forwarded) ? forwarded[0] : forwarded?.split(",")[0]) ||
-    req.ip ||
-    "";
   const userAgent = (req.headers["user-agent"] as string) || "";
-  return { ipAddress, userAgent };
+  return { ipAddress: getClientIp(req), userAgent };
 }

--- a/src/backend/utils/request-origin.ts
+++ b/src/backend/utils/request-origin.ts
@@ -64,6 +64,20 @@ export function normalizeBasePath(value: unknown): string {
   return basePath.replace(/\/+$/, "");
 }
 
+/**
+ * Real client IP behind a reverse proxy. `X-Forwarded-For`'s leftmost entry is
+ * the original client; socket.remoteAddress is only the immediate peer, which
+ * behind Traefik/Cloudflare is the proxy itself (often a loopback address).
+ */
+export function getClientIp(req: Request | IncomingMessage): string {
+  const forwarded = firstHeaderValue(req.headers["x-forwarded-for"]);
+  if (forwarded) return forwarded;
+
+  if ("ip" in req && req.ip) return req.ip;
+
+  return req.socket?.remoteAddress ?? "unknown";
+}
+
 export function getRequestOrigin(req: Request | IncomingMessage): string {
   let protocol: string;
   const protoHeader = req.headers["x-forwarded-proto"];


### PR DESCRIPTION
## Summary
Follow-up to #1169, per review comment: `getRequestMeta` in `src/backend/utils/audit-logger.ts` had near-identical forwarded-header logic to `getClientIp` but strictly worse — its array branch didn't split/trim, it never fell back to the socket peer, and it returned `""` instead of `"unknown"`. Now delegates to `getClientIp` so the audit trail gets the same correctness as the terminal login-alert path.

Note: this branch was cut from `worktree-snazzy-hugging-parrot` (source branch of #1169) before that branch was deleted on merge, so this diff still carries the `getClientIp` commits in its history. If `main` already has them by the time this is reviewed, that history should collapse cleanly; otherwise this PR is self-contained.

## Test plan
- [x] `npx vitest run src/backend/tests/utils/audit-logger.test.ts src/backend/tests/utils/request-origin.test.ts` — 24 passed
- [x] `npx tsc --noEmit`