### PR TITLE
feat: add drive file browser and drag-and-drop upload for RDP

### DIFF
--- a/src/types/guacamole-common-js.d.ts
+++ b/src/types/guacamole-common-js.d.ts
@@ -17,6 +17,22 @@ declare module "guacamole-common-js" {
       onfile:
         | ((stream: InputStream, mimetype: string, filename: string) => void)
         | null;
+      onfilesystem: ((filesystem: Object, name: string) => void) | null;
+    }
+
+    // Mirrors Guacamole.Object: a named collection of streams. Within this
+    // namespace `Object` refers to this class, not the global one.
+    class Object {
+      static readonly ROOT_STREAM: string;
+      static readonly STREAM_INDEX_MIMETYPE: string;
+      readonly index: number;
+      requestInputStream(
+        name: string,
+        bodyCallback?: (stream: InputStream, mimetype: string) => void,
+      ): void;
+      createOutputStream(mimetype: string, name: string): OutputStream;
+      onbody: ((stream: InputStream, mimetype: string) => void) | null;
+      onundefine: (() => void) | null;
     }
 
     class AudioPlayer {
@@ -191,6 +207,16 @@ declare module "guacamole-common-js" {
       getLength(): number;
       onprogress: ((length: number) => void) | null;
       onend: (() => void) | null;
+    }
+
+    class BlobWriter {
+      constructor(stream: OutputStream);
+      sendBlob(blob: Blob): void;
+      sendEnd(): void;
+      onack: ((status: Status) => void) | null;
+      onerror: ((blob: Blob, offset: number, error: Status) => void) | null;
+      onprogress: ((blob: Blob, offset: number) => void) | null;
+      oncomplete: ((blob: Blob) => void) | null;
     }
   }
 

--- a/src/ui/features/guacamole/GuacamoleApp.tsx
+++ b/src/ui/features/guacamole/GuacamoleApp.tsx
@@ -5,6 +5,7 @@ import React, {
   useCallback,
   useImperativeHandle,
 } from "react";
+import type Guacamole from "guacamole-common-js";
 import {
   GuacamoleDisplay,
   type GuacamoleDisplayHandle,
@@ -23,6 +24,7 @@ import { resolveConnectionOrigin } from "@/lib/connection-origin.ts";
 import { useTranslation } from "react-i18next";
 import { AlertCircle, RefreshCw } from "lucide-react";
 import { GuacamoleToolbar } from "@/features/guacamole/GuacamoleToolbar.tsx";
+import { GuacamoleFileBrowser } from "@/features/guacamole/GuacamoleFileBrowser.tsx";
 import { Button } from "@/components/button.tsx";
 import { Input } from "@/components/input.tsx";
 import { PasswordInput } from "@/components/password-input.tsx";
@@ -148,6 +150,20 @@ const GuacamoleAppInner = React.forwardRef<
       : null,
   );
   const displayRef = useRef<GuacamoleDisplayHandle>(null);
+  const [filesystem, setFilesystem] = useState<Guacamole.Object | null>(null);
+  const [fileBrowserOpen, setFileBrowserOpen] = useState(false);
+  const [pendingUploads, setPendingUploads] = useState<File[]>([]);
+
+  const guacConfig = parseGuacamoleConfig(hostConfig.guacamoleConfig);
+  const allowUpload = guacConfig.disableUpload !== true;
+  const allowDownload = guacConfig.disableDownload !== true;
+
+  // A dropped file has nowhere to go until the browser is showing the target
+  // directory, so opening it is part of accepting the drop.
+  const handleDropFiles = useCallback((files: File[]) => {
+    setPendingUploads(files);
+    setFileBrowserOpen(true);
+  }, []);
 
   const resolvedProtocolForConnect = (protocol ??
     hostConfig.connectionType ??
@@ -364,7 +380,6 @@ const GuacamoleAppInner = React.forwardRef<
   }
 
   const resolvedProtocol = resolvedProtocolForConnect;
-  const guacConfig = parseGuacamoleConfig(hostConfig.guacamoleConfig);
   const configuredDpi = readConfiguredDimension(guacConfig.dpi);
   const configuredWidth = readConfiguredDimension(guacConfig.width);
   const configuredHeight = readConfiguredDimension(guacConfig.height);
@@ -411,12 +426,28 @@ const GuacamoleAppInner = React.forwardRef<
         }}
         isVisible={isVisible}
         touchMode={touchMode}
