### PR TITLE
Restore the prettier baseline on dev-2.7.0

### DIFF
--- a/src/backend/hosts/metrics/index.ts
+++ b/src/backend/hosts/metrics/index.ts
@@ -1522,8 +1522,9 @@ async function collectMetrics(host: SSHHostWithCredentials): Promise<{
     const existingSession = metricsSessions[sessionKey];
 
     try {
-      const excludedMounts =
-        pollingManager.parseStatsConfig(host.statsConfig).excludedMounts;
+      const excludedMounts = pollingManager.parseStatsConfig(
+        host.statsConfig,
+      ).excludedMounts;
 
       const collectFn = async (client: Client) => {
         const cpu = await collectCpuMetrics(client);

--- a/src/backend/hosts/metrics/widgets/disk-collector.ts
+++ b/src/backend/hosts/metrics/widgets/disk-collector.ts
@@ -41,9 +41,7 @@ export function parseDfLines(output: string): DfRow[] {
         parts,
       };
     })
-    .filter(
-      (row) => row.parts.length >= 7 && !PSEUDO_FS_RE.test(row.type),
-    );
+    .filter((row) => row.parts.length >= 7 && !PSEUDO_FS_RE.test(row.type));
 }
 
 // Finds the index of the most-utilized real filesystem in a `df -T -B1`-style

--- a/src/backend/tests/utils/safe-outbound-fetch.test.ts
+++ b/src/backend/tests/utils/safe-outbound-fetch.test.ts
@@ -62,11 +62,7 @@ function runHook(
         family?: number,
       ) => void,
     ) => {
-      cb(
-        error,
-        addresses,
-        typeof addresses === "string" ? 4 : undefined,
-      );
+      cb(error, addresses, typeof addresses === "string" ? 4 : undefined);
     },
   );
 
