### PR TITLE
Fix Ctrl+W closing the Windows desktop window

### DIFF
--- a/electron/keyboard-shortcuts.cjs
+++ b/electron/keyboard-shortcuts.cjs
@@ -1,0 +1,12 @@
+function isCloseActiveTabInput(input) {
+  return (
+    input.type === "keyDown" &&
+    input.control === true &&
+    input.alt !== true &&
+    input.shift !== true &&
+    input.meta !== true &&
+    input.key.toLowerCase() === "w"
+  );
+}
+
+module.exports = { isCloseActiveTabInput };

--- a/electron/main.cjs
+++ b/electron/main.cjs
@@ -25,6 +25,7 @@ const { fork, spawn } = require("child_process");
 const WebSocket = require("ws");
 const remoteSync = require("./remote-sync.cjs");
 const { launchNativeRdp } = require("./native-rdp.cjs");
+const { isCloseActiveTabInput } = require("./keyboard-shortcuts.cjs");
 
 // The main process's Node.js networking (the `https`/`http` modules used by
 // httpFetch below, and the global `fetch` used by remote-sync.cjs) only
@@ -1188,6 +1189,13 @@ function createWindow() {
 
   const customUserAgent = `Termix-Desktop/${appVersion} (${platform}; Electron/${electronVersion})`;
   mainWindow.webContents.setUserAgent(customUserAgent);
+
+  mainWindow.webContents.on("before-input-event", (event, input) => {
+    if (process.platform !== "win32" || !isCloseActiveTabInput(input)) return;
+
+    event.preventDefault();
+    mainWindow.webContents.send("close-active-tab");
+  });
 
   mainWindow.webContents.session.webRequest.onBeforeSendHeaders(
     (details, callback) => {

--- a/electron/preload.js
+++ b/electron/preload.js
@@ -39,6 +39,11 @@ contextBridge.exposeInMainWorld("electronAPI", {
     return () =>
       ipcRenderer.removeListener("remote-sync-status-changed", listener);
   },
+  onCloseActiveTab: (callback) => {
+    const listener = () => callback();
+    ipcRenderer.on("close-active-tab", listener);
+    return () => ipcRenderer.removeListener("close-active-tab", listener);
+  },
 
   clearSessionCookies: () => ipcRenderer.invoke("clear-session-cookies"),
   getSessionCookie: (name, targetUrl) =>

--- a/scripts/electron-keyboard-shortcuts.test.ts
+++ b/scripts/electron-keyboard-shortcuts.test.ts
@@ -1,0 +1,33 @@
+import { createRequire } from "node:module";
+import { describe, expect, it } from "vitest";
+
+const require = createRequire(import.meta.url);
+const { isCloseActiveTabInput } =
+  require("../electron/keyboard-shortcuts.cjs") as {
+    isCloseActiveTabInput: (input: {
+      type: string;
+      key: string;
+      control?: boolean;
+      alt?: boolean;
+      shift?: boolean;
+      meta?: boolean;
+    }) => boolean;
+  };
+
+describe("Electron keyboard shortcuts", () => {
+  it("recognizes Ctrl+W without extra modifiers", () => {
+    expect(
+      isCloseActiveTabInput({ type: "keyDown", key: "w", control: true }),
+    ).toBe(true);
+  });
+
+  it.each([
+    { type: "keyUp", key: "w", control: true },
+    { type: "keyDown", key: "w", control: true, alt: true },
+    { type: "keyDown", key: "w", control: true, shift: true },
+    { type: "keyDown", key: "w", meta: true },
+    { type: "keyDown", key: "q", control: true },
+  ])("does not consume other input: %o", (input) => {
+    expect(isCloseActiveTabInput(input)).toBe(false);
+  });
+});

--- a/src/types/electron.d.ts
+++ b/src/types/electron.d.ts
@@ -79,6 +79,7 @@ export interface ElectronAPI {
       needsReauth: boolean;
     }) => void,
   ) => () => void;
+  onCloseActiveTab?: (callback: () => void) => () => void;
   clearSessionCookies: () => Promise<void>;
   getSessionCookie: (
     name: string,

--- a/src/ui/AppShell.tsx
+++ b/src/ui/AppShell.tsx
@@ -451,6 +451,7 @@ export function AppShell({
   const lastShiftTime = useRef(0);
   const tabsRef = useRef(tabs);
   const activeTabIdRef = useRef(activeTabId);
+  const closeActiveTabRef = useRef<() => void>(() => {});
   const splitModeRef = useRef(splitMode);
   const focusedPaneIndexRef = useRef<number | null>(null);
   const paneContentElsRef = useRef<(HTMLDivElement | null)[]>(
@@ -463,6 +464,11 @@ export function AppShell({
   useEffect(() => {
     activeTabIdRef.current = activeTabId;
   }, [activeTabId]);
+  useEffect(() => {
+    return window.electronAPI?.onCloseActiveTab?.(() =>
+      closeActiveTabRef.current(),
+    );
+  }, []);
   const skipSplitSyncRef = useRef(false);
   useEffect(() => {
     const active = tabsRef.current.find((tab) => tab.id === activeTabId);
@@ -1894,6 +1900,11 @@ export function AppShell({
 
     doCloseTab(id);
   }
+
+  closeActiveTabRef.current = () => {
+    const id = activeTabIdRef.current;
+    if (id !== "dashboard") closeTab(id);
+  };
 
   function renameTab(tabId: string, newLabel: string) {
     setTabs((prev) =>


### PR DESCRIPTION
Fixes Termix-SSH/Support#1148.

## What changed

- intercept bare `Ctrl+W` in the Windows Electron main process before Chromium closes the app window
- forward the shortcut through the preload bridge and close the active Termix tab
- keep the dashboard open when there is no closable active tab
- leave modified shortcuts such as `Ctrl+Alt+W` untouched so they can still be sent to the remote shell

## Validation

- `npx vitest run scripts/electron-keyboard-shortcuts.test.ts` (6 tests)
- `npm run type-check`
- `npm run lint` (0 errors; existing warnings only)
- `node --check electron/main.cjs`
- `node --check electron/preload.js`