+        allowUpload={allowUpload && filesystem !== null}
         onError={(err) => setConnectionError(err)}
+        onFilesystem={setFilesystem}
+        onDropFiles={handleDropFiles}
       />
+      {filesystem && fileBrowserOpen && (
+        <GuacamoleFileBrowser
+          filesystem={filesystem}
+          allowUpload={allowUpload}
+          allowDownload={allowDownload}
+          pendingUploads={pendingUploads}
+          onPendingUploadsHandled={() => setPendingUploads([])}
+          onClose={() => setFileBrowserOpen(false)}
+        />
+      )}
       <GuacamoleToolbar
         displayRef={displayRef}
         protocol={resolvedProtocol}
         touchMode={touchMode}
+        hasFilesystem={filesystem !== null}
+        fileBrowserOpen={fileBrowserOpen}
+        onToggleFileBrowser={() => setFileBrowserOpen((open) => !open)}
         onTouchModeChange={setTouchMode}
       />
       {shareModalOpen && guacamoleConnectionId && (

--- a/src/ui/features/guacamole/GuacamoleDisplay.tsx
+++ b/src/ui/features/guacamole/GuacamoleDisplay.tsx
@@ -1,3 +1,4 @@
+import type React from "react";
 import {
   useEffect,
   useRef,
@@ -7,6 +8,7 @@ import {
   useCallback,
 } from "react";
 import Guacamole from "guacamole-common-js";
+import { Upload } from "lucide-react";
 import { useTranslation } from "react-i18next";
 import { getGuacamoleToken, isElectron } from "@/main-axios.ts";
 import { SimpleLoader } from "@/lib/SimpleLoader.tsx";
@@ -46,6 +48,7 @@ export interface GuacamoleDisplayHandle {
   sendKey: (keysym: number, pressed: boolean) => void;
   sendMouse: (x: number, y: number, buttonMask: number) => void;
   setClipboard: (data: string) => void;
+  getFilesystem: () => Guacamole.Object | null;
 }
 
 export type GuacamoleTouchMode = "touchscreen" | "touchpad";
@@ -54,9 +57,12 @@ interface GuacamoleDisplayProps {
   connectionConfig: GuacamoleConnectionConfig;
   isVisible: boolean;
   touchMode?: GuacamoleTouchMode | null;
+  allowUpload?: boolean;
   onConnect?: () => void;
   onDisconnect?: () => void;
   onError?: (error: string) => void;
+  onFilesystem?: (filesystem: Guacamole.Object | null) => void;
+  onDropFiles?: (files: File[]) => void;
 }
 
 const isDev = import.meta.env.DEV;
@@ -65,7 +71,17 @@ export const GuacamoleDisplay = forwardRef<
   GuacamoleDisplayHandle,
   GuacamoleDisplayProps
 >(function GuacamoleDisplay(
-  { connectionConfig, isVisible, touchMode, onConnect, onDisconnect, onError },
+  {
+    connectionConfig,
+    isVisible,
+    touchMode,
+    allowUpload = false,
+    onConnect,
+    onDisconnect,
+    onError,
+    onFilesystem,
+    onDropFiles,
+  },
   ref,
 ) {
   const { t } = useTranslation();
@@ -77,6 +93,11 @@ export const GuacamoleDisplay = forwardRef<
   const displayRef = useRef<HTMLDivElement>(null);
   const displayElementRef = useRef<HTMLElement | null>(null);
   const clientRef = useRef<Guacamole.Client | null>(null);
+  const filesystemRef = useRef<Guacamole.Object | null>(null);
+  // Held in a ref so tearing down the client can report the loss without
+  // rebuilding the connect callback whenever the parent re-renders.
+  const onFilesystemRef = useRef(onFilesystem);
+  onFilesystemRef.current = onFilesystem;
   const keyboardRef = useRef<Guacamole.Keyboard | null>(null);
   const scaleRef = useRef<number>(1);
   const resizeTimeoutRef = useRef<NodeJS.Timeout | null>(null);
@@ -94,6 +115,10 @@ export const GuacamoleDisplay = forwardRef<
     const client = clientRef.current;
     clientRef.current = null;
     isConnectingRef.current = false;
+    if (filesystemRef.current) {
+      filesystemRef.current = null;
+      onFilesystemRef.current?.(null);
+    }
     if (!client) return;
 
     try {
@@ -132,6 +157,7 @@ export const GuacamoleDisplay = forwardRef<
         writer.sendEnd();
       }
     },
+    getFilesystem: () => filesystemRef.current,
   }));
 
   const getWebSocketConnection = useCallback(
@@ -555,6 +581,20 @@ export const GuacamoleDisplay = forwardRef<
       Guacamole.AudioPlayer.getInstance(stream, mimetype);
     };
 
+    // Only fires when the connection enables drive redirection; guacd exposes
+    // the redirected drive as a single filesystem object.
+    client.onfilesystem = (filesystem: Guacamole.Object) => {
+      if (!isMountedRef.current || clientRef.current !== client) return;
+      filesystemRef.current = filesystem;
+      onFilesystemRef.current?.(filesystem);
+
+      filesystem.onundefine = () => {
+        if (filesystemRef.current !== filesystem) return;
+        filesystemRef.current = null;
+        onFilesystemRef.current?.(null);
+      };
+    };
+
     client.onfile = (
       stream: Guacamole.InputStream,
       mimetype: string,
@@ -747,6 +787,40 @@ export const GuacamoleDisplay = forwardRef<
     };
   }, [isReady, syncClipboard]);
 
