### PR TITLE
fix(desktop): keep Linux credential storage working on unrecognised desktops

### DIFF
--- a/electron/linux-password-store.cjs
+++ b/electron/linux-password-store.cjs
@@ -1,0 +1,42 @@
+// Chromium derives safeStorage's backend from the running desktop and falls back
+// to the "basic_text" store for anything it has no mapping for, which is every
+// wlroots-style compositor (Hyprland, sway, niri, river, ...).
+// safeStorage.isEncryptionAvailable() reports false for that store, so every
+// credential the desktop app persists through it -- the remote sync JWT, the
+// Electron auth cookie -- is refused at the point of writing. The refusal is
+// invisible from the outside: the user signs in, nothing is stored, and the next
+// sync tick reports the session as expired rather than as never saved.
+//
+// Those desktops still run an ordinary Secret Service (gnome-keyring, KWallet's
+// compatibility service, KeePassXC, ...), so naming the libsecret backend is
+// enough to make encryption available again. Desktops whose auto-detection
+// already resolves to KWallet keep it, and an explicit --password-store from the
+// user always wins.
+//
+// Moving a machine off "basic_text" cannot orphan stored secrets: nothing was
+// ever written there, because isEncryptionAvailable() gated every write.
+const KWALLET_DESKTOPS = /\b(kde|plasma|lxqt)\b/i;
+const LIBSECRET_STORE = "gnome-libsecret";
+
+/**
+ * Picks safeStorage's backend on Linux, and returns the store it selected (or
+ * null when auto-detection was left to decide).
+ *
+ * Must run before the app is ready: Chromium reads the switch when the store is
+ * first opened, and appending it afterwards has no effect.
+ */
+function selectLinuxPasswordStore(commandLine, env) {
+  if (commandLine.hasSwitch("password-store")) {
+    return null;
+  }
+
+  const desktop = `${env.XDG_CURRENT_DESKTOP || ""}:${env.DESKTOP_SESSION || ""}`;
+  if (KWALLET_DESKTOPS.test(desktop)) {
+    return null;
+  }
+
+  commandLine.appendSwitch("password-store", LIBSECRET_STORE);
+  return LIBSECRET_STORE;
+}
+
+module.exports = { selectLinuxPasswordStore };

--- a/electron/main.cjs
+++ b/electron/main.cjs
@@ -29,6 +29,7 @@ const remoteSync = require("./remote-sync.cjs");
 const { launchNativeRdp } = require("./native-rdp.cjs");
 const { isCloseActiveTabInput } = require("./keyboard-shortcuts.cjs");
 const { quitApp } = require("./app-quit.cjs");
+const { selectLinuxPasswordStore } = require("./linux-password-store.cjs");
 
 const localTerminalSessions = new Map();
 
