### PR TITLE
Keep the tmux escaping test runnable on Windows

### DIFF
--- a/src/backend/tests/hosts/tmux/helper.test.ts
+++ b/src/backend/tests/hosts/tmux/helper.test.ts
@@ -16,12 +16,27 @@ describe("tmux command path handling", () => {
   });
 
   it("shell-escapes embedded single quotes in wrapped commands", () => {
-    const command = withTmuxPath(`printf '%s' "can't"`);
-
-    expect(execFileSync("/bin/sh", ["-c", command], { encoding: "utf8" })).toBe(
-      "can't",
+    // Asserted as a string so the escaping rule is covered everywhere. The
+    // round-trip below proves it against a real parser, but only where one
+    // exists -- see the note there.
+    expect(withTmuxPath(`printf '%s' "can't"`)).toBe(
+      "/bin/sh -c 'PATH=/opt/homebrew/bin:/usr/local/bin:/opt/bin:/usr/pkg/bin:\"$PATH\"; export PATH; printf '\\''%s'\\'' \"can'\\''t\"'",
     );
   });
+
+  // /bin/sh is not on Windows, and Windows is a supported platform for the
+  // desktop app -- contributors run `npm test` there. CI is ubuntu-only, so it
+  // would never notice this failing.
+  it.skipIf(process.platform === "win32")(
+    "produces a command a real shell parses back to the original",
+    () => {
+      const command = withTmuxPath(`printf '%s' "can't"`);
+
+      expect(
+        execFileSync("/bin/sh", ["-c", command], { encoding: "utf8" }),
+      ).toBe("can't");
+    },
+  );
 
   it("runs every tmux invocation in UTF-8 mode through the path wrapper", () => {
     expect(tmuxCommand("list-sessions")).toBe(


### PR DESCRIPTION
Follow-up to #1157, which landed with a test that cannot run on Windows.

`helper.test.ts` verifies single-quote escaping by executing the wrapped command:

```js
expect(execFileSync("/bin/sh", ["-c", command], { encoding: "utf8" })).toBe("can't");
```

`/bin/sh` does not exist there, so `npm test` fails on a test about string quoting. Windows is a supported platform for the desktop app — there are `build:win-portable` and `build:win-installer` scripts, and contributors do run the suite locally. CI is ubuntu-only, so it will never report this.

## The change

Split the case in two rather than dropping either kind of evidence:

- **the escaping rule is asserted as a string**, which runs everywhere;
- **the round trip through a real shell stays**, as its own case guarded by `it.skipIf(process.platform === "win32")` — it is the stronger check, since it proves the escaping against an actual parser rather than against my reading of it, and it still runs on every platform that has a shell.

Dropping the round trip entirely would have been smaller, but it is the case that would catch an escaping bug a hand-written expectation happens to share.

I raised this on #1157 before it merged; it went in as-is, so here it is separately rather than left for someone to trip over.

Backend suite passes; on this machine all five cases run, and the guarded one is skipped where there is no `/bin/sh`. `tsc -p tsconfig.node.json` and prettier are clean.