+  const canDropFiles = allowUpload && onDropFiles != null;
+  const [isDraggingFiles, setIsDraggingFiles] = useState(false);
+  // Nested elements fire dragleave as the pointer crosses them, so track depth
+  // rather than clearing the highlight on the first leave.
+  const dragDepthRef = useRef(0);
+
+  const handleDragEnter = useCallback(
+    (event: React.DragEvent) => {
+      if (!canDropFiles || !event.dataTransfer.types.includes("Files")) return;
+      event.preventDefault();
+      dragDepthRef.current += 1;
+      setIsDraggingFiles(true);
+    },
+    [canDropFiles],
+  );
+
+  const handleDragLeave = useCallback(() => {
+    dragDepthRef.current = Math.max(0, dragDepthRef.current - 1);
+    if (dragDepthRef.current === 0) setIsDraggingFiles(false);
+  }, []);
+
+  const handleDrop = useCallback(
+    (event: React.DragEvent) => {
+      if (!canDropFiles) return;
+      event.preventDefault();
+      dragDepthRef.current = 0;
+      setIsDraggingFiles(false);
+
+      const files = Array.from(event.dataTransfer.files);
+      if (files.length > 0) onDropFiles?.(files);
+    },
+    [canDropFiles, onDropFiles],
+  );
+
   const connectingMessage = t("guacamole.connecting", {
     type: (
       connectionConfig.protocol ||
@@ -760,6 +834,10 @@ export const GuacamoleDisplay = forwardRef<
       ref={containerRef}
       className="absolute inset-0 overflow-hidden"
       style={{ backgroundColor: "var(--bg-base)" }}
+      onDragEnter={handleDragEnter}
+      onDragOver={canDropFiles ? (e) => e.preventDefault() : undefined}
+      onDragLeave={canDropFiles ? handleDragLeave : undefined}
+      onDrop={handleDrop}
     >
       <div
         ref={displayRef}
@@ -769,6 +847,15 @@ export const GuacamoleDisplay = forwardRef<
           visibility: isReady ? "visible" : "hidden",
         }}
       />
+
+      {isDraggingFiles && (
+        <div className="absolute inset-0 z-30 flex items-center justify-center pointer-events-none bg-background/70 backdrop-blur-sm">
+          <div className="flex items-center gap-2 rounded-sm border-2 border-dashed border-border px-4 py-3 text-sm font-semibold">
+            <Upload className="size-4" />
+            {t("guacamole.files.dropToUpload")}
+          </div>
+        </div>
+      )}
 
       <SimpleLoader
         visible={!isReady && !hasError}

--- a/src/ui/features/guacamole/GuacamoleFileBrowser.tsx
+++ b/src/ui/features/guacamole/GuacamoleFileBrowser.tsx
@@ -1,0 +1,245 @@
+import { useCallback, useEffect, useRef, useState } from "react";
+import Guacamole from "guacamole-common-js";
+import { useTranslation } from "react-i18next";
+import {
+  ArrowUp,
+  Download,
+  File as FileIcon,
+  Folder,
+  RefreshCw,
+  Upload,
+  X,
+} from "lucide-react";
+import { toast } from "sonner";
+import { Button } from "@/components/button.tsx";
+import {
+  downloadFile,
+  listDirectory,
+  parentPath,
+  saveBlobAs,
+  uploadFile,
+  type RemoteFileEntry,
+} from "./guacamole-filesystem.ts";
+
+interface GuacamoleFileBrowserProps {
+  filesystem: Guacamole.Object;
+  allowUpload: boolean;
+  allowDownload: boolean;
+  pendingUploads: File[];
+  onPendingUploadsHandled: () => void;
+  onClose: () => void;
+}
+
+export function GuacamoleFileBrowser({
+  filesystem,
+  allowUpload,
+  allowDownload,
+  pendingUploads,
+  onPendingUploadsHandled,
+  onClose,
+}: GuacamoleFileBrowserProps) {
+  const { t } = useTranslation();
+  const [path, setPath] = useState("/");
+  const [entries, setEntries] = useState<RemoteFileEntry[]>([]);
+  const [loading, setLoading] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+  const [busyName, setBusyName] = useState<string | null>(null);
+  const fileInputRef = useRef<HTMLInputElement>(null);
+
+  const refresh = useCallback(
+    async (target: string) => {
+      setLoading(true);
+      setError(null);
+      try {
+        setEntries(await listDirectory(filesystem, target));
+      } catch (err) {
+        setEntries([]);
+        setError(
+          err instanceof Error ? err.message : t("guacamole.files.listFailed"),
+        );
+      } finally {
+        setLoading(false);
+      }
+    },
+    [filesystem, t],
+  );
+
+  useEffect(() => {
+    void refresh(path);
+  }, [refresh, path]);
+
+  const upload = useCallback(
+    async (files: File[]) => {
+      for (const file of files) {
+        setBusyName(file.name);
+        try {
+          await uploadFile(filesystem, path, file);
+          toast.success(t("guacamole.files.uploaded", { name: file.name }));
+        } catch (err) {
+          toast.error(
+            err instanceof Error
+              ? err.message
+              : t("guacamole.files.uploadFailed", { name: file.name }),
+          );
+        } finally {
+          setBusyName(null);
+        }
+      }
+      void refresh(path);
+    },
+    [filesystem, path, refresh, t],
+  );
+
+  // Files dropped on the display land here so they share the browser's current
+  // directory rather than always going to the drive root.
+  useEffect(() => {
+    if (pendingUploads.length === 0) return;
+    onPendingUploadsHandled();
+    if (!allowUpload) {
+      toast.error(t("guacamole.files.uploadDisabled"));
+      return;
+    }
+    void upload(pendingUploads);
+  }, [pendingUploads, onPendingUploadsHandled, allowUpload, upload, t]);
+
+  const download = useCallback(
+    async (entry: RemoteFileEntry) => {
+      setBusyName(entry.name);
+      try {
+        const { blob, filename } = await downloadFile(filesystem, entry.path);
+        saveBlobAs(blob, filename);
+      } catch (err) {
+        toast.error(
+          err instanceof Error
+            ? err.message
+            : t("guacamole.files.downloadFailed", { name: entry.name }),
+        );
+      } finally {
+        setBusyName(null);
+      }
+    },
+    [filesystem, t],
+  );
+
+  return (
+    <div className="absolute right-2 top-2 bottom-2 z-30 flex w-80 flex-col rounded-sm border border-border bg-background/95 shadow-lg backdrop-blur-sm">
+      <div className="flex items-center gap-1 border-b border-border px-2 py-1.5">
+        <span className="flex-1 truncate text-xs font-semibold">
+          {t("guacamole.files.title")}
+        </span>
+        <Button
+          variant="ghost"
+          size="icon"
+          className="size-6"
+          onClick={onClose}
+          aria-label={t("common.close")}
+        >
+          <X className="size-3.5" />
+        </Button>
+      </div>
+
+      <div className="flex items-center gap-1 border-b border-border px-2 py-1.5">
+        <Button
+          variant="ghost"
+          size="icon"
+          className="size-6"
+          disabled={path === "/"}
+          onClick={() => setPath(parentPath(path))}
+          aria-label={t("guacamole.files.parent")}
+        >
+          <ArrowUp className="size-3.5" />
+        </Button>
+        <span className="flex-1 truncate text-[11px] text-muted-foreground">
+          {path}
+        </span>
+        <Button
+          variant="ghost"
+          size="icon"
+          className="size-6"
+          onClick={() => void refresh(path)}
+          aria-label={t("guacamole.files.refresh")}
+        >
+          <RefreshCw className="size-3.5" />
+        </Button>
+      </div>
+
+      <div className="flex-1 overflow-y-auto">
+        {loading && (
+          <p className="px-2 py-3 text-[11px] text-muted-foreground">
+            {t("common.loading")}
+          </p>
+        )}
+        {!loading && error && (
+          <p className="px-2 py-3 text-[11px] text-red-500">{error}</p>
+        )}
+        {!loading && !error && entries.length === 0 && (
+          <p className="px-2 py-3 text-[11px] text-muted-foreground">
+            {t("guacamole.files.empty")}
+          </p>
+        )}
+        {!loading &&
+          !error &&
+          entries.map((entry) => (
+            <div
+              key={entry.path}
+              className="flex items-center gap-1.5 px-2 py-1 hover:bg-muted"
+            >
+              {entry.isDirectory ? (
+                <Folder className="size-3.5 shrink-0 text-muted-foreground" />
+              ) : (
+                <FileIcon className="size-3.5 shrink-0 text-muted-foreground" />
+              )}
+              <button
+                type="button"
+                className="flex-1 truncate text-left text-[11px] disabled:opacity-60"
+                disabled={!entry.isDirectory}
+                onClick={() => entry.isDirectory && setPath(entry.path)}
+              >
+                {entry.name}
+              </button>
+              {!entry.isDirectory && allowDownload && (
+                <Button
+                  variant="ghost"
+                  size="icon"
+                  className="size-5 shrink-0"
+                  disabled={busyName === entry.name}
+                  onClick={() => void download(entry)}
+                  aria-label={t("guacamole.files.download")}
+                >
+                  <Download className="size-3" />
+                </Button>
+              )}
+            </div>
+          ))}
+      </div>
+
+      {allowUpload && (
+        <div className="border-t border-border px-2 py-1.5">
+          <input
+            ref={fileInputRef}
+            type="file"
+            multiple
+            className="hidden"
+            onChange={(e) => {
+              const files = Array.from(e.target.files ?? []);
+              e.target.value = "";
+              if (files.length > 0) void upload(files);
+            }}
+          />
+          <Button
+            variant="outline"
+            size="sm"
+            className="h-7 w-full text-[11px]"
+            disabled={busyName !== null}
+            onClick={() => fileInputRef.current?.click()}
+          >
+            <Upload className="mr-1 size-3" />
+            {busyName !== null
+              ? t("guacamole.files.uploading", { name: busyName })
+              : t("guacamole.files.upload")}
+          </Button>
+        </div>
+      )}
+    </div>
+  );
+}

--- a/src/ui/features/guacamole/GuacamoleToolbar.tsx
+++ b/src/ui/features/guacamole/GuacamoleToolbar.tsx
@@ -13,6 +13,7 @@ import {
   ChevronUp,
   ChevronDown,
   ChevronsLeftRight,
+  FolderOpen,
   Touchpad,
   MousePointer,
 } from "lucide-react";
@@ -33,6 +34,9 @@ interface GuacamoleToolbarProps {
   displayRef: React.RefObject<GuacamoleDisplayHandle>;
   protocol: "rdp" | "vnc" | "telnet";
   touchMode?: GuacamoleTouchMode | null;
+  hasFilesystem?: boolean;
+  fileBrowserOpen?: boolean;
+  onToggleFileBrowser?: () => void;
   onTouchModeChange?: (mode: GuacamoleTouchMode) => void;
 }
 
@@ -115,6 +119,9 @@ export const GuacamoleToolbar: React.FC<GuacamoleToolbarProps> = ({
   displayRef,
   protocol,
   touchMode,
+  hasFilesystem = false,
+  fileBrowserOpen = false,
+  onToggleFileBrowser,
   onTouchModeChange,
 }) => {
   const { t } = useTranslation();
@@ -326,6 +333,20 @@ export const GuacamoleToolbar: React.FC<GuacamoleToolbarProps> = ({
                       : t("guacamole.toolbar.switchToTouch")}
                   </TooltipContent>
                 </Tooltip>
+              </>
+            )}
+
+            {/* Drive files — only once guacd reports a redirected filesystem */}
+            {hasFilesystem && onToggleFileBrowser && (
+              <>
+                <div className={SEP} />
+                <TipIconBtn
+                  tooltip={t("guacamole.files.title")}
+                  onClick={onToggleFileBrowser}
+                  className={cn(fileBrowserOpen && "bg-muted text-foreground")}
+                >
+                  <FolderOpen className="size-3.5" />
+                </TipIconBtn>
               </>
             )}
 

--- a/src/ui/features/guacamole/guacamole-filesystem.ts
+++ b/src/ui/features/guacamole/guacamole-filesystem.ts
@@ -1,0 +1,165 @@
+import Guacamole from "guacamole-common-js";
+
+// The root stream of a Guacamole.Object maps stream name to mimetype; a stream
+// carrying that same mimetype is itself a directory.
+export const STREAM_INDEX_MIMETYPE =
+  "application/vnd.glyptodon.guacamole.stream-index+json";
+
+export interface RemoteFileEntry {
+  name: string;
+  path: string;
+  mimetype: string;
+  isDirectory: boolean;
+}
+
+export function isDirectoryMimetype(mimetype: string): boolean {
+  return mimetype === STREAM_INDEX_MIMETYPE;
+}
+
+export function joinPath(parent: string, name: string): string {
+  return parent === "/" ? `/${name}` : `${parent}/${name}`;
+}
+
+export function parentPath(path: string): string {
+  const cut = path.lastIndexOf("/");
+  return cut <= 0 ? "/" : path.slice(0, cut);
+}
+
+export function basename(path: string): string {
+  return path.slice(path.lastIndexOf("/") + 1) || path;
+}
+
+// guacd returns absolute paths as keys, but a malformed or relative key would
+// otherwise produce a broken path on the next descent.
+export function parseDirectoryIndex(
+  json: string,
+  path: string,
+): RemoteFileEntry[] {
+  const index = JSON.parse(json) as Record<string, string>;
+
+  return Object.entries(index)
+    .map(([key, mimetype]) => {
+      const name = basename(key);
+      return {
+        name,
+        path: key.startsWith("/") ? key : joinPath(path, name),
+        mimetype,
+        isDirectory: isDirectoryMimetype(mimetype),
+      };
+    })
+    .sort((a, b) =>
+      a.isDirectory === b.isDirectory
+        ? a.name.localeCompare(b.name)
+        : a.isDirectory
+          ? -1
+          : 1,
+    );
+}
+
+// A refused stream is answered with an error ack that never reaches the body
+// callback, so every request needs its own deadline to avoid hanging forever.
+const REQUEST_TIMEOUT_MS = 15000;
+
+function requestStream(
+  filesystem: Guacamole.Object,
+  path: string,
+): Promise<{ stream: Guacamole.InputStream; mimetype: string }> {
+  return new Promise((resolve, reject) => {
+    const timeout = setTimeout(
+      () => reject(new Error(`Timed out reading ${path}`)),
+      REQUEST_TIMEOUT_MS,
+    );
+
+    filesystem.requestInputStream(path, (stream, mimetype) => {
+      clearTimeout(timeout);
+      resolve({ stream, mimetype });
+    });
+  });
+}
+
+export async function listDirectory(
+  filesystem: Guacamole.Object,
+  path: string,
+): Promise<RemoteFileEntry[]> {
+  const { stream, mimetype } = await requestStream(filesystem, path);
+
+  if (!isDirectoryMimetype(mimetype)) {
+    throw new Error(`${path} is not a directory`);
+  }
+
+  const json = await new Promise<string>((resolve) => {
+    const reader = new Guacamole.StringReader(stream);
+    let text = "";
+    reader.ontext = (chunk: string) => {
+      text += chunk;
+    };
+    reader.onend = () => resolve(text);
+  });
+
+  return parseDirectoryIndex(json, path);
+}
+
+export async function downloadFile(
+  filesystem: Guacamole.Object,
+  path: string,
+): Promise<{ blob: Blob; filename: string }> {
+  const { stream, mimetype } = await requestStream(filesystem, path);
+
+  if (isDirectoryMimetype(mimetype)) {
+    throw new Error(`${path} is a directory`);
+  }
+
+  const blob = await new Promise<Blob>((resolve) => {
+    const reader = new Guacamole.BlobReader(stream, mimetype);
+    reader.onend = () => resolve(reader.getBlob());
+  });
+
+  return { blob, filename: basename(path) };
+}
+
+export function uploadFile(
+  filesystem: Guacamole.Object,
+  directory: string,
+  file: File,
+  onProgress?: (sent: number, total: number) => void,
+): Promise<void> {
+  return new Promise((resolve, reject) => {
+    const path = joinPath(directory, file.name);
+    const stream = filesystem.createOutputStream(
+      file.type || "application/octet-stream",
+      path,
+    );
+    const writer = new Guacamole.BlobWriter(stream);
+
+    // A rejected blob stops the writer without firing onerror or oncomplete —
+    // only the error ack reports it, so without this the upload hangs forever.
+    writer.onack = (status: Guacamole.Status) => {
+      if (status.isError()) {
+        reject(
+          new Error(
+            status.message || `Server refused the upload of ${file.name}`,
+          ),
+        );
+      }
+    };
+    writer.onerror = () => reject(new Error(`Failed to upload ${file.name}`));
+    writer.onprogress = (_blob: Blob, offset: number) =>
+      onProgress?.(offset, file.size);
+    writer.oncomplete = () => {
+      writer.sendEnd();
+      onProgress?.(file.size, file.size);
+      resolve();
+    };
+
+    writer.sendBlob(file);
+  });
+}
+
+export function saveBlobAs(blob: Blob, filename: string): void {
+  const url = URL.createObjectURL(blob);
+  const link = document.createElement("a");
+  link.href = url;
+  link.download = filename;
+  link.click();
+  URL.revokeObjectURL(url);
+}

--- a/src/ui/locales/en.json
+++ b/src/ui/locales/en.json
@@ -1684,6 +1684,21 @@
     "credentialPromptDescription": "This host is set to prompt for credentials on connect. They are used for this session only and are not saved.",
     "connect": "Connect",
     "ctrlAltDel": "Ctrl+Alt+Del",
+    "files": {
+      "title": "Drive Files",
+      "parent": "Parent directory",
+      "refresh": "Refresh",
+      "empty": "This folder is empty",
+      "listFailed": "Failed to read this folder",
+      "download": "Download",
+      "downloadFailed": "Failed to download {{name}}",
+      "upload": "Upload files",
+      "uploading": "Uploading {{name}}...",
+      "uploaded": "Uploaded {{name}}",
+      "uploadFailed": "Failed to upload {{name}}",
+      "uploadDisabled": "Uploads are disabled for this connection",
+      "dropToUpload": "Drop files to upload"
+    },
     "toolbar": {
       "ctrlAltDel": "Ctrl+Alt+Del",
       "winL": "Win+L (Lock Screen)",

--- a/src/ui/tests/features/guacamole/guacamole-filesystem.test.ts
+++ b/src/ui/tests/features/guacamole/guacamole-filesystem.test.ts
@@ -1,0 +1,88 @@
+import { describe, expect, it } from "vitest";
+import {
+  STREAM_INDEX_MIMETYPE,
+  basename,
+  isDirectoryMimetype,
+  joinPath,
+  parentPath,
+  parseDirectoryIndex,
+} from "../../../features/guacamole/guacamole-filesystem.js";
+
+describe("path helpers", () => {
+  it("joins onto the root without doubling the separator", () => {
+    expect(joinPath("/", "Users")).toBe("/Users");
+    expect(joinPath("/Users", "kei")).toBe("/Users/kei");
+  });
+
+  it("stops walking up at the root", () => {
+    expect(parentPath("/Users/kei")).toBe("/Users");
+    expect(parentPath("/Users")).toBe("/");
+    expect(parentPath("/")).toBe("/");
+  });
+
+  it("reads the trailing segment as the name", () => {
+    expect(basename("/Users/kei/notes.txt")).toBe("notes.txt");
+    expect(basename("notes.txt")).toBe("notes.txt");
+  });
+});
+
+describe("isDirectoryMimetype", () => {
+  it("treats only the stream index mimetype as a directory", () => {
+    expect(isDirectoryMimetype(STREAM_INDEX_MIMETYPE)).toBe(true);
+    expect(isDirectoryMimetype("text/plain")).toBe(false);
+  });
+});
+
+describe("parseDirectoryIndex", () => {
+  it("sorts directories before files and alphabetises within each group", () => {
+    const json = JSON.stringify({
+      "/report.pdf": "application/pdf",
+      "/apps": STREAM_INDEX_MIMETYPE,
+      "/notes.txt": "text/plain",
+      "/Documents": STREAM_INDEX_MIMETYPE,
+    });
+
+    expect(parseDirectoryIndex(json, "/").map((e) => e.name)).toEqual([
+      "apps",
+      "Documents",
+      "notes.txt",
+      "report.pdf",
+    ]);
+  });
+
+  it("marks entries carrying the stream index mimetype as directories", () => {
+    const json = JSON.stringify({
+      "/apps": STREAM_INDEX_MIMETYPE,
+      "/notes.txt": "text/plain",
+    });
+    const [dir, file] = parseDirectoryIndex(json, "/");
+
+    expect(dir).toEqual({
+      name: "apps",
+      path: "/apps",
+      mimetype: STREAM_INDEX_MIMETYPE,
+      isDirectory: true,
+    });
+    expect(file.isDirectory).toBe(false);
+  });
+
+  it("keeps absolute keys as-is when listing a nested directory", () => {
+    const json = JSON.stringify({ "/Users/kei/notes.txt": "text/plain" });
+
+    expect(parseDirectoryIndex(json, "/Users/kei")[0].path).toBe(
+      "/Users/kei/notes.txt",
+    );
+  });
+
+  it("resolves a relative key against the directory being listed", () => {
+    const json = JSON.stringify({ "notes.txt": "text/plain" });
+
+    expect(parseDirectoryIndex(json, "/Users/kei")[0].path).toBe(
+      "/Users/kei/notes.txt",
+    );
+  });
+
+  it("returns nothing for an empty directory", () => {
+    expect(parseDirectoryIndex("{}", "/")).toEqual([]);
+  });
+});


### PR DESCRIPTION
## Problem

Drive redirection is already configurable per host — `enableDriveRedirection` in the host editor, with the backend filling in `drive-path` and `create-drive-path` automatically. Turning it on does mount a drive inside the Windows session.

But that drive lives in guacd's container and there was no way to reach it from the browser. The client never set `client.onfilesystem`, which is the only hook that hands the page a `Guacamole.Object` for the redirected volume. So the drive was writable from the remote desktop and completely invisible from Termix — the feature was half-connected.

`onfile` was handled, but that only catches streams the server pushes on its own (the printing path); it is not a way to browse or upload.

## What this adds

- **File browser panel** — lists the redirected drive, navigates into folders, downloads files. Opened from a toolbar button that only appears once guacd actually reports a filesystem.
- **Upload** — from the panel, into the directory currently being viewed.
- **Drag and drop** — dropping files on the display opens the panel and uploads them to the directory it is showing, rather than always dumping them at the drive root.
- **`disable-upload` / `disable-download` are honoured by the UI.** These settings were already mapped and sent to guacd, but the browser is our own code — without checking them, an administrator who disabled uploads would still see an upload button.

## Two hangs worth calling out

`BlobWriter` fires neither `onerror` nor `oncomplete` when the *server* refuses a blob — the internal `onack` handler simply stops advancing:

```js
n.onack = function(o){ t.onack && t.onack(o), o.isError() || (…, i()) }
```

`onerror` only covers local `FileReader` failures. A refused upload (read-only drive, full disk, illegal path) would leave the promise pending forever and the UI stuck on "Uploading…". The error ack is now watched explicitly.

Directory and file reads have the same shape — a refused `requestInputStream` never invokes the body callback — so those carry a deadline.

## Type definitions

`src/types/guacamole-common-js.d.ts` is the effective source of types for this module; the installed `@types/guacamole-common-js` does not apply. It was missing `Guacamole.Object`, `Client.onfilesystem`, `BlobReader` and `BlobWriter`. Added.

Note `BlobReader` was **already used** by the existing `onfile` handler and was already a type error before this change.

## What this does not do

Cross-window Ctrl+C / Ctrl+V of *files* is still not possible. guacd implements only text and image clipboards; RDP's CLIPRDR file transfer is not exposed through the Guacamole protocol. Text clipboard sync is unaffected and continues to work as before.

## Verification

Frontend types are not actually checked anywhere today — the root `tsconfig.json` is solution-style with `"files": []`, so `npx tsc --noEmit` (what CI runs) compiles nothing. Checked against the real project instead:

```
tsc -p tsconfig.app.json --noEmit
  upstream/dev-2.7.0 : 305 errors
  this branch        : 304 errors
```

No new errors; one pre-existing `BlobReader` error is resolved by the added declarations. The 6 remaining errors under `features/guacamole/` are all present on the baseline.

- `npm run lint` — 0 errors
- `npx prettier@3.9.6 --check .` — clean
- `npx vitest run` — 228 files, 1646 passed
- `npm run build` — passes

New unit tests cover the directory-index parsing and path derivation in `guacamole-filesystem.ts`, which is split out from the component for that reason.

## Follow-ups, not in this PR

- `create-drive-path: true` means guacd creates the directory itself, so uploads do not survive a guacd container restart. Whether the drive should be a mounted volume or documented as scratch space is a deployment decision.
- CI's type-check step is a no-op for both frontend and backend. Worth a separate PR.