### PR TITLE
fix: make mobile terminal scrollback match xterm wheel behavior

### DIFF
--- a/src/ui/features/terminal/Terminal.tsx
+++ b/src/ui/features/terminal/Terminal.tsx
@@ -73,6 +73,7 @@ import {
   getTerminalFontZoomDirection,
 } from "./terminal-font-zoom.ts";
 import { isTabKeyEvent } from "./terminal-key-event.ts";
+import { installTouchWheelCoordinator } from "./touch-wheel-coordinator.ts";
 import {
   getUserPreferences,
   parseCustomKeybindings,
@@ -2444,6 +2445,10 @@ const TerminalInner = forwardRef<TerminalHandle, SSHTerminalProps>(
         });
       });
 
+      // Send one-finger drags through xterm's real wheel DOM path. This keeps
+      // scrollback, alternate-buffer/tmux, mouse reporting and wheel remainder
+      // handling identical to desktop wheel input.
+      const disposeTouchWheel = installTouchWheelCoordinator(xtermRef.current);
       const element = xtermRef.current;
       const handleContextMenu = (e: MouseEvent) => {
         if (e.ctrlKey && onOpenFileManager) {
@@ -2558,6 +2563,7 @@ const TerminalInner = forwardRef<TerminalHandle, SSHTerminalProps>(
         element?.removeEventListener("mouseup", handleTmuxDragEnd);
         element?.removeEventListener("keydown", handleBackspaceMode, true);
         element?.removeEventListener("keydown", handleTabCapture, true);
+        disposeTouchWheel();
         if (notifyTimerRef.current) clearTimeout(notifyTimerRef.current);
         if (resizeTimeout.current) clearTimeout(resizeTimeout.current);
       };

--- a/src/ui/features/terminal/touch-wheel-coordinator.ts
+++ b/src/ui/features/terminal/touch-wheel-coordinator.ts
@@ -1,0 +1,332 @@
+export interface TouchWheelPoint {
+  clientX: number;
+  clientY: number;
+}
+
+export interface SyntheticWheelInput extends TouchWheelPoint {
+  deltaY: number;
+  deltaMode: number;
+}
+
+const DEFAULT_DRAG_THRESHOLD_PX = 6;
+const DEFAULT_MAX_WHEEL_DELTA_PX = 120;
+const MOMENTUM_SAMPLE_WINDOW_MS = 100;
+const MOMENTUM_RELEASE_GRACE_MS = 120;
+const MOMENTUM_MIN_VELOCITY_PX_PER_MS = 0.15;
+const MOMENTUM_MAX_VELOCITY_PX_PER_MS = 2.5;
+const MOMENTUM_MAX_DURATION_MS = 1_000;
+const MOMENTUM_MAX_TRAVEL_PX = 720;
+const MOMENTUM_DECAY_TIME_MS = 300;
+const MOMENTUM_PIXELS_PER_TICK = 12;
+const MOMENTUM_MAX_FRAME_MS = 32;
+const MOMENTUM_MAX_TICKS_PER_FRAME = 4;
+
+interface TouchWheelTiming {
+  now: () => number;
+  requestFrame: (callback: FrameRequestCallback) => number;
+  cancelFrame: (handle: number) => void;
+  momentumAllowed: () => boolean;
+}
+
+const defaultTiming: TouchWheelTiming = {
+  now: () => performance.now(),
+  requestFrame: (callback) => requestAnimationFrame(callback),
+  cancelFrame: (handle) => cancelAnimationFrame(handle),
+  momentumAllowed: () => true,
+};
+
+interface VelocitySample {
+  deltaY: number;
+  durationMs: number;
+  endedAt: number;
+}
+
+export class TouchWheelCoordinator {
+  private startY: number | undefined;
+  private lastPoint: TouchWheelPoint | undefined;
+  private pendingDeltaY = 0;
+  private scrolling = false;
+  private cancelled = false;
+  private velocitySamples: VelocitySample[] = [];
+  private lastMoveTime: number | undefined;
+  private momentumFrame: number | undefined;
+  private momentumRemainderY = 0;
+
+  constructor(
+    private readonly emitWheel: (input: SyntheticWheelInput) => void,
+    private readonly dragThresholdPx = DEFAULT_DRAG_THRESHOLD_PX,
+    private readonly maxWheelDeltaPx = DEFAULT_MAX_WHEEL_DELTA_PX,
+    private readonly timing: TouchWheelTiming = defaultTiming,
+  ) {}
+
+  start(point: TouchWheelPoint | undefined, time = this.timing.now()): void {
+    this.reset();
+    if (!point) {
+      this.cancelled = true;
+      return;
+    }
+    this.startY = point.clientY;
+    this.lastPoint = point;
+    this.lastMoveTime = time;
+  }
+
+  move(point: TouchWheelPoint | undefined, time = this.timing.now()): boolean {
+    if (this.cancelled || !point || !this.lastPoint) {
+      if (!point) this.cancel();
+      return false;
+    }
+
+    const deltaY = this.lastPoint.clientY - point.clientY;
+    this.pendingDeltaY += deltaY;
+    this.lastPoint = point;
+    if (this.lastMoveTime !== undefined && time > this.lastMoveTime) {
+      this.velocitySamples.push({
+        deltaY,
+        durationMs: time - this.lastMoveTime,
+        endedAt: time,
+      });
+      this.velocitySamples = this.velocitySamples.filter(
+        (sample) => time - sample.endedAt <= MOMENTUM_SAMPLE_WINDOW_MS,
+      );
+    }
+    this.lastMoveTime = time;
+
+    if (!this.scrolling) {
+      if (Math.abs(point.clientY - this.startY!) < this.dragThresholdPx) {
+        return true;
+      }
+      this.scrolling = true;
+    }
+
+    this.flush(point);
+    return true;
+  }
+
+  end(time = this.timing.now()): void {
+    const point = this.lastPoint;
+    const velocity = this.scrolling ? this.recentVelocity(time) : 0;
+    this.clearGesture();
+    if (
+      point &&
+      this.timing.momentumAllowed() &&
+      Math.abs(velocity) >= MOMENTUM_MIN_VELOCITY_PX_PER_MS
+    ) {
+      this.startMomentum(point, velocity, time);
+    }
+  }
+
+  cancel(): void {
+    this.reset();
+    this.cancelled = true;
+  }
+
+  private flush(point: TouchWheelPoint): void {
+    while (Math.abs(this.pendingDeltaY) > this.maxWheelDeltaPx) {
+      const deltaY = Math.sign(this.pendingDeltaY) * this.maxWheelDeltaPx;
+      this.emitWheel({
+        ...point,
+        deltaY,
+        deltaMode: WheelEvent.DOM_DELTA_PIXEL,
+      });
+      this.pendingDeltaY -= deltaY;
+    }
+    if (this.pendingDeltaY !== 0) {
+      this.emitWheel({
+        ...point,
+        deltaY: this.pendingDeltaY,
+        deltaMode: WheelEvent.DOM_DELTA_PIXEL,
+      });
+      this.pendingDeltaY = 0;
+    }
+  }
+
+  private reset(): void {
+    this.stopMomentum();
+    this.clearGesture();
+    this.cancelled = false;
+  }
+
+  private clearGesture(): void {
+    this.startY = undefined;
+    this.lastPoint = undefined;
+    this.pendingDeltaY = 0;
+    this.scrolling = false;
+    this.velocitySamples = [];
+    this.lastMoveTime = undefined;
+  }
+
+  private recentVelocity(time: number): number {
+    const newestSampleTime = this.velocitySamples.at(-1)?.endedAt;
+    if (
+      newestSampleTime === undefined ||
+      time - newestSampleTime > MOMENTUM_RELEASE_GRACE_MS
+    ) {
+      return 0;
+    }
+    const samples = this.velocitySamples.filter(
+      (sample) =>
+        newestSampleTime - sample.endedAt <= MOMENTUM_SAMPLE_WINDOW_MS,
+    );
+    const duration = samples.reduce(
+      (total, sample) => total + sample.durationMs,
+      0,
+    );
+    if (duration === 0) return 0;
+    const distance = samples.reduce(
+      (total, sample) => total + sample.deltaY,
+      0,
+    );
+    return Math.max(
+      -MOMENTUM_MAX_VELOCITY_PX_PER_MS,
+      Math.min(MOMENTUM_MAX_VELOCITY_PX_PER_MS, distance / duration),
+    );
+  }
+
+  private startMomentum(
+    point: TouchWheelPoint,
+    initialVelocity: number,
+    startedAt: number,
+  ): void {
+    let lastTime = startedAt;
+    let travelled = 0;
+
+    const step = (time: number) => {
+      if (!this.timing.momentumAllowed()) {
+        this.momentumFrame = undefined;
+        this.momentumRemainderY = 0;
+        return;
+      }
+
+      const elapsed = Math.max(0, time - startedAt);
+      const remainingTravel = MOMENTUM_MAX_TRAVEL_PX - travelled;
+      if (elapsed > MOMENTUM_MAX_DURATION_MS || remainingTravel <= 0) {
+        this.momentumFrame = undefined;
+        return;
+      }
+
+      const duration = Math.min(
+        Math.max(0, time - lastTime),
+        MOMENTUM_MAX_FRAME_MS,
+      );
+      if (duration > 0) {
+        const frameStart = Math.max(0, elapsed - duration);
+        const distance =
+          Math.abs(initialVelocity) *
+          MOMENTUM_DECAY_TIME_MS *
+          (Math.exp(-frameStart / MOMENTUM_DECAY_TIME_MS) -
+            Math.exp(-elapsed / MOMENTUM_DECAY_TIME_MS));
+        const deltaY =
+          Math.sign(initialVelocity) * Math.min(distance, remainingTravel);
+        this.flushMomentum(point, deltaY);
+        travelled += Math.abs(deltaY);
+      }
+
+      lastTime = time;
+      if (
+        elapsed < MOMENTUM_MAX_DURATION_MS &&
+        travelled < MOMENTUM_MAX_TRAVEL_PX
+      ) {
+        this.momentumFrame = this.timing.requestFrame(step);
+      } else {
+        this.momentumFrame = undefined;
+      }
+    };
+
+    this.momentumFrame = this.timing.requestFrame(step);
+  }
+
+  private flushMomentum(point: TouchWheelPoint, deltaY: number): void {
+    this.momentumRemainderY += deltaY;
+    const availableTicks = Math.trunc(
+      Math.abs(this.momentumRemainderY) / MOMENTUM_PIXELS_PER_TICK,
+    );
+    const tickCount = Math.min(availableTicks, MOMENTUM_MAX_TICKS_PER_FRAME);
+    const direction = Math.sign(this.momentumRemainderY);
+    for (let index = 0; index < tickCount; index++) {
+      this.emitWheel({
+        ...point,
+        deltaY: direction,
+        deltaMode: WheelEvent.DOM_DELTA_LINE,
+      });
+    }
+    this.momentumRemainderY -= direction * tickCount * MOMENTUM_PIXELS_PER_TICK;
+  }
+
+  private stopMomentum(): void {
+    if (this.momentumFrame !== undefined) {
+      this.timing.cancelFrame(this.momentumFrame);
+      this.momentumFrame = undefined;
+    }
+    this.momentumRemainderY = 0;
+  }
+}
+
+export function installTouchWheelCoordinator(
+  terminalElement: HTMLElement,
+  momentumAllowed: () => boolean = () => true,
+): () => void {
+  const wheelElement = terminalElement.querySelector<HTMLElement>(
+    ".xterm-scrollable-element",
+  );
+  if (!wheelElement) return () => {};
+
+  const coordinator = new TouchWheelCoordinator(
+    ({ deltaY, deltaMode, clientX, clientY }) => {
+      wheelElement.dispatchEvent(
+        new WheelEvent("wheel", {
+          bubbles: true,
+          cancelable: true,
+          composed: true,
+          clientX,
+          clientY,
+          deltaMode,
+          deltaY,
+        }),
+      );
+    },
+    DEFAULT_DRAG_THRESHOLD_PX,
+    DEFAULT_MAX_WHEEL_DELTA_PX,
+    {
+      ...defaultTiming,
+      momentumAllowed: () =>
+        momentumAllowed() &&
+        !window.matchMedia?.("(prefers-reduced-motion: reduce)").matches,
+    },
+  );
+
+  const getSingleTouch = (event: TouchEvent): Touch | undefined =>
+    event.touches.length === 1
+      ? (event.touches.item(0) ?? undefined)
+      : undefined;
+
+  const handleTouchStart = (event: TouchEvent) => {
+    const touch = getSingleTouch(event);
+    coordinator.start(touch);
+  };
+  const handleTouchMove = (event: TouchEvent) => {
+    if (coordinator.move(getSingleTouch(event))) event.preventDefault();
+  };
+  const handleTouchEnd = () => coordinator.end();
+  const handleTouchCancel = () => coordinator.cancel();
+
+  terminalElement.addEventListener("touchstart", handleTouchStart, {
+    passive: true,
+  });
+  terminalElement.addEventListener("touchmove", handleTouchMove, {
+    passive: false,
+  });
+  terminalElement.addEventListener("touchend", handleTouchEnd, {
+    passive: true,
+  });
+  terminalElement.addEventListener("touchcancel", handleTouchCancel, {
+    passive: true,
+  });
+
+  return () => {
+    coordinator.cancel();
+    terminalElement.removeEventListener("touchstart", handleTouchStart);
+    terminalElement.removeEventListener("touchmove", handleTouchMove);
+    terminalElement.removeEventListener("touchend", handleTouchEnd);
+    terminalElement.removeEventListener("touchcancel", handleTouchCancel);
+  };
+}

--- a/src/ui/tests/features/terminal/touch-wheel-coordinator.test.ts
+++ b/src/ui/tests/features/terminal/touch-wheel-coordinator.test.ts
@@ -1,0 +1,402 @@
+import { describe, expect, it, vi } from "vitest";
+import {
+  installTouchWheelCoordinator,
+  TouchWheelCoordinator,
+} from "../../../features/terminal/touch-wheel-coordinator";
+
+const point = (clientY: number, clientX = 10) => ({ clientX, clientY });
+
+const touchEvent = (type: string, clientYValues: number[]) => {
+  const event = new Event(type, { bubbles: true, cancelable: true });
+  const touches = clientYValues.map((clientY) => ({ clientX: 10, clientY }));
+  Object.defineProperty(event, "touches", {
+    value: Object.assign(touches, {
+      item: (index: number) => touches[index] ?? null,
+    }),
+  });
+  return event;
+};
+
+const createTiming = (momentumAllowed = true) => {
+  let now = 0;
+  let nextHandle = 1;
+  const callbacks = new Map<number, FrameRequestCallback>();
+  return {
+    timing: {
+      now: () => now,
+      requestFrame: (callback: FrameRequestCallback) => {
+        const handle = nextHandle++;
+        callbacks.set(handle, callback);
+        return handle;
+      },
+      cancelFrame: (handle: number) => callbacks.delete(handle),
+      momentumAllowed: () => momentumAllowed,
+    },
+    advance(milliseconds: number) {
+      now += milliseconds;
+      const pending = [...callbacks.values()];
+      callbacks.clear();
+      pending.forEach((callback) => callback(now));
+    },
+    pendingFrames: () => callbacks.size,
+  };
+};
+
+describe("TouchWheelCoordinator", () => {
+  it("accumulates the drag threshold and preserves delta direction", () => {
+    const emit = vi.fn();
+    const coordinator = new TouchWheelCoordinator(emit);
+
+    coordinator.start(point(100));
+    expect(coordinator.move(point(97.5))).toBe(true);
+    expect(coordinator.move(point(93))).toBe(true);
+    coordinator.move(point(101));
+
+    expect(emit.mock.calls.map(([event]) => event.deltaY)).toEqual([7, -8]);
+  });
+
+  it("keeps movement below the tap threshold from scrolling", () => {
+    const emit = vi.fn();
+    const coordinator = new TouchWheelCoordinator(emit);
+
+    coordinator.start(point(100));
+    expect(coordinator.move(point(95))).toBe(true);
+    coordinator.end();
+
+    expect(emit).not.toHaveBeenCalled();
+  });
+
+  it("cancels the gesture when more than one touch is represented", () => {
+    const emit = vi.fn();
+    const coordinator = new TouchWheelCoordinator(emit);
+
+    coordinator.start(point(100));
+    coordinator.move(undefined);
+    expect(coordinator.move(point(80))).toBe(false);
+
+    expect(emit).not.toHaveBeenCalled();
+  });
+
+  it("cleans up cancelled state before the next gesture", () => {
+    const emit = vi.fn();
+    const coordinator = new TouchWheelCoordinator(emit);
+
+    coordinator.start(point(100));
+    coordinator.cancel();
+    coordinator.start(point(50));
+    expect(coordinator.move(point(43.5))).toBe(true);
+
+    expect(emit).toHaveBeenCalledOnce();
+    expect(emit.mock.calls[0][0].deltaY).toBe(6.5);
+  });
+
+  it.each([
+    { start: 100, end: 20, direction: 1 },
+    { start: 20, end: 100, direction: -1 },
+  ])(
+    "emits multiple $direction line ticks after release",
+    ({ start, end, direction }) => {
+      const emit = vi.fn();
+      const clock = createTiming();
+      const coordinator = new TouchWheelCoordinator(
+        emit,
+        undefined,
+        undefined,
+        clock.timing,
+      );
+
+      coordinator.start(point(start));
+      clock.advance(20);
+      coordinator.move(point((start + end) / 2));
+      clock.advance(20);
+      coordinator.move(point(end));
+      coordinator.end();
+      const dragCallCount = emit.mock.calls.length;
+
+      for (let index = 0; index < 12; index++) clock.advance(16);
+      const momentum = emit.mock.calls
+        .slice(dragCallCount)
+        .map(([event]) => event);
+
+      expect(momentum.length).toBeGreaterThan(3);
+      expect(
+        momentum.every(
+          (event) =>
+            event.deltaMode === WheelEvent.DOM_DELTA_LINE &&
+            event.deltaY === direction,
+        ),
+      ).toBe(true);
+    },
+  );
+
+  it("decays the number of line ticks emitted over time", () => {
+    const emit = vi.fn();
+    const clock = createTiming();
+    const coordinator = new TouchWheelCoordinator(
+      emit,
+      undefined,
+      undefined,
+      clock.timing,
+    );
+    coordinator.start(point(200));
+    clock.advance(20);
+    coordinator.move(point(100));
+    coordinator.end();
+    const dragCalls = emit.mock.calls.length;
+
+    const frameCounts: number[] = [];
+    for (let index = 0; index < 24; index++) {
+      const before = emit.mock.calls.length;
+      clock.advance(16);
+      frameCounts.push(emit.mock.calls.length - before);
+    }
+
+    expect(emit.mock.calls.length - dragCalls).toBeGreaterThan(3);
+    expect(frameCounts.slice(0, 8).reduce((a, b) => a + b, 0)).toBeGreaterThan(
+      frameCounts.slice(-8).reduce((a, b) => a + b, 0),
+    );
+  });
+
+  it("uses the recent movement window despite a short touchend delay", () => {
+    const emit = vi.fn();
+    const clock = createTiming();
+    const coordinator = new TouchWheelCoordinator(
+      emit,
+      undefined,
+      undefined,
+      clock.timing,
+    );
+    coordinator.start(point(100));
+    clock.advance(20);
+    coordinator.move(point(50));
+    clock.advance(80);
+    coordinator.end();
+
+    expect(clock.pendingFrames()).toBe(1);
+  });
+
+  it("bounds momentum velocity, duration, and total travel", () => {
+    const emit = vi.fn();
+    const clock = createTiming();
+    const coordinator = new TouchWheelCoordinator(
+      emit,
+      undefined,
+      undefined,
+      clock.timing,
+    );
+
+    coordinator.start(point(1000));
+    clock.advance(1);
+    coordinator.move(point(0));
+    coordinator.end();
+    const dragCallCount = emit.mock.calls.length;
+    clock.advance(200);
+    const firstFrameTicks = emit.mock.calls.length - dragCallCount;
+    for (let index = 0; index < 30; index++) clock.advance(20);
+    expect(clock.pendingFrames()).toBe(1);
+    for (let index = 0; index < 10; index++) clock.advance(20);
+    const totalTicks = emit.mock.calls.length - dragCallCount;
+
+    expect(firstFrameTicks).toBeLessThanOrEqual(4);
+    expect(totalTicks).toBeLessThanOrEqual(Math.floor(720 / 12));
+    expect(clock.pendingFrames()).toBe(0);
+  });
+
+  it("cancels momentum on a new touch or cancellation", () => {
+    const emit = vi.fn();
+    const clock = createTiming();
+    const coordinator = new TouchWheelCoordinator(
+      emit,
+      undefined,
+      undefined,
+      clock.timing,
+    );
+
+    coordinator.start(point(100));
+    clock.advance(20);
+    coordinator.move(point(50));
+    coordinator.end();
+    expect(clock.pendingFrames()).toBe(1);
+    coordinator.start(point(60));
+    expect(clock.pendingFrames()).toBe(0);
+
+    clock.advance(20);
+    coordinator.move(point(20));
+    coordinator.end();
+    expect(clock.pendingFrames()).toBe(1);
+    coordinator.cancel();
+    expect(clock.pendingFrames()).toBe(0);
+  });
+
+  it("disables momentum when reduced motion is requested", () => {
+    const emit = vi.fn();
+    const clock = createTiming(false);
+    const coordinator = new TouchWheelCoordinator(
+      emit,
+      undefined,
+      undefined,
+      clock.timing,
+    );
+
+    coordinator.start(point(100));
+    clock.advance(20);
+    coordinator.move(point(50));
+    coordinator.end();
+
+    expect(clock.pendingFrames()).toBe(0);
+    expect(emit).toHaveBeenCalledOnce();
+  });
+
+  it("stops momentum if the active terminal mode changes", () => {
+    const emit = vi.fn();
+    let momentumAllowed = true;
+    const clock = createTiming();
+    const coordinator = new TouchWheelCoordinator(emit, undefined, undefined, {
+      ...clock.timing,
+      momentumAllowed: () => momentumAllowed,
+    });
+
+    coordinator.start(point(100));
+    clock.advance(20);
+    coordinator.move(point(50));
+    coordinator.end();
+    momentumAllowed = false;
+    clock.advance(20);
+
+    expect(emit).toHaveBeenCalledOnce();
+    expect(clock.pendingFrames()).toBe(0);
+  });
+
+  it("retains fractional pixel distance until it forms a whole line tick", () => {
+    const emit = vi.fn();
+    const clock = createTiming();
+    const coordinator = new TouchWheelCoordinator(
+      emit,
+      undefined,
+      undefined,
+      clock.timing,
+    );
+
+    coordinator.start(point(100));
+    clock.advance(100);
+    coordinator.move(point(80));
+    coordinator.end();
+    const dragCallCount = emit.mock.calls.length;
+    for (let index = 0; index < 4; index++) clock.advance(16);
+    expect(emit.mock.calls.length).toBe(dragCallCount);
+    clock.advance(16);
+    expect(emit.mock.calls.length).toBeGreaterThan(dragCallCount);
+    expect(emit.mock.calls[dragCallCount][0]).toMatchObject({
+      deltaY: 1,
+      deltaMode: WheelEvent.DOM_DELTA_LINE,
+    });
+  });
+});
+
+describe("installTouchWheelCoordinator", () => {
+  it("claims the first single-touch move but preserves taps and multi-touch", () => {
+    const terminalElement = document.createElement("div");
+    const scrollableElement = document.createElement("div");
+    scrollableElement.className = "xterm-scrollable-element";
+    const screenElement = document.createElement("div");
+    screenElement.className = "xterm-screen";
+    scrollableElement.append(screenElement);
+    terminalElement.append(scrollableElement);
+    const dispose = installTouchWheelCoordinator(terminalElement);
+
+    terminalElement.dispatchEvent(touchEvent("touchstart", [100]));
+    const earlyMove = touchEvent("touchmove", [99]);
+    terminalElement.dispatchEvent(earlyMove);
+    expect(earlyMove.defaultPrevented).toBe(true);
+
+    terminalElement.dispatchEvent(touchEvent("touchend", []));
+    const tapEnd = touchEvent("touchend", []);
+    terminalElement.dispatchEvent(tapEnd);
+    expect(tapEnd.defaultPrevented).toBe(false);
+
+    terminalElement.dispatchEvent(touchEvent("touchstart", [100]));
+    const multiTouchMove = touchEvent("touchmove", [90, 80]);
+    terminalElement.dispatchEvent(multiTouchMove);
+    expect(multiTouchMove.defaultPrevented).toBe(false);
+    dispose();
+  });
+
+  it("dispatches wheel events at xterm's normal scrollback seam", () => {
+    const terminalElement = document.createElement("div");
+    const scrollableElement = document.createElement("div");
+    scrollableElement.className = "xterm-scrollable-element";
+    const screenElement = document.createElement("div");
+    const canvas = document.createElement("canvas");
+    screenElement.className = "xterm-screen";
+    screenElement.append(canvas);
+    scrollableElement.append(screenElement);
+    terminalElement.append(scrollableElement);
+    const scrollableWheel = vi.fn();
+    const canvasWheel = vi.fn();
+    scrollableElement.addEventListener("wheel", scrollableWheel);
+    canvas.addEventListener("wheel", canvasWheel);
+    const dispose = installTouchWheelCoordinator(terminalElement);
+
+    canvas.dispatchEvent(touchEvent("touchstart", [100]));
+    canvas.dispatchEvent(touchEvent("touchmove", [90]));
+
+    expect(scrollableWheel).toHaveBeenCalledOnce();
+    expect(canvasWheel).not.toHaveBeenCalled();
+    expect((scrollableWheel.mock.calls[0][0] as WheelEvent).deltaY).toBe(10);
+    expect((scrollableWheel.mock.calls[0][0] as WheelEvent).deltaMode).toBe(
+      WheelEvent.DOM_DELTA_PIXEL,
+    );
+    dispose();
+  });
+
+  it("dispatches momentum as line-mode wheel ticks from the scrollback seam", () => {
+    let now = 0;
+    let nextHandle = 1;
+    const callbacks = new Map<number, FrameRequestCallback>();
+    vi.spyOn(performance, "now").mockImplementation(() => now);
+    vi.stubGlobal("requestAnimationFrame", (callback: FrameRequestCallback) => {
+      const handle = nextHandle++;
+      callbacks.set(handle, callback);
+      return handle;
+    });
+    vi.stubGlobal("cancelAnimationFrame", (handle: number) => {
+      callbacks.delete(handle);
+    });
+
+    const terminalElement = document.createElement("div");
+    const scrollableElement = document.createElement("div");
+    scrollableElement.className = "xterm-scrollable-element";
+    const screenElement = document.createElement("div");
+    const canvas = document.createElement("canvas");
+    screenElement.className = "xterm-screen";
+    screenElement.append(canvas);
+    scrollableElement.append(screenElement);
+    terminalElement.append(scrollableElement);
+    const wheels: WheelEvent[] = [];
+    scrollableElement.addEventListener("wheel", (event) =>
+      wheels.push(event as WheelEvent),
+    );
+    const dispose = installTouchWheelCoordinator(terminalElement);
+
+    canvas.dispatchEvent(touchEvent("touchstart", [100]));
+    now = 20;
+    canvas.dispatchEvent(touchEvent("touchmove", [40]));
+    canvas.dispatchEvent(touchEvent("touchend", []));
+    for (let index = 0; index < 8; index++) {
+      now += 16;
+      const pending = [...callbacks.values()];
+      callbacks.clear();
+      pending.forEach((callback) => callback(now));
+    }
+
+    const momentum = wheels.filter(
+      (event) => event.deltaMode === WheelEvent.DOM_DELTA_LINE,
+    );
+    expect(momentum.length).toBeGreaterThan(1);
+    expect(momentum.every((event) => event.deltaY === 1)).toBe(true);
+    expect(wheels.every((event) => event.currentTarget === null)).toBe(true);
+    dispose();
+    vi.unstubAllGlobals();
+    vi.restoreAllMocks();
+  });
+});

--- a/src/ui/tests/features/terminal/touch-wheel-coordinator.xterm.test.ts
+++ b/src/ui/tests/features/terminal/touch-wheel-coordinator.xterm.test.ts
@@ -1,0 +1,140 @@
+import { Terminal } from "@xterm/xterm";
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { installTouchWheelCoordinator } from "../../../features/terminal/touch-wheel-coordinator";
+
+const touchEvent = (type: string, clientYValues: number[]) => {
+  const event = new Event(type, { bubbles: true, cancelable: true });
+  const touches = clientYValues.map((clientY) => ({ clientX: 10, clientY }));
+  Object.defineProperty(event, "touches", {
+    value: Object.assign(touches, {
+      item: (index: number) => touches[index] ?? null,
+    }),
+  });
+  return event;
+};
+
+const write = (terminal: Terminal, data: string) =>
+  new Promise<void>((resolve) => terminal.write(data, resolve));
+
+describe("touch wheel coordinator with xterm", () => {
+  let terminal: Terminal | undefined;
+  let container: HTMLDivElement | undefined;
+
+  afterEach(() => {
+    terminal?.dispose();
+    container?.remove();
+    terminal = undefined;
+    container = undefined;
+    vi.unstubAllGlobals();
+  });
+
+  const installXtermCharacterMeasurements = () => {
+    vi.spyOn(HTMLCanvasElement.prototype, "getContext").mockReturnValue({
+      clearRect: vi.fn(),
+      fillRect: vi.fn(),
+      fillStyle: "",
+      lineWidth: 1,
+    } as unknown as CanvasRenderingContext2D);
+    vi.spyOn(HTMLElement.prototype, "offsetWidth", "get").mockImplementation(
+      function (this: HTMLElement) {
+        return this.classList.contains("xterm-char-measure-element")
+          ? 32 * 9
+          : 0;
+      },
+    );
+    vi.spyOn(HTMLElement.prototype, "offsetHeight", "get").mockImplementation(
+      function (this: HTMLElement) {
+        return this.classList.contains("xterm-char-measure-element") ? 18 : 0;
+      },
+    );
+  };
+
+  it("moves real normal-buffer scrollback during a drag and momentum", async () => {
+    installXtermCharacterMeasurements();
+    let now = 0;
+    let nextHandle = 1;
+    const frames = new Map<number, FrameRequestCallback>();
+    vi.spyOn(performance, "now").mockImplementation(() => now);
+    vi.stubGlobal("requestAnimationFrame", (callback: FrameRequestCallback) => {
+      const handle = nextHandle++;
+      frames.set(handle, callback);
+      return handle;
+    });
+    vi.stubGlobal("cancelAnimationFrame", (handle: number) => {
+      frames.delete(handle);
+    });
+
+    container = document.createElement("div");
+    document.body.appendChild(container);
+    terminal = new Terminal({ cols: 80, rows: 10, scrollback: 1_000 });
+    terminal.open(container);
+    await write(
+      terminal,
+      Array.from({ length: 500 }, (_, index) => `${index + 1}\r\n`).join(""),
+    );
+
+    const element = terminal.element!;
+    const dispose = installTouchWheelCoordinator(element);
+    terminal.scrollToBottom();
+    const bottom = terminal.buffer.active.viewportY;
+
+    element.dispatchEvent(touchEvent("touchstart", [20]));
+    now = 20;
+    element.dispatchEvent(touchEvent("touchmove", [100]));
+    const afterDrag = terminal.buffer.active.viewportY;
+    element.dispatchEvent(touchEvent("touchend", []));
+    for (let index = 0; index < 8; index++) {
+      now += 16;
+      const pending = [...frames.values()];
+      frames.clear();
+      pending.forEach((callback) => callback(now));
+    }
+
+    expect(bottom).toBeGreaterThan(400);
+    expect(afterDrag).toBeLessThan(bottom);
+    expect(terminal.buffer.active.viewportY).toBeLessThan(afterDrag);
+    dispose();
+  });
+
+  it("preserves alternate-buffer wheel line ticks", async () => {
+    installXtermCharacterMeasurements();
+    let now = 0;
+    let nextHandle = 1;
+    const frames = new Map<number, FrameRequestCallback>();
+    vi.spyOn(performance, "now").mockImplementation(() => now);
+    vi.stubGlobal("requestAnimationFrame", (callback: FrameRequestCallback) => {
+      const handle = nextHandle++;
+      frames.set(handle, callback);
+      return handle;
+    });
+    vi.stubGlobal("cancelAnimationFrame", (handle: number) => {
+      frames.delete(handle);
+    });
+    container = document.createElement("div");
+    document.body.appendChild(container);
+    terminal = new Terminal({ cols: 80, rows: 10 });
+    terminal.open(container);
+    const data: string[] = [];
+    terminal.onData((value) => data.push(value));
+    await write(terminal, "\x1b[?1049h");
+
+    const element = terminal.element!;
+    const dispose = installTouchWheelCoordinator(element);
+    element.dispatchEvent(touchEvent("touchstart", [100]));
+    now = 20;
+    element.dispatchEvent(touchEvent("touchmove", [0]));
+    data.length = 0;
+    element.dispatchEvent(touchEvent("touchend", []));
+    for (let index = 0; index < 8; index++) {
+      now += 16;
+      const pending = [...frames.values()];
+      frames.clear();
+      pending.forEach((callback) => callback(now));
+    }
+
+    expect(terminal.buffer.active.type).toBe("alternate");
+    expect(data.length).toBeGreaterThan(1);
+    expect(data.every((value) => value === "\x1b[B")).toBe(true);
+    dispose();
+  });
+});


### PR DESCRIPTION
## Why

Mobile scrolling in the web app was frustrating: single-finger gestures did
not behave like normal terminal wheel scrolling, and regular shell scrollback
could behave differently from alternate-screen terminal applications. This
change makes mobile touch scrolling use xterm's own wheel and scrollback paths
so the interaction is consistent with desktop terminal behavior.

## Summary

- Route one-finger mobile terminal drags through xterm's native wheel path.
- Dispatch synthetic wheel events at `.xterm-scrollable-element` so normal
  shell scrollback uses xterm's real viewport handler.
- Preserve alternate-buffer/TUI and tmux wheel behavior through xterm's
  existing terminal handler.
- Add bounded post-release kinetic momentum with cancellation and reduced-motion
  support.
- Add unit tests plus real-xterm normal-buffer and alternate-buffer regression
  coverage.

## Root cause

Synthetic touch wheel events were dispatched at `.xterm-screen`. That reached
xterm's alternate-buffer/TUI wheel handling, but did not reliably enter the
normal scrollback viewport seam. The normal shell path is owned by
`.xterm-scrollable-element`.

## Verification

- `npm test`: 206 test files passed; 1,486 tests passed; 1 skipped.
- Focused touch/xterm tests: 18/18 passed.
- Type-check passed.
- Prettier and `git diff --check` passed.
- Production Docker build passed.
- Isolated container smoke test passed.
- Manual mobile acceptance passed for regular terminal scrollback and Hermes
  TUI behavior.

## Scope

No history-overlay code, runtime changes, generated output, credentials, or
unrelated files are included.

Momentum speed tuning is intentionally left as a separate follow-up.