### PR TITLE
Fix tray Quit being blocked by active sessions

### DIFF
--- a/electron/app-quit.cjs
+++ b/electron/app-quit.cjs
@@ -1,0 +1,6 @@
+function quitApp(app, window) {
+  window?.destroy();
+  app.quit();
+}
+
+module.exports = { quitApp };

--- a/electron/main.cjs
+++ b/electron/main.cjs
@@ -26,6 +26,7 @@ const WebSocket = require("ws");
 const remoteSync = require("./remote-sync.cjs");
 const { launchNativeRdp } = require("./native-rdp.cjs");
 const { isCloseActiveTabInput } = require("./keyboard-shortcuts.cjs");
+const { quitApp } = require("./app-quit.cjs");
 
 // The main process's Node.js networking (the `https`/`http` modules used by
 // httpFetch below, and the global `fetch` used by remote-sync.cjs) only
@@ -1111,7 +1112,7 @@ function createTray() {
         label: "Quit",
         click: () => {
           isQuitting = true;
-          app.quit();
+          quitApp(app, mainWindow);
         },
       },
     ]);

--- a/scripts/electron-app-quit.test.ts
+++ b/scripts/electron-app-quit.test.ts
@@ -1,0 +1,28 @@
+import { createRequire } from "node:module";
+import { describe, expect, it, vi } from "vitest";
+
+const require = createRequire(import.meta.url);
+const { quitApp } = require("../electron/app-quit.cjs") as {
+  quitApp: (
+    app: { quit: () => void },
+    window: { destroy: () => void } | null,
+  ) => void;
+};
+
+describe("Electron app quit", () => {
+  it("destroys the window before quitting so renderer unload guards cannot cancel it", () => {
+    const calls: string[] = [];
+    quitApp(
+      { quit: vi.fn(() => calls.push("quit")) },
+      { destroy: vi.fn(() => calls.push("destroy")) },
+    );
+
+    expect(calls).toEqual(["destroy", "quit"]);
+  });
+
+  it("still quits after the window has already gone", () => {
+    const quit = vi.fn();
+    quitApp({ quit }, null);
+    expect(quit).toHaveBeenCalledOnce();
+  });
+});


### PR DESCRIPTION
Fixes Termix-SSH/Support#1149.

## What changed

The tray Quit action now destroys the Electron window before asking the app to quit. This bypasses the renderer `beforeunload` guard that intentionally protects active sessions but was also canceling an explicit application exit.

Normal window-close behavior is unchanged: using the title-bar close button still hides Termix to the tray.

## Validation

- `npx vitest run scripts/electron-app-quit.test.ts scripts/electron-keyboard-shortcuts.test.ts` (8 tests)
- `npm run type-check`
- `node --check electron/main.cjs`
- `git diff --check`