### PR TITLE
fix: allow eight-digit secure auth codes

### DIFF
--- a/src/ui/ssh/dialogs/TOTPDialog.tsx
+++ b/src/ui/ssh/dialogs/TOTPDialog.tsx
@@ -120,7 +120,8 @@ export function TOTPDialog({
                 name="totpCode"
                 type="text"
                 autoFocus
-                maxLength={6}
+                // Some Secure Auth codes can be longer than 6 digits, so allow up to 8 digits here.
+                maxLength={8}
                 pattern="[0-9]*"
                 inputMode="numeric"
                 placeholder="000000"


### PR DESCRIPTION
Allow TOTP prompts to accept secure auth codes longer than six digits without blocking valid authentication attempts.

# Overview
 
Allow SSH Secure Auth/TOTP codes longer than six digits by increasing the input limit from 6 to 8 digits.
 
- [ ] Added: ...
- [ ] Updated: ...
- [ ] Removed: ...
- [x] Fixed: Prevented valid Secure Auth codes longer than 6 digits from being blocked by the input field.
 
# Changes Made
 
- Updated `src/ui/ssh/dialogs/TOTPDialog.tsx` to change `maxLength={6}` to `maxLength={8}`.
- Added a comment explaining that some Secure Auth codes can be longer than 6 digits.
- No changes were made to the validation pattern, layout, or authentication flow.
 
# Related Issues
 
- No related issue provided.
 
# Screenshots / Demos
 
Not applicable. This is a small input validation change with no visual layout changes.
 
# Validation
 
- `npm run type-check` passed.
- Prettier check passed for `src/ui/ssh/dialogs/TOTPDialog.tsx`.
- Test suite: 200 test files passed; 12 existing tests failed because `localStorage.clear` is unavailable in the current test environment. The failures are unrelated to this change.
 
# Checklist
 
- [x] Code follows project style guidelines
- [x] Supports mobile and desktop UI/app (if applicable)
- [x] I have read [Contributing.md](https://github.com/Termix-SSH/Termix/blob/main/CONTRIBUTING.md)
- [x] This is not a translation request. See [docs](https://docs.termix.site/translations)