@@ -76,24 +72,12 @@ function runHook(
   hook("example.invalid", lookupOptions, callback);
 
   return { callback, fakeLookup };
-};
+}
 
 const lookupOptionsCases: Array<[string, LookupOptions, unknown[]]> = [
-  [
-    "all:true",
-    { all: true },
-    ["", 0],
-  ],
-  [
-    "all:false",
-    { all: false },
-    ["", 0],
-  ],
-  [
-    "all omitted",
-    {},
-    ["", 0],
-  ],
+  ["all:true", { all: true }, ["", 0]],
+  ["all:false", { all: false }, ["", 0]],
+  ["all omitted", {}, ["", 0]],
 ];
 
 const publicAddresses: LookupAddress[] = [
@@ -155,53 +139,25 @@ describe("createDnsLookupHook", () => {
   );
 
   it("returns a single lookup result when all is false", () => {
-    const { callback } = runHook(
-      "104.21.52.150",
-      null,
-      { all: false },
-    );
+    const { callback } = runHook("104.21.52.150", null, { all: false });
 
-    expect(callback).toHaveBeenCalledWith(
-      null,
-      "104.21.52.150",
-      4,
-    );
+    expect(callback).toHaveBeenCalledWith(null, "104.21.52.150", 4);
   });
 
   it("returns a single lookup result when all is omitted", () => {
-    const { callback } = runHook(
-      "104.21.52.150",
-      null,
-      {},
-    );
+    const { callback } = runHook("104.21.52.150", null, {});
 
-    expect(callback).toHaveBeenCalledWith(
-      null,
-      "104.21.52.150",
-      4,
-    );
+    expect(callback).toHaveBeenCalledWith(null, "104.21.52.150", 4);
   });
 
   it("returns all lookup results when all is true", () => {
-    const { callback } = runHook(
-      publicAddresses,
-      null,
-      { all: true },
-    );
+    const { callback } = runHook(publicAddresses, null, { all: true });
 
-    expect(callback).toHaveBeenCalledWith(
-      null,
-      publicAddresses,
-      0,
-    );
+    expect(callback).toHaveBeenCalledWith(null, publicAddresses, 0);
   });
 
   it("rejects invalid single lookup results with a DNS lookup error", () => {
-    const { callback } = runHook(
-      undefined,
-      null,
-      { all: false },
-    );
+    const { callback } = runHook(undefined, null, { all: false });
 
     expect(callback).toHaveBeenCalledWith(
       expect.objectContaining({
@@ -225,18 +181,13 @@ describe("createDnsLookupHook", () => {
   });
 
   it("propagates a real DNS lookup error untouched", () => {
-    const dnsError = Object.assign(
-      new Error("getaddrinfo ENOTFOUND"),
-      { code: "ENOTFOUND" },
-    );
+    const dnsError = Object.assign(new Error("getaddrinfo ENOTFOUND"), {
+      code: "ENOTFOUND",
+    });
 
     const { callback } = runHook([], dnsError);
 
-    expect(callback).toHaveBeenCalledWith(
-      dnsError,
-      "",
-      0,
-    );
+    expect(callback).toHaveBeenCalledWith(dnsError, "", 0);
   });
 
   it("always asks the underlying resolver for all:true regardless of the caller's option", () => {

--- a/src/ui/sidebar/HostEditorStatsTab.tsx
+++ b/src/ui/sidebar/HostEditorStatsTab.tsx
@@ -201,21 +201,16 @@ export function HostStatsTab({
               key={`${mount}-${i}`}
               className="flex items-center gap-2 p-2 bg-muted/20 border border-border group"
             >
-              <span className="text-xs flex-1 font-mono truncate">
-                {mount}
-              </span>
+              <span className="text-xs flex-1 font-mono truncate">{mount}</span>
               <button
                 className="text-muted-foreground hover:text-destructive opacity-0 group-hover:opacity-100 transition-opacity"
                 onClick={() =>
-                  setField(
-                    "statsConfig",
-                    {
-                      ...form.statsConfig,
-                      excludedMounts: excludedMounts.filter(
-                        (_, idx) => idx !== i,
-                      ),
-                    },
-                  )
+                  setField("statsConfig", {
+                    ...form.statsConfig,
+                    excludedMounts: excludedMounts.filter(
+                      (_, idx) => idx !== i,
+                    ),
+                  })
                 }
               >
                 <Trash2 className="size-3.5" />

--- a/src/ui/tests/api/system-status-api.test.ts
+++ b/src/ui/tests/api/system-status-api.test.ts
@@ -25,9 +25,9 @@ describe("releaseUrlFrom", () => {
   it("returns an empty string when the response carries no release", () => {
     // The badge treats "" as "nothing to link to" and stays an inert span, so
     // a version response without a release must not produce a dead anchor.
-    expect(releaseUrlFrom({ status: "up_to_date", localVersion: "2.6.1" })).toBe(
-      "",
-    );
+    expect(
+      releaseUrlFrom({ status: "up_to_date", localVersion: "2.6.1" }),
+    ).toBe("");
   });
 
   it("returns an empty string when the release carries no URL", () => {


### PR DESCRIPTION
`dev-2.7.0` currently fails its own formatting check, so `lint-and-build` is red on **every** pull request regardless of what it changes.

Reproducible on a clean checkout of the branch:

```
$ git checkout upstream/dev-2.7.0 && npx prettier --check .
[warn] src/backend/hosts/metrics/index.ts
[warn] src/backend/hosts/metrics/widgets/disk-collector.ts
[warn] src/backend/tests/utils/safe-outbound-fetch.test.ts
[warn] src/ui/sidebar/HostEditorStatsTab.tsx
[warn] src/ui/tests/api/system-status-api.test.ts
```

I hit it on #1184, which touches one unrelated test file and failed on these five.

## The change

`npx prettier --write` on exactly those five files, nothing else. Line wrapping and trailing commas; `git diff -w` shows only re-wrapped expressions.

Verified it is inert rather than assuming it:

- `tsc -p tsconfig.node.json --noEmit` and `tsc --noEmit` both clean
- backend 148 files / 1106 tests, UI 71 files / 479 tests — all passing
- `npm run lint` 0 errors
- `npx prettier --check .` now clean across the repo

## Why it happened, and the thing that would stop it recurring

These came in with yesterday's merges. Two of the five — `safe-outbound-fetch.test.ts` (#1158) and `system-status-api.test.ts` (#1167) — are files where I had asked the contributor to run prettier; the branches went in before those runs were green.

#1174 wired up the `prepare` script so husky installs the hooks, which means `lint-staged` now formats staged files on commit. That only helps contributors who have reinstalled dependencies since, so a gap like this can still open until everyone has. Worth keeping in mind when merging ahead of a green check.

Recommend landing this first — it unblocks every other open PR.