@@ -597,6 +598,13 @@ if (process.platform === "linux") {
   // Chromium's hit-testing uses unscaled coords while the compositor scales visually,
   // so forcing scale factor 1 keeps them in sync. See: https://github.com/brave/brave-browser/issues/50028
   app.commandLine.appendSwitch("--force-device-scale-factor", "1");
+
+  const passwordStore = selectLinuxPasswordStore(app.commandLine, process.env);
+  if (passwordStore) {
+    logToFile(
+      `[safeStorage] Selected the ${passwordStore} password store for this desktop.`,
+    );
+  }
 }
 
 if (process.platform === "win32") {

--- a/electron/remote-sync.cjs
+++ b/electron/remote-sync.cjs
@@ -96,7 +96,15 @@ function getSafeStorageAvailable() {
 
 function saveRemoteSyncJwt(token) {
   if (!getSafeStorageAvailable()) {
-    return { success: false, error: "Encryption unavailable on this system" };
+    // Carries a stable reason alongside the message: the renderer has a
+    // translated explanation for this one, because "no OS keyring" is a
+    // machine-level problem the user has to go and fix, not something signing
+    // in again can resolve.
+    return {
+      success: false,
+      reason: "encryption_unavailable",
+      error: "Encryption unavailable on this system",
+    };
   }
   writeJson(getRemoteSyncCredentialPath(), {
     encrypted: true,

--- a/scripts/electron-linux-password-store.test.ts
+++ b/scripts/electron-linux-password-store.test.ts
@@ -1,0 +1,65 @@
+import { createRequire } from "node:module";
+import { describe, expect, it, vi } from "vitest";
+
+const require = createRequire(import.meta.url);
+const { selectLinuxPasswordStore } =
+  require("../electron/linux-password-store.cjs") as {
+    selectLinuxPasswordStore: (
+      commandLine: {
+        hasSwitch: (name: string) => boolean;
+        appendSwitch: (name: string, value: string) => void;
+      },
+      env: NodeJS.ProcessEnv,
+    ) => string | null;
+  };
+
+function commandLine(existing: string[] = []) {
+  const appended: Array<[string, string]> = [];
+  return {
+    appended,
+    hasSwitch: (name: string) => existing.includes(name),
+    appendSwitch: vi.fn((name: string, value: string) =>
+      appended.push([name, value]),
+    ),
+  };
+}
+
+describe("Linux password store selection", () => {
+  it("names libsecret on desktops Chromium has no mapping for", () => {
+    // Without this the backend resolves to "basic_text", and safeStorage
+    // reports encryption as unavailable even though a keyring is running.
+    for (const desktop of ["Hyprland", "sway", "niri", "river", "wayfire"]) {
+      const cmd = commandLine();
+      expect(
+        selectLinuxPasswordStore(cmd, { XDG_CURRENT_DESKTOP: desktop }),
+      ).toBe("gnome-libsecret");
+      expect(cmd.appended).toEqual([["password-store", "gnome-libsecret"]]);
+    }
+  });
+
+  it("leaves KWallet desktops to auto-detection", () => {
+    for (const env of [
+      { XDG_CURRENT_DESKTOP: "KDE" },
+      { XDG_CURRENT_DESKTOP: "KDE", DESKTOP_SESSION: "plasma" },
+      { DESKTOP_SESSION: "/usr/share/xsessions/plasma" },
+      { XDG_CURRENT_DESKTOP: "LXQt" },
+    ]) {
+      const cmd = commandLine();
+      expect(selectLinuxPasswordStore(cmd, env)).toBeNull();
+      expect(cmd.appendSwitch).not.toHaveBeenCalled();
+    }
+  });
+
+  it("never overrides a password store the user asked for", () => {
+    const cmd = commandLine(["password-store"]);
+    expect(
+      selectLinuxPasswordStore(cmd, { XDG_CURRENT_DESKTOP: "Hyprland" }),
+    ).toBeNull();
+    expect(cmd.appendSwitch).not.toHaveBeenCalled();
+  });
+
+  it("selects libsecret when the desktop is unset, matching a bare session", () => {
+    const cmd = commandLine();
+    expect(selectLinuxPasswordStore(cmd, {})).toBe("gnome-libsecret");
+  });
+});

--- a/src/ui/auth/ElectronLoginForm.tsx
+++ b/src/ui/auth/ElectronLoginForm.tsx
@@ -16,6 +16,12 @@ interface ElectronLoginFormProps {
   targetPurpose?: "local" | "remoteSync";
 }
 
+interface SaveRemoteSyncJwtResult {
+  success: boolean;
+  reason?: string;
+  error?: string;
+}
+
 const AUTH_MESSAGE_SOURCES = new Set([
   "auth_component",
   "totp_auth_component",
@@ -52,14 +58,33 @@ export function ElectronLoginForm({
       try {
         if (token) {
           if (targetPurpose === "remoteSync") {
-            await window.electronAPI?.invoke?.("save-remote-sync-jwt", token);
+            // The main process refuses to persist the JWT when it has no OS
+            // keyring to encrypt it with, and reports that by resolving with
+            // success: false. Dropping the result signs the user in against a
+            // store that kept nothing, so the next sync tick calls a session
+            // that was never saved expired.
+            const result = (await window.electronAPI?.invoke?.(
+              "save-remote-sync-jwt",
+              token,
+            )) as SaveRemoteSyncJwtResult | undefined;
+            if (!result?.success) {
+              throw new Error(
+                result?.reason === "encryption_unavailable"
+                  ? t("errors.keyringUnavailable")
+                  : result?.error || t("errors.authTokenSaveFailed"),
+              );
+            }
           } else {
             localStorage.setItem("jwt", token);
           }
         }
         await onAuthSuccessRef.current(token);
-      } catch {
-        setError(t("errors.authTokenSaveFailed"));
+      } catch (err) {
+        setError(
+          err instanceof Error && err.message
+            ? err.message
+            : t("errors.authTokenSaveFailed"),
+        );
         isAuthenticatingRef.current = false;
         setIsAuthenticating(false);
         hasAuthenticatedRef.current = false;

--- a/src/ui/locales/en.json
+++ b/src/ui/locales/en.json
@@ -2799,6 +2799,7 @@
     "resetCodeRateLimited": "Rate limited: Too many verification attempts. Please try again later.",
     "resetCodeRateLimitedWithTime": "Rate limited: Too many verification attempts. Please wait {{time}} seconds before trying again.",
     "authTokenSaveFailed": "Failed to save authentication token",
+    "keyringUnavailable": "Signed in, but the session could not be stored: this system has no keyring available to encrypt it with. Start a Secret Service (such as gnome-keyring or KWallet) and sign in again.",
     "failedToLoadServer": "Failed to load server",
     "remoteServerRequired": "Remote server required. Connect a remote server in Settings to use this connection type."
   },


### PR DESCRIPTION
# Overview

On Linux desktops Chromium has no mapping for, the desktop app cannot store any
credential, and reports it as an expired session rather than a storage failure.
Signing in to a remote sync server over OIDC succeeds, stores nothing, and the
next sync tick shows "Sign-in expired" — permanently. Reconnecting cannot fix it.

- [x] Fixed: `safeStorage` unavailable on wlroots-style desktops (Hyprland, sway, niri, river), so `saveRemoteSyncJwt` refuses every write
- [x] Fixed: `ElectronLoginForm` discarded the `{ success: false }` the main process returns when it cannot store a credential
- [x] Added: unit coverage for the password-store selection

# Changes Made

**Root cause.** Chromium resolves `safeStorage`'s backend from
`XDG_CURRENT_DESKTOP` / `DESKTOP_SESSION` and falls back to the `basic_text`
store for any desktop it does not recognise. `isEncryptionAvailable()` returns
`false` for that store, so `remote-sync.cjs`'s `getSafeStorageAvailable()` gate
rejects the write, and the persisted Electron auth cookie in `main.cjs` is
dropped for the same reason. Nothing surfaces it: the sync engine finds no JWT,
sets `needsReauth`, and that renders as "Sign-in expired".

`electron/linux-password-store.cjs` names the libsecret backend explicitly on
those desktops — they still run an ordinary Secret Service, so that is enough.

- an explicit `--password-store` from the user always wins
- KWallet desktops (KDE, Plasma, LXQt) keep their auto-detected backend
- no stored secret can be orphaned by the switch, because
  `isEncryptionAvailable()` gated every write that could have created one

It takes its command line and environment as arguments, following
`app-quit.cjs` and `keyboard-shortcuts.cjs`, so the selection is testable
without booting Electron.

**Honest failure.** A machine with no Secret Service at all still cannot store
credentials. `saveRemoteSyncJwt` already reported that by resolving with
`success: false`, but the renderer awaited the call and dropped the result, so
the sign-in completed against a store that kept nothing. It now carries a stable
`reason` and the renderer shows a translated explanation — same spirit as the
existing `proxyBlocked` error: a machine-level problem should not be reported as
an expired session. Only `en.json` is touched.

# Related Issues

None open for this.

# Screenshots / Demos

Electron 43 on Hyprland, reading the resolved backend directly:

```
before  {"xdgCurrentDesktop":"Hyprland","backend":"basic_text",     "isEncryptionAvailable":false}
after   {"xdgCurrentDesktop":"Hyprland","backend":"gnome_libsecret","isEncryptionAvailable":true,"roundTripOk":true}
```

User override still wins:

```
electron . --password-store=basic
{"selectedByPatch":null,"backend":"basic_text","isEncryptionAvailable":false}
```

Reproduced end to end against a self-hosted server with Keycloak OIDC: before,
the callback returned a valid token that was silently discarded; after, the JWT
persists across restarts and remote sync authenticates.

`type-check`, `lint`, `prettier --check .` and the `scripts` + `frontend` vitest
projects (828 tests) pass.

# Checklist

- [x] Code follows project style guidelines
- [x] Supports mobile and desktop UI/app (if applicable)
- [x] I have read [Contributing.md](https://github.com/Termix-SSH/Termix/blob/main/CONTRIBUTING.md)
- [x] This is not a translation request. See [docs](https://docs.termix.site/translations)
