### PR TITLE
fix: keep the mouse working on touch-capable devices in RDP/VNC

### DIFF
--- a/src/ui/features/guacamole/GuacamoleDisplay.tsx
+++ b/src/ui/features/guacamole/GuacamoleDisplay.tsx
@@ -24,6 +24,7 @@ import {
   pasteTextToRemote,
 } from "./guacamole-clipboard.ts";
 import { getGuacamoleDisplaySize } from "./guacamole-display-size.ts";
+import { bindPointerInput } from "./guacamole-pointer.ts";
 
 export type GuacamoleConnectionType = "rdp" | "vnc" | "telnet";
 
@@ -447,10 +448,9 @@ export const GuacamoleDisplay = forwardRef<
       setIsReady(true);
     }
 
-    const sendMouseEvent = (event: Guacamole.Mouse.MouseEvent) => {
+    const sendMouseState = (state: Guacamole.Mouse.State) => {
       displayElement.focus({ preventScroll: true });
       const scale = scaleRef.current;
-      const state = event.state;
       const adjustedState = new Guacamole.Mouse.State(
         Math.round(state.x / scale),
         Math.round(state.y / scale),
@@ -463,30 +463,7 @@ export const GuacamoleDisplay = forwardRef<
       client.sendMouseState(adjustedState);
     };
 
-    if (touchMode === "touchscreen") {
-      const touchscreen = new Guacamole.Mouse.Touchscreen(displayElement);
-      touchscreen.onEach(["mousedown", "mousemove", "mouseup"], sendMouseEvent);
-    } else if (touchMode === "touchpad") {
-      const touchpad = new Guacamole.Mouse.Touchpad(displayElement);
-      touchpad.onEach(["mousedown", "mousemove", "mouseup"], sendMouseEvent);
-    } else {
-      const mouse = new Guacamole.Mouse(displayElement);
-      const sendMouseState = (state: Guacamole.Mouse.State) => {
-        displayElement.focus({ preventScroll: true });
-        const scale = scaleRef.current;
-        const adjustedState = new Guacamole.Mouse.State(
-          Math.round(state.x / scale),
-          Math.round(state.y / scale),
-          state.left,
-          state.middle,
-          state.right,
-          state.up,
-          state.down,
-        ) as Guacamole.Mouse.State;
-        client.sendMouseState(adjustedState);
-      };
-      mouse.onmousedown = mouse.onmouseup = mouse.onmousemove = sendMouseState;
-    }
+    bindPointerInput(displayElement, touchMode, sendMouseState);
 
     const keyboard = new Guacamole.Keyboard(displayElement);
     keyboardRef.current = keyboard;

--- a/src/ui/features/guacamole/guacamole-pointer.ts
+++ b/src/ui/features/guacamole/guacamole-pointer.ts
@@ -1,0 +1,37 @@
+import Guacamole from "guacamole-common-js";
+
+export type GuacamoleTouchMode = "touchscreen" | "touchpad";
+
+/**
+ * Guacamole.Mouse listens for mousedown/mousemove/mouseup; the Touchscreen and
+ * Touchpad emulators listen only for touch events. The two sets do not overlap,
+ * so binding one instead of the other leaves that input dead.
+ *
+ * A touch-capable device is not a device without a pointer: laptops with a
+ * touchscreen report maxTouchPoints > 0 and are still driven by a mouse. The
+ * physical pointer is therefore always bound, and a touch emulator is layered
+ * on top when one is selected.
+ */
+export function bindPointerInput(
+  element: HTMLElement,
+  touchMode: GuacamoleTouchMode | null | undefined,
+  onState: (state: Guacamole.Mouse.State) => void,
+): void {
+  const mouse = new Guacamole.Mouse(element);
+  mouse.onmousedown = mouse.onmouseup = mouse.onmousemove = onState;
+
+  if (touchMode === "touchscreen") {
+    const touchscreen = new Guacamole.Mouse.Touchscreen(element);
+    touchscreen.onEach(["mousedown", "mousemove", "mouseup"], (event) =>
+      onState(event.state),
+    );
+    return;
+  }
+
+  if (touchMode === "touchpad") {
+    const touchpad = new Guacamole.Mouse.Touchpad(element);
+    touchpad.onEach(["mousedown", "mousemove", "mouseup"], (event) =>
+      onState(event.state),
+    );
+  }
+}

--- a/src/ui/tests/features/guacamole/guacamole-pointer.test.ts
+++ b/src/ui/tests/features/guacamole/guacamole-pointer.test.ts
@@ -1,0 +1,50 @@
+import { describe, expect, it, vi } from "vitest";
+import { bindPointerInput } from "../../../features/guacamole/guacamole-pointer.js";
+
+function listenedEvents(): {
+  element: HTMLElement;
+  events: () => string[];
+} {
+  const element = document.createElement("div");
+  const seen: string[] = [];
+  const original = element.addEventListener.bind(element);
+  element.addEventListener = ((type: string, ...rest: unknown[]) => {
+    seen.push(type);
+    return (original as (t: string, ...r: unknown[]) => void)(type, ...rest);
+  }) as typeof element.addEventListener;
+  return { element, events: () => seen };
+}
+
+describe("bindPointerInput", () => {
+  // A touchscreen laptop reports maxTouchPoints > 0 and still has a mouse.
+  // Binding only the touch emulator left the pointer dead on those machines.
+  it.each([
+    ["no touch mode", null],
+    ["touchscreen", "touchscreen" as const],
+    ["touchpad", "touchpad" as const],
+  ])("keeps the physical pointer bound with %s", (_label, touchMode) => {
+    const { element, events } = listenedEvents();
+
+    bindPointerInput(element, touchMode, vi.fn());
+
+    expect(events()).toContain("mousedown");
+    expect(events()).toContain("mousemove");
+    expect(events()).toContain("mouseup");
+  });
+
+  it("adds touch listeners only when a touch mode is selected", () => {
+    const withoutTouch = listenedEvents();
+    bindPointerInput(withoutTouch.element, null, vi.fn());
+    const plainTouchCount = withoutTouch
+      .events()
+      .filter((e) => e.startsWith("touch")).length;
+
+    const withTouch = listenedEvents();
+    bindPointerInput(withTouch.element, "touchscreen", vi.fn());
+    const touchModeCount = withTouch
+      .events()
+      .filter((e) => e.startsWith("touch")).length;
+
+    expect(touchModeCount).toBeGreaterThan(plainTouchCount);
+  });
+});


### PR DESCRIPTION
Fixes part of Termix-SSH/Support#1102 — "mouse input broken, keyboard fine", regressed after 2.5.1.

## The branch replaced the mouse instead of adding to it

2.5.1 bound the pointer unconditionally:

```js
const mouse = new Guacamole.Mouse(displayElement);
```

2.6.0 turned that into a three-way branch on `touchMode`:

```js
if (touchMode === "touchscreen")      new Guacamole.Mouse.Touchscreen(el)
else if (touchMode === "touchpad")    new Guacamole.Mouse.Touchpad(el)
else                                  new Guacamole.Mouse(el)
```

The three are not interchangeable. Checked against the vendored library:

| class | DOM events it registers |
|---|---|
| `Guacamole.Mouse` | `mousedown` `mousemove` `mouseup` `mouseout` `contextmenu` `wheel` … |
| `Guacamole.Mouse.Touchscreen` | `touchstart` `touchmove` `touchend` |
| `Guacamole.Mouse.Touchpad` | `touchstart` `touchmove` `touchend` |

Disjoint. In either touch mode **nothing is listening for the mouse**.

## Why ordinary desktops hit it

`GuacamoleApp` picks the initial mode from feature detection:

```js
navigator.maxTouchPoints > 0 || "ontouchstart" in window ? "touchscreen" : null
```

`maxTouchPoints > 0` is true of every laptop with a touchscreen — Surface devices, convertibles, a large slice of consumer Windows laptops. Those machines have a mouse and a trackpad and are driven by them. They were put into touchscreen mode and lost the pointer completely.

The keyboard kept working because `Guacamole.Keyboard` is bound outside the branch. That asymmetry is exactly the reported symptom.

## Fix

Bind the physical pointer always, layer a touch emulator on top when one is selected. Extracted to `bindPointerInput()` so the behaviour is covered by a test rather than living inside a 700-line effect.

The test asserts `mousedown`/`mousemove`/`mouseup` are registered in all three modes, and that touch listeners are added only when a touch mode is chosen. Confirmed it fails against the old branch (2 of 4 cases) and passes after.

## What this does not fix

#1102 accumulated a second report. `@doudalidou` captured WS frames plus a fake guacd in the proxy path and showed well-formed `5.mouse,...;` instructions arriving at guacd verbatim, with the VNC leg then ignoring them — a different failure, downstream of anything this repo controls.

Worth recording there: that analysis attributes the regression to guacd 1.6.0, but the image is pinned identically in both releases —

```
release-2.5.1-tag: guacd:1.6.0
release-2.6.1-tag: guacd:1.6.0
```

— pinned since v2.1.0, so an upgrade cannot be the trigger. I'll follow up on the issue separately.

## Verification

- `npm run type-check` — 0 errors
- `npx vitest run` — 229 files, 1650 passed
- `npm run lint` — 0 errors
- `npx prettier@3.9.6 --check .` — clean
- `npm run build` — passes